### PR TITLE
Capitalize quipucords requirement name

### DIFF
--- a/camayoc/tests/qcs/test_credentials.py
+++ b/camayoc/tests/qcs/test_credentials.py
@@ -5,7 +5,7 @@
 :casecomponent: api
 :caseimportance: high
 :caselevel: integration
-:requirement: sonar
+:requirement: Sonar
 :testtype: functional
 :upstream: yes
 """

--- a/camayoc/tests/qcs/test_profiles.py
+++ b/camayoc/tests/qcs/test_profiles.py
@@ -5,7 +5,7 @@
 :casecomponent: api
 :caseimportance: high
 :caselevel: integration
-:requirement: sonar
+:requirement: Sonar
 :testtype: functional
 :upstream: yes
 """


### PR DESCRIPTION
Capitalize the requirement name as it is the title of the requirement.