### PR TITLE
Update qcs tests to reflect API changes

### DIFF
--- a/camayoc/qcs_models.py
+++ b/camayoc/qcs_models.py
@@ -253,20 +253,20 @@ class Source(QCSObject):
             client=None,
             name=None,
             hosts=None,
-            ssh_port=22,
+            port=22,
             credential_ids=None,
             source_type=None,
             _id=None):
         """Iniitalize a Source object with given data.
 
-        If no ssh_port is supplied, it will be set to 22 by default.
+        If no port is supplied, it will be set to 22 by default.
         A uuid4 name and api.Client are also supplied if none are provided.
         """
         super().__init__(client=client, _id=_id)
         self.name = str(uuid.uuid4()) if name is None else name
         self.endpoint = QCS_SOURCE_PATH
         self.hosts = hosts
-        self.ssh_port = ssh_port
+        self.port = port
         self.credentials = credential_ids
         self.source_type = source_type
 
@@ -325,7 +325,7 @@ class Scan(QCSObject):
                             credential_ids=[cred._id]
                             )
         >>> src.create()
-        >>> scan = Scan(source_id=src._id)
+        >>> scan = Scan(source_ids=[src._id])
         >>> scan.create()
         >>> scan.pause()
         >>> assert scan.status() == 'paused'
@@ -334,9 +334,9 @@ class Scan(QCSObject):
     def __init__(
             self,
             client=None,
-            source_id=None,
+            source_ids=None,
             max_concurrency=50,
-            scan_type='host',
+            scan_type='inspect',
             _id=None):
         """Iniitalize a Scan object with given data.
 
@@ -348,12 +348,12 @@ class Scan(QCSObject):
         """
         super().__init__(client=client, _id=_id)
 
-        self.source = source_id
+        self.sources = source_ids
         self.endpoint = QCS_SCAN_PATH
 
         # valid scan types are 'host' and 'discovery'
         self.scan_type = scan_type
-        self.max_concurrency = max_concurrency
+        self.options = {'max_concurrency': max_concurrency}
 
     def delete(self):
         """No delete method is implemented for scan objects.

--- a/camayoc/tests/qcs/test_scan.py
+++ b/camayoc/tests/qcs/test_scan.py
@@ -95,7 +95,7 @@ def test_create(shared_client, cleanup, source, isolated_filesystem):
     )
     netsrc.create()
     cleanup.append(netsrc)
-    scan = Scan(source_id=netsrc._id)
+    scan = Scan(source_ids=[netsrc._id])
     scan.create()
     wait_until_complete(scan)
     assert scan.status() == 'completed'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -40,7 +40,7 @@ MOCK_SOURCE = {
     'id': 25,
     'source_type': 'network',
     'name': 'e193081c-2423-4407-b9e2-05d20b6443dc',
-    'ssh_port': 22
+    'port': 22
 }
 
 


### PR DESCRIPTION
Updates several changes, including:
    * ssh_port is now port for Sources
    * Scans now take a list of sources
    * Scans now take a dictionary of options
    * Scans now have types 'connect' or 'inspect'