### PR TITLE
Avoid extra scan by storing scan result as fact

### DIFF
--- a/camayoc/tests/remote/rho/conftest.py
+++ b/camayoc/tests/remote/rho/conftest.py
@@ -101,15 +101,42 @@ def testable_facts(profiles_to_scan):
                 assert os.path.isfile(reportfile)
             except (AssertionError, pexpect.exceptions.EOF):
                 # The scan failed for some reason.
-                # This is a fixture for tests that ensure scanned facts in a
-                # successful scan are correct, not that we can scan, so we
-                # will carry on.
-                pass
+                # We insert a fact that records that the scan failed
+                # so we will see a test failure for this profile scan
+                facts_to_test.append(
+                    {
+                        'fact': 'scan-performed',
+                        'expected': True,
+                        'actual': False,
+                        'host': 'N/A',
+                        'host-ip': 'N/A',
+                        'profile': profile['name'],
+                        'auth': profile['auths'],
+                        'scandir': path,
+                        'privileged': profile.get('privileged')
+                    }
+                )
 
             scan_results = []
             if os.path.isfile(reportfile):
                 # open the report and collect the facts of interest, injecting
                 # other useful information while we are at it.
+                # We insert a fact that records that the scan succeeded
+                # in producing a report so we will see a test success for this
+                # profile scan
+                facts_to_test.append(
+                    {
+                        'fact': 'scan-performed',
+                        'expected': True,
+                        'actual': True,
+                        'host': 'N/A',
+                        'host-ip': 'N/A',
+                        'profile': profile['name'],
+                        'auth': profile['auths'],
+                        'scandir': path,
+                        'privileged': profile.get('privileged')
+                    }
+                )
                 with open(reportfile) as csvfile:
                     reader = csv.DictReader(csvfile)
                     for row in reader:

--- a/camayoc/tests/remote/rho/test_scan.py
+++ b/camayoc/tests/remote/rho/test_scan.py
@@ -14,16 +14,11 @@ failed facts will be reported with associated host.
 :upstream: yes
 """
 
-import os
-from io import BytesIO
-
-import pexpect
 import pytest
 
 from camayoc import config
 from camayoc.exceptions import ConfigFileNotFoundError
 from camayoc.constants import RHO_PRIVILEGED_FACTS
-from camayoc.tests.rho.utils import auth_add, input_vault_password
 
 
 def profiles():
@@ -33,61 +28,6 @@ def profiles():
     except ConfigFileNotFoundError:
         profs = []
     return profs
-
-
-# The test will execute once per profile.
-@pytest.mark.parametrize(
-    'profile', profiles(),
-    ids=[p['name'] for p in profiles()]
-)
-def test_scan(isolated_filesystem, profile):
-    """Scan the machines listed in profile.
-
-    :id: 6ee18084-86db-45ea-8fdd-59fed5639170
-    :description: Scan a profile
-    :steps:
-        1) Run ``rho scan --profile <profile> --reportfile <reportfile>``
-        2) Check the exit code of the scan command
-        3) Confirm that a report file is created
-    :expectedresults:
-        A scan is performed and a report is generated
-    """
-    cfg = config.get_config()
-
-    for auth in cfg['rho']['auths']:
-        auth_add({
-            'name': auth['name'],
-            'username': auth['username'],
-            'sshkeyfile': auth['sshkeyfile'],
-        })
-
-    auths = ' '.join(item for item in profile['auths'])
-    hosts = ' '.join(item for item in profile['hosts'])
-    rho_profile_add = pexpect.spawn(
-        'rho profile add --name {} --auth {} --hosts {}'
-        .format(profile['name'], auths, hosts)
-    )
-    input_vault_password(rho_profile_add)
-    assert rho_profile_add.expect(
-        'Profile "{}" was added'.format(profile['name'])) == 0
-    assert rho_profile_add.expect(pexpect.EOF) == 0
-    rho_profile_add.close()
-    assert rho_profile_add.exitstatus == 0
-
-    reportfile = '{}-report.csv'.format(profile['name'])
-    rho_scan = pexpect.spawn(
-        'rho scan --profile {} --reportfile {} --facts all'
-        .format(profile['name'], reportfile),
-        timeout=300,
-    )
-    input_vault_password(rho_scan)
-    rho_scan.logfile = BytesIO()
-    assert rho_scan.expect(pexpect.EOF) == 0
-    logfile = rho_scan.logfile.getvalue().decode('utf-8')
-    rho_scan.logfile.close()
-    rho_scan.close()
-    assert rho_scan.exitstatus == 0, logfile
-    assert os.path.isfile(reportfile)
 
 
 @pytest.mark.facts_needed


### PR DESCRIPTION
This removes the separate test parametrized on the profiles that did a
whole other scan on the systems to record that test result. Instead, the
result of the scan is stored as a fact called "scan performed" and we
get a test result for that fact based on whether or not the scan got
through the whole process and produced a report.