### PR TITLE
Issues/56 Test facts based on privilege of auth

### DIFF
--- a/camayoc/constants.py
+++ b/camayoc/constants.py
@@ -92,6 +92,177 @@ RHO_RHEL_FACTS = (
 )
 """List of RHO's RHEL facts."""
 
+RHO_PRIVILEGED_FACTS = {
+    'date.yum_history': {
+        'denials': [
+            'sudo: a password is required',
+            'error'
+        ]
+    },
+    'date.anaconda_log': {
+        'denials': [
+            'error',
+        ]
+    },
+    'dmi.bios-vendor': {
+        'denials': [
+            'sudo: a password is required',
+            'N/A (dmidecode not found)',
+            'error',
+        ]
+    },
+    'dmi.bios-version': {
+        'denials': [
+            'sudo: a password is required',
+            'N/A (dmidecode not found)',
+            'error',
+        ]
+    },
+    'dmi.processor-family': {
+        'denials': [
+            'sudo: a password is required',
+            'N/A (dmidecode not found)',
+            'error',
+        ]
+    },
+    'dmi.system-manufacturer': {
+        'denials': [
+            'sudo: a password is required',
+            'N/A (dmidecode not found)',
+            'error',
+        ]
+    },
+    'jboss.brms.kie-war-ver': {
+        'denials': [
+            '(jboss.brms.kie-war-ver not found)',
+        ]
+    },
+    'jboss.brms.kie-api-ver': {
+        'denials': [
+            '(jboss.brms.kie-api-ver not found)',
+        ]
+    },
+    'jboss.brms.drools-core-ver': {
+        'denials': [
+            '(jboss.brms.drools-core-ver not found)',
+        ]
+    },
+    'jboss.fuse.cxf-ver': {
+        'denials': [
+            '(jboss.fuse.cxf-ver not found)',
+        ]
+    },
+    'jboss.fuse.camel-ver': {
+        'denials': [
+            '(jboss.fuse.camel-ver not found)',
+        ]
+    },
+    'jboss.fuse.activemq-ver': {
+        'denials': [
+            '(jboss.fuse.activemq-ver not found)',
+        ]
+    },
+    'subman.consumed': {
+        'denials': [
+            'sudo: a password is required',
+            'N/A (subscription-manager not found)',
+            'error',
+        ]
+    },
+    'subman.cpu.core(s)_per_socket': {
+        'denials': [
+            'sudo: a password is required',
+            'N/A (subscription-manager not found)',
+            'error',
+        ]
+    },
+    'subman.cpu.cpu(s)': {
+        'denials': [
+            'sudo: a password is required',
+            'N/A (subscription-manager not found)',
+            'error',
+        ]
+    },
+    'subman.cpu.cpu_socket(s)': {
+        'denials': [
+            'sudo: a password is required',
+            'N/A (subscription-manager not found)',
+            'error',
+        ]
+    },
+    'subman.virt.host_type': {
+        'denials': [
+            'sudo: a password is required',
+            'N/A (subscription-manager not found)',
+            'error',
+        ]
+    },
+    'subman.virt.is_guest': {
+        'denials': [
+            'sudo: a password is required',
+            'N/A (subscription-manager not found)',
+            'error',
+        ]
+    },
+    'subman.virt.uuid': {
+        'denials': [
+            'sudo: a password is required',
+            'N/A (subscription-manager not found)',
+            'error',
+        ]
+    },
+    'virt.type': {
+        'denials': [
+            'sudo: a password is required',
+            'error',
+            'N/A (dmidecode not found)',
+            '',
+        ]
+    },
+    'virt.virt': {
+        'denials': [
+            'sudo: a password is required',
+            'error',
+            'N/A (dmidecode not found)',
+            '',
+        ]
+    },
+    'virt-what.type': {
+        'denials': [
+            'sudo: a password is required',
+            'error',
+            'N/A (virt-what not found)',
+            '',
+        ]
+    },
+    'virt.num_guests': {
+        'denials': [
+            'sudo: a password is required',
+            'N/A (virsh not found)',
+            'error',
+            '',
+        ]
+    },
+    'virt.num_running_guests': {
+        'denials': [
+            'sudo: a password is required',
+            'N/A (virsh not found)',
+            'error',
+            '',
+        ]
+    },
+}
+"""Dictionary of facts that change based on privilege level.
+
+When testing facts, we can differentiate between profiles that use credentials
+with root/sudo privilege and those that do not. Those with root/sudo privilege
+should obtain the fact as expected in the config file.
+
+If the user is not marked as privileged, then instead of the value that the
+root user should find, under privileged users may encounter any of the values
+in the list of 'denials' and these will be considered valid scan values.
+"""
+
 RHO_DEFAULT_FACTS = RHO_CONNECTION_FACTS + RHO_JBOSS_FACTS + RHO_RHEL_FACTS
 """List of RHO's default facts."""
 

--- a/camayoc/tests/remote/rho/conftest.py
+++ b/camayoc/tests/remote/rho/conftest.py
@@ -3,123 +3,146 @@
 
 import csv
 import os
-import pexpect
-import pytest
-import tempfile
-import shutil
 from io import BytesIO
 
+import pexpect
+import pytest
+
 from camayoc import config
+from camayoc.utils import isolated_filesystem
 from camayoc.tests.rho.utils import auth_add, input_vault_password
-from camayoc.utils import _XDG_ENV_VARS
+
 
 def pytest_generate_tests(metafunc):
+    """Do magic things with parameters.
+
+    This function enables us to create custom marks and do special things to
+    the parameters of fixtures based on the value of the marks.
+
+    In particular, the marks that use this function are:
+
+    .. code-block:: python
+
+        @pytest.mark.facts_needed
+
+    The `facts_needed` mark tells us to take the parameters, which should be
+    profiles, to the test marked with this marker and pass them to the
+    `testable_facts` function which will perform a scan for each profile passed
+    to the original test. It will then, in turn, generate a list of facts for
+    the test to be parametrized on. This has the effect of the test being
+    parametrized on the facts, not the profiles.
+    """
     if hasattr(metafunc.function, 'facts_needed'):
         # this grabs the parameters handed to the pytest.mark.parametrize
         # associated with the function that is marked 'facts_needed'
         profiles_to_scan = metafunc.function.parametrize
         # now we will pass those parameters to another function
-        # to perform the scan and collect all testable facts.
-        # This will have the effect of the test being parametrized
-        # on the facts, not the profiles, so a test will run
-        # for each fact
+        # to perform the scans and return a list of all testable facts.
         metafunc.function.parametrize = [testable_facts(profiles_to_scan)]
 
 
 def testable_facts(profiles_to_scan):
+    """Perform scans on each profile and return facts.
+
+    This function will attempt to scan all profiles listed in config file. For
+    those that are successful, facts will be returned so the test may be
+    parametrized on them.
+
+    Additional data about the facts like what host, profile, auth, actual and
+    expected value are collected into a single dictionary with the scanned fact
+    and passed to the test that is marked as follows:
+
+    .. code-block:: python
+
+        @pytest.mark.facts_needed
+        @pytest.mark.parametrize('fact', profiles())
+
+    """
     profiles_to_scan = profiles_to_scan.args[1]
     cfg = config.get_config()
     facts_to_test = []
     for profile in profiles_to_scan:
-        cwd = os.getcwd()
-        path = tempfile.mkdtemp()
-        for envvar in _XDG_ENV_VARS:
-            os.environ[envvar] = path
-        os.chdir(path)
-        reportfile = '{}-report.csv'.format(profile['name'])
-        try:
-            for auth in cfg['rho']['auths']:
-                if auth['name'] in profile['auths']:
-                    auth_add({
-                        'name': auth['name'],
-                        'username': auth['username'],
-                        'sshkeyfile': auth['sshkeyfile'],
-                    })
+        with isolated_filesystem() as path:
+            reportfile = '{}-report.csv'.format(profile['name'])
+            try:
+                for auth in cfg['rho']['auths']:
+                    if auth['name'] in profile['auths']:
+                        auth_add({
+                            'name': auth['name'],
+                            'username': auth['username'],
+                            'sshkeyfile': auth['sshkeyfile'],
+                        })
 
-            auths = ' '.join(item for item in profile['auths'])
-            hosts = ' '.join(item for item in profile['hosts'])
-            rho_profile_add = pexpect.spawn(
-                'rho profile add --name {} --auth {} --hosts {}'
-                .format(profile['name'], auths, hosts)
-            )
-            input_vault_password(rho_profile_add)
-            assert rho_profile_add.expect(
-                'Profile "{}" was added'.format(profile['name'])) == 0
-            assert rho_profile_add.expect(pexpect.EOF) == 0
-            rho_profile_add.close()
-            assert rho_profile_add.exitstatus == 0
+                auths = ' '.join(item for item in profile['auths'])
+                hosts = ' '.join(item for item in profile['hosts'])
+                rho_profile_add = pexpect.spawn(
+                    'rho profile add --name {} --auth {} --hosts {}'
+                    .format(profile['name'], auths, hosts)
+                )
+                input_vault_password(rho_profile_add)
+                assert rho_profile_add.expect(
+                    'Profile "{}" was added'.format(profile['name'])) == 0
+                assert rho_profile_add.expect(pexpect.EOF) == 0
+                rho_profile_add.close()
+                assert rho_profile_add.exitstatus == 0
 
-            rho_scan = pexpect.spawn(
-                'rho scan --profile {} --reportfile {} --facts all'
-                .format(profile['name'], reportfile),
-                timeout=300,
-            )
-            input_vault_password(rho_scan)
-            rho_scan.logfile = BytesIO()
-            assert rho_scan.expect(pexpect.EOF) == 0
-            logfile = rho_scan.logfile.getvalue().decode('utf-8')
-            rho_scan.logfile.close()
-            rho_scan.close()
-            assert rho_scan.exitstatus == 0, logfile
-            assert os.path.isfile(reportfile)
-        except (AssertionError, pexpect.exceptions.EOF):
-            # The scan failed for some reason.
-            # This is a fixture for tests that ensure scanned facts in a
-            # successful scan are correct, not that we can scan, so we
-            # will carry on.
-            pass
+                rho_scan = pexpect.spawn(
+                    'rho scan --profile {} --reportfile {} --facts all'
+                    .format(profile['name'], reportfile),
+                    timeout=300,
+                )
+                input_vault_password(rho_scan)
+                rho_scan.logfile = BytesIO()
+                assert rho_scan.expect(pexpect.EOF) == 0
+                logfile = rho_scan.logfile.getvalue().decode('utf-8')
+                rho_scan.logfile.close()
+                rho_scan.close()
+                assert rho_scan.exitstatus == 0, logfile
+                assert os.path.isfile(reportfile)
+            except (AssertionError, pexpect.exceptions.EOF):
+                # The scan failed for some reason.
+                # This is a fixture for tests that ensure scanned facts in a
+                # successful scan are correct, not that we can scan, so we
+                # will carry on.
+                pass
 
-        scan_results = []
-        if os.path.isfile(reportfile):
-            # open the report and collect the facts of interest, injecting
-            # other useful information while we are at it.
-            with open(reportfile) as csvfile:
-                reader = csv.DictReader(csvfile)
-                for row in reader:
-                    row['profile'] = profile['name']
-                    row['auth'] = profile['auths']
-                    scan_results.append(row)
+            scan_results = []
+            if os.path.isfile(reportfile):
+                # open the report and collect the facts of interest, injecting
+                # other useful information while we are at it.
+                with open(reportfile) as csvfile:
+                    reader = csv.DictReader(csvfile)
+                    for row in reader:
+                        row['profile'] = profile['name']
+                        row['auth'] = profile['auths']
+                        scan_results.append(row)
 
-            for row in scan_results:
-                known_facts = {}
-                for host in cfg['rho']['hosts']:
-                    # find the facts for the scanned host we are inspecting
-                    if host['ip'] == row.get('connection.host'):
-                        known_facts = host['facts']
-                        for fact in known_facts:
-                            facts_to_test.append(
-                                {
-                                    'fact': fact,
-                                    'expected': known_facts.get(fact),
-                                    'actual': row.get(fact),
-                                    'host': host['hostname'],
-                                    'profile': row['profile'],
-                                    'auth': row['auth'],
-                                    'scandir': path,
-                                })
-                        break
-        for envvar in _XDG_ENV_VARS:
-            os.environ[envvar] = ''
-        os.chdir(cwd)
-        try:
-            shutil.rmtree(path)
-        except (OSError, IOError):
-            pass
+                for row in scan_results:
+                    known_facts = {}
+                    for host in cfg['rho']['hosts']:
+                        # find the facts for the scanned host we are inspecting
+                        if host['ip'] == row.get('connection.host'):
+                            known_facts = host['facts']
+                            for fact in known_facts:
+                                facts_to_test.append(
+                                    {
+                                        'fact': fact,
+                                        'expected': known_facts.get(fact),
+                                        'actual': row.get(fact),
+                                        'host': host['hostname'],
+                                        'host-ip': host['ip'],
+                                        'profile': row['profile'],
+                                        'auth': row['auth'],
+                                        'scandir': path,
+                                        'privileged': profile.get('privileged')
+                                    }
+                                )
+                            break
     return pytest.mark.parametrize(
-                            'fact',
-                            facts_to_test,
-                            ids=['{}-{}-{}-{}'.format(
-                                fact['host'],
-                                fact['profile'],
-                                fact['auth'],
-                                fact['fact']) for fact in facts_to_test])
+        'fact',
+        facts_to_test,
+        ids=['{}-{}-{}-{}'.format(
+            fact['host-ip'],
+            fact['profile'],
+            fact['auth'],
+            fact['fact']) for fact in facts_to_test])

--- a/camayoc/tests/remote/rho/conftest.py
+++ b/camayoc/tests/remote/rho/conftest.py
@@ -1,0 +1,125 @@
+# coding=utf-8
+"""Pytest customizations and fixtures for tests to execute on remote hosts."""
+
+import csv
+import os
+import pexpect
+import pytest
+import tempfile
+import shutil
+from io import BytesIO
+
+from camayoc import config
+from camayoc.tests.rho.utils import auth_add, input_vault_password
+from camayoc.utils import _XDG_ENV_VARS
+
+def pytest_generate_tests(metafunc):
+    if hasattr(metafunc.function, 'facts_needed'):
+        # this grabs the parameters handed to the pytest.mark.parametrize
+        # associated with the function that is marked 'facts_needed'
+        profiles_to_scan = metafunc.function.parametrize
+        # now we will pass those parameters to another function
+        # to perform the scan and collect all testable facts.
+        # This will have the effect of the test being parametrized
+        # on the facts, not the profiles, so a test will run
+        # for each fact
+        metafunc.function.parametrize = [testable_facts(profiles_to_scan)]
+
+
+def testable_facts(profiles_to_scan):
+    profiles_to_scan = profiles_to_scan.args[1]
+    cfg = config.get_config()
+    facts_to_test = []
+    for profile in profiles_to_scan:
+        cwd = os.getcwd()
+        path = tempfile.mkdtemp()
+        for envvar in _XDG_ENV_VARS:
+            os.environ[envvar] = path
+        os.chdir(path)
+        reportfile = '{}-report.csv'.format(profile['name'])
+        try:
+            for auth in cfg['rho']['auths']:
+                if auth['name'] in profile['auths']:
+                    auth_add({
+                        'name': auth['name'],
+                        'username': auth['username'],
+                        'sshkeyfile': auth['sshkeyfile'],
+                    })
+
+            auths = ' '.join(item for item in profile['auths'])
+            hosts = ' '.join(item for item in profile['hosts'])
+            rho_profile_add = pexpect.spawn(
+                'rho profile add --name {} --auth {} --hosts {}'
+                .format(profile['name'], auths, hosts)
+            )
+            input_vault_password(rho_profile_add)
+            assert rho_profile_add.expect(
+                'Profile "{}" was added'.format(profile['name'])) == 0
+            assert rho_profile_add.expect(pexpect.EOF) == 0
+            rho_profile_add.close()
+            assert rho_profile_add.exitstatus == 0
+
+            rho_scan = pexpect.spawn(
+                'rho scan --profile {} --reportfile {} --facts all'
+                .format(profile['name'], reportfile),
+                timeout=300,
+            )
+            input_vault_password(rho_scan)
+            rho_scan.logfile = BytesIO()
+            assert rho_scan.expect(pexpect.EOF) == 0
+            logfile = rho_scan.logfile.getvalue().decode('utf-8')
+            rho_scan.logfile.close()
+            rho_scan.close()
+            assert rho_scan.exitstatus == 0, logfile
+            assert os.path.isfile(reportfile)
+        except (AssertionError, pexpect.exceptions.EOF):
+            # The scan failed for some reason.
+            # This is a fixture for tests that ensure scanned facts in a
+            # successful scan are correct, not that we can scan, so we
+            # will carry on.
+            pass
+
+        scan_results = []
+        if os.path.isfile(reportfile):
+            # open the report and collect the facts of interest, injecting
+            # other useful information while we are at it.
+            with open(reportfile) as csvfile:
+                reader = csv.DictReader(csvfile)
+                for row in reader:
+                    row['profile'] = profile['name']
+                    row['auth'] = profile['auths']
+                    scan_results.append(row)
+
+            for row in scan_results:
+                known_facts = {}
+                for host in cfg['rho']['hosts']:
+                    # find the facts for the scanned host we are inspecting
+                    if host['ip'] == row.get('connection.host'):
+                        known_facts = host['facts']
+                        for fact in known_facts:
+                            facts_to_test.append(
+                                {
+                                    'fact': fact,
+                                    'expected': known_facts.get(fact),
+                                    'actual': row.get(fact),
+                                    'host': host['hostname'],
+                                    'profile': row['profile'],
+                                    'auth': row['auth'],
+                                    'scandir': path,
+                                })
+                        break
+        for envvar in _XDG_ENV_VARS:
+            os.environ[envvar] = ''
+        os.chdir(cwd)
+        try:
+            shutil.rmtree(path)
+        except (OSError, IOError):
+            pass
+    return pytest.mark.parametrize(
+                            'fact',
+                            facts_to_test,
+                            ids=['{}-{}-{}-{}'.format(
+                                fact['host'],
+                                fact['profile'],
+                                fact['auth'],
+                                fact['fact']) for fact in facts_to_test])

--- a/docs/api/camayoc.tests.remote.rho.conftest.rst
+++ b/docs/api/camayoc.tests.remote.rho.conftest.rst
@@ -1,0 +1,7 @@
+camayoc\.tests\.remote\.rho\.conftest module
+============================================
+
+.. automodule:: camayoc.tests.remote.rho.conftest
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/camayoc.tests.remote.rho.rst
+++ b/docs/api/camayoc.tests.remote.rho.rst
@@ -11,5 +11,6 @@ Submodules
 
 .. toctree::
 
+   camayoc.tests.remote.rho.conftest
    camayoc.tests.remote.rho.test_scan
 


### PR DESCRIPTION
@elyezer 

This "works" but has a couple rough points:

One is the fact that a lot of the jboss facts will come back '(...factname... not found)' if JBoss is in a location that the scan user cannot read. This is the case on most of our machines, but you would actually get the same data if the files were in directories that the scan user could read (like its home directory).

Also, I'm not sure if the underprivileged user will get the same count on jboss processes, it seems not but I'm not 100% sure this is a privilege issue, and I don't feel great about doing some kind of arithmetic on how many fewer jboss processes the user will find.


All in all, I think our test results will now provide a lot more insight as to how many facts we are having issues with when we see this:
```
test_scan.py::test_facts[IPADDR-PROFILENAME-['scanbasic']-virt.num_guests] PASSED
test_scan.py::test_facts[IPADDR-PROFILENAME-['scanbasic']-virt.num_running_guests] PASSED
test_scan.py::test_facts[IPADDR-PROFILENAME-['scanbasic']-virt.type] PASSED
test_scan.py::test_facts[IPADDR-PROFILENAME-['scanbasic']-virt.virt] PASSED

2 failed, 816 passed in 365.77 seconds
```

That is just with a small sample of the test machines. It is upwards of 3000 "test" items when I scan all vcenter machines.

Let me know what you think!