### PR TITLE
Assert for exact facts match on fact related tests

### DIFF
--- a/camayoc/constants.py
+++ b/camayoc/constants.py
@@ -2,6 +2,81 @@
 """Values usable by multiple test modules."""
 from camayoc import utils
 
+RHO_CONNECTION_FACTS = (
+    'connection.host',
+    'connection.port',
+    'connection.uuid',
+)
+"""List of RHO's connection facts."""
+
+RHO_JBOSS_FACTS = (
+    'jboss.installed-versions',
+    'jboss.deploy-dates',
+    'jboss.running-versions',
+    'jboss.brms.kie-api-ver',
+    'jboss.brms.drools-core-ver',
+    'jboss.brms.kie-war-ver',
+    'jboss.fuse.activemq-ver',
+    'jboss.fuse.camel-ver',
+    'jboss.fuse.cxf-ver',
+)
+"""List of RHO's jboss facts."""
+
+RHO_RHEL_FACTS = (
+    'cpu.bogomips',
+    'cpu.count',
+    'cpu.cpu_family',
+    'cpu.model_name',
+    'cpu.model_ver',
+    'cpu.socket_count',
+    'cpu.vendor_id',
+    'date.anaconda_log',
+    'date.date',
+    'date.filesystem_create',
+    'date.machine_id',
+    'date.yum_history',
+    'dmi.bios-vendor',
+    'dmi.bios-version',
+    'dmi.processor-family',
+    'dmi.system-manufacturer',
+    'etc-issue.etc-issue',
+    'etc_release.name',
+    'etc_release.release',
+    'etc_release.version',
+    'instnum.instnum',
+    'redhat-packages.is_redhat',
+    'redhat-packages.last_built',
+    'redhat-packages.last_installed',
+    'redhat-packages.num_installed_packages',
+    'redhat-packages.num_rh_packages',
+    'redhat-release.name',
+    'redhat-release.release',
+    'redhat-release.version',
+    'subman.cpu.core(s)_per_socket',
+    'subman.cpu.cpu(s)',
+    'subman.cpu.cpu_socket(s)',
+    'subman.has_facts_file',
+    'subman.virt.host_type',
+    'subman.virt.is_guest',
+    'subman.virt.uuid',
+    'systemid.system_id',
+    'systemid.username',
+    'uname.all',
+    'uname.hardware_platform',
+    'uname.hostname',
+    'uname.kernel',
+    'uname.os',
+    'uname.processor',
+    'virt-what.type',
+    'virt.num_guests',
+    'virt.num_running_guests',
+    'virt.type',
+    'virt.virt',
+)
+"""List of RHO's RHEL facts."""
+
+RHO_DEFAULT_FACTS = RHO_CONNECTION_FACTS + RHO_JBOSS_FACTS + RHO_RHEL_FACTS
+"""List of RHO's default facts."""
 
 MASKED_PASSWORD_OUTPUT = '\*{8}'
 """Regex that matches password on outputs."""


### PR DESCRIPTION
Add the list of facts that RHO scan's for and update the fact related
tests to match for the exact match of the expected facts.

Closes #32