### PR TITLE
Automate existing test scan stubs

### DIFF
--- a/camayoc/exceptions.py
+++ b/camayoc/exceptions.py
@@ -34,3 +34,12 @@ class QCSBaseUrlNotFound(Exception):
     qcs:
         hostname: 'http://hostname_or_ip_with_port'
     """
+
+
+class WaitTimeError(Exception):
+    """A task has raised this error because it has been waiting too long.
+
+    A task was waiting for a long running task, but it has exceeded the time
+    allowed. Instead of allowing the task to hang, it has aborted and raised
+    this error.
+    """

--- a/camayoc/tests/qcs/test_scan.py
+++ b/camayoc/tests/qcs/test_scan.py
@@ -14,7 +14,7 @@ import pytest
 import time
 
 from camayoc import config
-from camayoc.exceptions import ConfigFileNotFoundError
+from camayoc.exceptions import ConfigFileNotFoundError, WaitTimeError
 from camayoc.qcs_models import (
     Credential,
     Source,
@@ -23,16 +23,38 @@ from camayoc.qcs_models import (
 
 
 def sources():
-    """Gather sources from config file."""
+    """Gather sources from config file.
+
+    If no config file is found, or no sources defined,
+    then an empty list will be returned.
+
+    If a test is parametrized on the sources in the config file, it will skip
+    if no sources are found.
+    """
     try:
-        srcs = config.get_config()['qcs']['profiles']
+        srcs = config.get_config()['qcs']['sources']
     except (ConfigFileNotFoundError, KeyError):
         srcs = []
     return srcs
 
 
-def wait_until_complete(scan, timeout=120):
-    """Wait until the scan has either failed or completed.
+def first_source():
+    """Gather sources from config file.
+
+    If no source is found in the config file, or no config file is found, a
+    default source will be returned.
+    """
+    try:
+        src = [config.get_config()['qcs']['sources'][0]]
+    except (ConfigFileNotFoundError, KeyError):
+        src = [{'hosts': ['localhost'], 'name':'localhost', 'auths':'default'}]
+    return src
+
+
+def wait_until_state(scan, timeout=120, state='completed'):
+    """Wait until the scan has failed or reached desired state.
+
+    The default state is 'completed'.
 
     This method should not be called on scan jobs that have not yet been
     created, are paused, or are canceled.
@@ -40,24 +62,84 @@ def wait_until_complete(scan, timeout=120):
     The default timeout is set to 120 seconds, but can be overridden if it is
     anticipated that a scan may take longer to complete.
     """
-    if scan.status() in ['paused', 'cancelled']:
-        raise UserWarning(
-            'You have called wait_until_complete() on a scan '
-            'that is paused or cancelled, and this could hang forever.'
-            ' This exception has been raised instead.'
-        )
     while (
         not scan.status() or not scan.status() in [
             'failed',
-            'completed']) and timeout > 0:
+            state]) and timeout > 0:
         time.sleep(5)
         timeout -= 5
+        if timeout <= 0:
+            raise WaitTimeError(
+                'You have called wait_until_state() on a scan and the scan\n'
+                'timed out while waiting to achieve the state="{}" When the\n'
+                'scan timed out, it had the state="{}".\n'
+                .format(state, scan.status())
+            )
+
+
+def prep_broken_network_scan(cleanup):
+    """Return a scan that can be created but will fail to complete.
+
+    Create and return a source with a non-existent host and dummy credential.
+    It is returned ready to be POSTed to the server via the create() instance
+    method.
+    """
+    bad_cred = Credential(
+        username='broken',
+        password='broken',
+        cred_type='network'
+    )
+    bad_cred.create()
+    cleanup.append(bad_cred)
+    bad_src = Source(
+        source_type='network',
+        hosts=['1.0.0.0'],
+        credential_ids=[bad_cred._id],
+    )
+    bad_src.create()
+    cleanup.append(bad_src)
+    bad_scn = Scan(
+        source_ids=[bad_src._id],
+    )
+    return bad_scn
+
+
+def prep_network_scan(source, cleanup, client):
+    """Given a source from config file, prep the scan.
+
+    Takes care of creating the Credential and Source objects on the server and
+    staging them for cleanup after the tests complete.
+    """
+    cfg = config.get_config()
+    auth_ids = []
+    for auth in cfg['qcs'].get('auths'):
+        if auth['name'] in source['auths']:
+            cred = Credential(
+                cred_type='network',
+                client=client,
+                ssh_keyfile=auth['sshkeyfile'],
+                username=auth['username'],
+            )
+            cred.create()
+            cleanup.append(cred)
+            auth_ids.append(cred._id)
+
+    netsrc = Source(
+        source_type='network',
+        client=client,
+        hosts=source['hosts'],
+        credential_ids=auth_ids,
+    )
+    netsrc.create()
+    cleanup.append(netsrc)
+    scan = Scan(source_ids=[netsrc._id])
+    return scan
 
 
 @pytest.mark.parametrize('source', sources(), ids=[
                          '{}-{}'.format(
-                             p['name'],
-                             p['auths']) for p in sources()]
+                             s['name'],
+                             s['auths']) for s in sources()]
                          )
 def test_create(shared_client, cleanup, source, isolated_filesystem):
     """Run a scan on a system and confirm it completes.
@@ -72,42 +154,23 @@ def test_create(shared_client, cleanup, source, isolated_filesystem):
         4) Assert that the scan completes and a fact id is generated
     :expectedresults: A scan is run and has facts associated with it
     """
-    cfg = config.get_config()
-
-    auth_ids = []
-    for auth in cfg['qcs'].get('auths'):
-        if auth['name'] in source['auths']:
-            cred = Credential(
-                cred_type='network',
-                client=shared_client,
-                ssh_keyfile=auth['sshkeyfile'],
-                username=auth['username'],
-            )
-            cred.create()
-            cleanup.append(cred)
-            auth_ids.append(cred._id)
-
-    netsrc = Source(
-        source_type='network',
-        client=shared_client,
-        hosts=source['hosts'],
-        credential_ids=auth_ids,
-    )
-    netsrc.create()
-    cleanup.append(netsrc)
-    scan = Scan(source_ids=[netsrc._id])
+    scan = prep_network_scan(source, cleanup, shared_client)
     scan.create()
-    wait_until_complete(scan)
+    wait_until_state(scan)
     assert scan.status() == 'completed'
     assert isinstance(scan.read().json().get('fact_collection_id'), int)
 
 
-@pytest.mark.skip
+@pytest.mark.parametrize('source', first_source(), ids=[
+                         '{}-{}'.format(
+                             first_source()[0]['name'],
+                             first_source()[0]['auths'])]
+                         )
 def test_pause_cancel(shared_client, cleanup, source, isolated_filesystem):
     """Run a scan on a system and confirm we can pause and cancel it.
 
     :id: 4d4b9839-1672-4183-bd27-11864787eb8e
-    :description: Assert that scans can be paused and then cancelled.
+    :description: Assert that scans can be paused and then canceled.
     :steps:
         1) Create host credential
         2) Send POST with data to create network source using the host
@@ -115,13 +178,22 @@ def test_pause_cancel(shared_client, cleanup, source, isolated_filesystem):
         3) Create a scan
         4) Assert that the scan can be paused
         5) Assert that the scan can be canceled
-    :expectedresults: A scan can be paused and cancelled
-    :caseautomation: notautomated
+    :expectedresults: A scan can be paused and canceled
     """
-    pass
+    scan = prep_network_scan(source, cleanup, shared_client)
+    scan.create()
+    wait_until_state(scan, state='running')
+    scan.pause()
+    wait_until_state(scan, state='paused')
+    scan.cancel()
+    wait_until_state(scan, state='canceled')
 
 
-@pytest.mark.skip
+@pytest.mark.parametrize('source', first_source(), ids=[
+                         '{}-{}'.format(
+                             first_source()[0]['name'],
+                             first_source()[0]['auths'])]
+                         )
 def test_restart(shared_client, cleanup, source, isolated_filesystem):
     """Run a scan on a system and confirm we can pause and restart it.
 
@@ -136,12 +208,23 @@ def test_restart(shared_client, cleanup, source, isolated_filesystem):
         5) Assert that the scan can be restarted
         6) Assert that he scan completes
     :expectedresults: A restarted scan completes
-    :caseautomation: notautomated
     """
-    pass
+    scan = prep_network_scan(source, cleanup, shared_client)
+    scan.create()
+    wait_until_state(scan, state='running')
+    scan.pause()
+    wait_until_state(scan, state='paused')
+    scan.restart()
+    wait_until_state(scan, state='running')
+    wait_until_state(scan, state='completed')
+    assert scan.read().json().get('fact_collection_id') > 0
 
 
-@pytest.mark.skip
+@pytest.mark.parametrize('source', first_source(), ids=[
+                         '{}-{}'.format(
+                             first_source()[0]['name'],
+                             first_source()[0]['auths'])]
+                         )
 def test_queue_mix_valid_invalid(
         shared_client,
         cleanup,
@@ -158,29 +241,80 @@ def test_queue_mix_valid_invalid(
         2) Assert that all valid scans complete
         3) Assert all invalid scans fail
     :expectedresults: A queue will progress even if some scans fail
-    :caseautomation: notautomated
     """
-    pass
+    good_scans = []
+    bad_scans = []
+    for k in range(6):
+        time.sleep(2)
+        if not k % 2:
+            bad_scn = prep_broken_network_scan(cleanup)
+            bad_scn.create()
+            bad_scans.append(bad_scn)
+        else:
+            scan = prep_network_scan(source, cleanup, shared_client)
+            scan.create()
+            good_scans.append(scan)
+
+    for scan in good_scans:
+        wait_until_state(scan)
+    assert scan.read().json().get('fact_collection_id') > 0
+
+    for scan in bad_scans:
+        assert scan.status() == 'failed'
 
 
-@pytest.mark.skip
-def test_queue_mix_paused_cancelled(
+@pytest.mark.parametrize('source', first_source(), ids=[
+                         '{}-{}'.format(
+                             first_source()[0]['name'],
+                             first_source()[0]['auths'])]
+                         )
+def test_queue_mix_paused_canceled(
         shared_client,
         cleanup,
         source,
         isolated_filesystem):
-    """Assert all non-cancelled and paused scans in a queue complete.
+    """Assert all non-canceled and paused scans in a queue complete.
 
     :id: 925e2a72-3e69-4947-bfd7-5298bc033963
     :description: Ensure scans can progress in queue that contains paused and
-        cancelled scans to completion.
+        canceled scans to completion.
     :steps:
         1) Create a series of valid scans
         2) Pause and cancel a random selection of scans
-        3) Assert that all non-paused/cancelled scans complete
+        3) Assert that all non-paused/canceled scans complete
         4) Restart the paused scans and assert they complete
-        5) Assert the cancelled scans stay cancelled
-    :expectedresults: All non-paused/cancelled scans will progress in queue
-    :caseautomation: notautomated
+        5) Assert the canceled scans stay canceled
+    :expectedresults: All non-paused/canceled scans will progress in queue
     """
-    pass
+    good_scans = []
+    paused_scans = []
+    canceled_scans = []
+    for k in range(7):
+        if k in [0, 3]:
+            scan = prep_network_scan(source, cleanup, shared_client)
+            scan.create()
+            wait_until_state(scan, state='running')
+            scan.pause()
+            wait_until_state(scan, state='paused')
+            paused_scans.append(scan)
+        if k in [2, 5]:
+            scan = prep_network_scan(source, cleanup, shared_client)
+            scan.create()
+            scan.cancel()
+            wait_until_state(scan, state='canceled')
+            canceled_scans.append(scan)
+        else:
+            scan = prep_network_scan(source, cleanup, shared_client)
+            scan.create()
+            good_scans.append(scan)
+
+    for scan in good_scans:
+        wait_until_state(scan, state='completed')
+        assert scan.read().json().get('fact_collection_id') > 0
+
+    for scan in paused_scans:
+        assert scan.status() == 'paused'
+        scan.cancel()
+
+    for scan in paused_scans:
+        assert scan.status() == 'canceled'


### PR DESCRIPTION
Automate test stubs in qcs test_scan module.

These tests include testing that scans can be paused and canceled, as
well that queues of scans progress even if some fail or are paused or
canceled.

Closes #83