### PR TITLE
Make test results more readable

### DIFF
--- a/camayoc/tests/remote/rho/test_scan.py
+++ b/camayoc/tests/remote/rho/test_scan.py
@@ -35,7 +35,10 @@ def profiles():
 
 
 # The test will execute once per profile.
-@pytest.mark.parametrize('profile', profiles())
+@pytest.mark.parametrize(
+    'profile', profiles(),
+    ids=[p['name'] for p in profiles()]
+    )
 def test_scan(isolated_filesystem, profile):
     """Scan the machines listed in profile.
 


### PR DESCRIPTION
Setting the test id for each test based on the profile it is testing
will make it easier to read the test results in Jenkins.

Eventually I want to parametrize on each fact, but that is going to require some not-so-obvious pytest finagling because you cannot directly parametrize based on results of a fixture (yet, this is a proposed feature)

Meanwhile, this will make jenkins a lot easier to decipher.