### PR TITLE
Update expected rho fact list

### DIFF
--- a/camayoc/constants.py
+++ b/camayoc/constants.py
@@ -10,22 +10,32 @@ RHO_CONNECTION_FACTS = (
 """List of RHO's connection facts."""
 
 RHO_JBOSS_FACTS = (
-    'jboss.installed-versions',
-    'jboss.deploy-dates',
-    'jboss.running-versions',
-    'jboss.brms.kie-api-ver',
+    'jboss.eap.common-directories',
+    'jboss.eap.jboss-user',
+    'jboss.eap.packages',
+    'jboss.eap.processes',
+    'jboss.eap.running-versions',
+)
+"""List of RHO's jboss facts."""
+
+RHO_JBOSS_ALL_FACTS = (
     'jboss.brms.drools-core-ver',
+    'jboss.brms.kie-api-ver',
     'jboss.brms.kie-war-ver',
+    'jboss.eap.deploy-dates',
+    'jboss.eap.installed-versions',
     'jboss.fuse.activemq-ver',
     'jboss.fuse.camel-ver',
     'jboss.fuse.cxf-ver',
 )
-"""List of RHO's jboss facts."""
+"""List of rho's additional jboss facts (for --facts all)."""
 
 RHO_RHEL_FACTS = (
     'cpu.bogomips',
+    'cpu.core_count',
     'cpu.count',
     'cpu.cpu_family',
+    'cpu.hyperthreading',
     'cpu.model_name',
     'cpu.model_ver',
     'cpu.socket_count',

--- a/camayoc/tests/rho/test_scan.py
+++ b/camayoc/tests/rho/test_scan.py
@@ -21,6 +21,7 @@ from camayoc import utils
 from camayoc.constants import (
     RHO_CONNECTION_FACTS,
     RHO_DEFAULT_FACTS,
+    RHO_JBOSS_ALL_FACTS,
     RHO_JBOSS_FACTS,
     RHO_RHEL_FACTS,
 )
@@ -71,7 +72,7 @@ def test_scan(isolated_filesystem):
     assert os.path.isfile(reportfile), logfile
     with open(reportfile) as f:
         fieldnames = csv.DictReader(f).fieldnames
-    assert sorted(fieldnames) == sorted(RHO_CONNECTION_FACTS + RHO_RHEL_FACTS)
+    assert sorted(fieldnames) == sorted(RHO_DEFAULT_FACTS)
 
 
 @pytest.mark.parametrize('facts', ('all', 'default', 'jboss', 'rhel', 'file'))
@@ -106,7 +107,9 @@ def test_scan_with_facts(isolated_filesystem, facts):
     rho_profile_add.close()
     assert rho_profile_add.exitstatus == 0
 
-    if facts == 'all' or facts == 'default':
+    if facts == 'all':
+        expected_facts = RHO_DEFAULT_FACTS + RHO_JBOSS_ALL_FACTS
+    if facts == 'default':
         expected_facts = RHO_DEFAULT_FACTS
     elif facts == 'jboss':
         expected_facts = RHO_JBOSS_FACTS + RHO_CONNECTION_FACTS


### PR DESCRIPTION
Also update the rho scan tests to match the new set of facts depending
on the fact group passed to the `--facts` option when running a scan.

Closes #59