### PR TITLE
Create the automation framework directory structure

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,49 @@
+help:
+	@echo "Please use \`make <target>' where <target> is one of:"
+	@echo "  help            to show this message"
+	@echo "  all             to to execute test-coverage and lint"
+	@echo "  docs-clean      to remove documentation"
+	@echo "  docs-html       to generate HTML documentation"
+	@echo "  install         to install in editable mode"
+	@echo "  install-dev     to install in editable modeplus the dev packages"
+	@echo "  lint            to run flake8"
+	@echo "  package         to generate installable Python packages"
+	@echo "  package-clean   to remove generated Python packages"
+	@echo "  package-upload  to upload dist/* to PyPI"
+	@echo "  test            to run unit tests"
+	@echo "  test-coverage   to run unit tests and measure test coverage"
+
+all: test-coverage lint
+
+docs-clean:
+	@cd docs; $(MAKE) clean
+
+docs-html:
+	@cd docs; $(MAKE) html
+
+install:
+	pip install -e .
+
+install-dev:
+	pip install -e .[dev]
+
+lint:
+	flake8 .
+
+package: package-clean
+	python setup.py --quiet sdist bdist_wheel
+
+package-clean:
+	rm -rf build dist camayoc.egg-info
+
+package-upload: package
+	twine upload dist/*
+
+test:
+	py.test tests
+
+test-coverage:
+	py.test --verbose --cov-report term --cov=camayoc tests
+
+.PHONY: all docs-clean docs-html install install-dev lint package \
+	package-clean package-upload test test-coverage

--- a/README.rst
+++ b/README.rst
@@ -1,2 +1,5 @@
-# camayoc
+=======
+camayoc
+=======
+
 A GPL-licensed Python library that facilitates functional testing of quipucords.

--- a/camayoc/__init__.py
+++ b/camayoc/__init__.py
@@ -1,0 +1,2 @@
+# coding=utf-8
+"""A Python library that facilitates functional testing of quipucords."""

--- a/camayoc/tests/__init__.py
+++ b/camayoc/tests/__init__.py
@@ -1,0 +1,8 @@
+# coding=utf-8
+"""Tests for RHO.
+
+This package and its sub-packages contain functional tests for RHO. These tests
+should be run against RHO installations. These tests run RHO remotely (trhough
+a SSH connection) or locally. These tests are entirely different from the unit
+tests in :mod:`tests`.
+"""

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line.
+SPHINXOPTS    =
+SPHINXBUILD   = python -msphinx
+SPHINXPROJ    = Camayoc
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,76 @@
+# coding=utf-8
+"""Sphinx documentation generator configuration file.
+
+The full set of configuration options is listed on the Sphinx website:
+http://sphinx-doc.org/config.html
+"""
+
+import os
+import sys
+
+# Add the project root directory to the system path. This allows references
+# such as :mod:`camayoc.whatever` to be processed correctly.
+ROOT_DIR = os.path.abspath(os.path.join(
+    os.path.dirname(__file__),
+    os.path.pardir
+))
+sys.path.insert(0, ROOT_DIR)
+
+# Project information ---------------------------------------------------------
+
+project = 'Camayoc'
+author = 'Quipucords Team'
+copyright = '2017, {}'.format(author)
+
+# The short X.Y version.
+version = ''
+# The full version, including alpha/beta/rc tags.
+release = ''
+
+
+# General configuration -------------------------------------------------------
+
+exclude_patterns = ['_build']
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.viewcode',
+]
+language = None
+master_doc = 'index'
+pygments_style = 'sphinx'
+source_suffix = '.rst'
+templates_path = ['_templates']
+todo_include_todos = False
+
+
+# Options for HTML output -----------------------------------------------------
+
+html_theme = 'alabaster'
+
+# Theme options are theme-specific and customize the look and feel of a theme
+# further. For a list of options see:
+# http://alabaster.readthedocs.io/en/latest/customization.html#theme-options
+html_theme_options = {
+    'github_user': 'quipucords',
+    'github_repo': 'camayoc',
+    'travis_button': True,
+}
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']
+
+# Custom sidebar templates, must be a dictionary that maps document names to
+# template names.
+#
+# See: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
+html_sidebars = {
+    '**': [
+        'about.html',
+        'navigation.html',
+        'relations.html',  # needs 'show_related': True theme option to display
+        'searchbox.html',
+        'donate.html',
+    ]
+}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,20 @@
+.. Camayoc documentation master file, created by
+   sphinx-quickstart on Fri Jul 28 15:31:27 2017.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Camayoc's documentation!
+===================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 # coding=utf-8
 """A setuptools-based script for installing camayoc."""
 import os
-from setuptools import setup
+from setuptools import find_packages, setup
 
 _project_root = os.path.abspath(os.path.dirname(__file__))
 
@@ -30,9 +30,26 @@ setup(
         'A GPL-licensed Python library that facilitates functional testing of '
         'quipucords.'
     ),
-    include_package_data=True,
+    extras_require={
+        'dev': [
+            # For `make docs`
+            'sphinx',
+            # For `make lint`
+            'flake8',
+            'flake8-docstrings',
+            'flake8-quotes',
+            # For `make package`
+            'wheel',
+            # For `make package-upload`
+            'twine',
+            # For `make test`
+            'pytest',
+            # For `make test-coverage`
+            'pytest-cov',
+        ],
+    },
     license='GPLv3',
     long_description=long_description,
-    package_data={'': ['LICENSE']},
+    packages=find_packages(include=['camayoc*']),
     url='https://github.com/quipucords/camayoc',
 )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,14 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding=utf-8
 """A setuptools-based script for installing camayoc."""
+import os
 from setuptools import setup
+
+_project_root = os.path.abspath(os.path.dirname(__file__))
+
+# Get the long description from the README file
+with open(os.path.join(_project_root, 'README.rst'), encoding='utf-8') as f:
+    long_description = f.read()
 
 setup(
     name='camayoc',
@@ -9,10 +16,23 @@ setup(
     author_email='quipucords@redhat.com',
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        'Programming Language :: Python :: 3 :: Only',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Topic :: Software Development :: Quality Assurance'
     ],
+    description=(
+        'A GPL-licensed Python library that facilitates functional testing of '
+        'quipucords.'
+    ),
     include_package_data=True,
     license='GPLv3',
+    long_description=long_description,
     package_data={'': ['LICENSE']},
     url='https://github.com/quipucords/camayoc',
 )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,6 @@
+# coding=utf-8
+"""Unit tests for Camayoc.
+
+This package and its sub-packages contain tests for Camayoc. These tests verify
+that Camayoc's internal functions and libraries function correctly.
+"""


### PR DESCRIPTION
Added three commits (_they are meant to not be squashed_):

* Update the README file to use RST instead of Markdown
* Add more metadata information on setup.py
* Create the automation framework directory structure with the camayoc package and the test packages for both RHO's functional tests and camayoc's unittests. Bonus created a Makefile to help with common tasks like running the unittests, linting, building docs and building the Python package.