### PR TITLE
Add tests/stubs for vcenter and satellite scans

### DIFF
--- a/camayoc/constants.py
+++ b/camayoc/constants.py
@@ -329,3 +329,9 @@ QCS_SOURCE_TYPES = ('vcenter', 'network')
 
 QCS_HOST_MANAGER_TYPES = ('vcenter',)
 """Types of host managers that the quipucords server supports."""
+
+VCENTER_SCAN_TIMEOUT = 540
+"""Maximum amount of time to let vcenter scan run before timing out."""
+
+SATELLITE_SCAN_TIMEOUT = 120
+"""Maximum amount of time to let satellite scan run before timing out."""

--- a/camayoc/tests/qcs/api/v1/scans/test_satellite_scans.py
+++ b/camayoc/tests/qcs/api/v1/scans/test_satellite_scans.py
@@ -1,0 +1,170 @@
+# coding=utf-8
+"""Tests for ``Scan`` API endpoint for quipucords server.
+
+:caseautomation: automated
+:casecomponent: api
+:caseimportance: high
+:caselevel: integration
+:requirement: Sonar
+:testtype: functional
+:upstream: yes
+"""
+
+import pytest
+
+from camayoc import config
+from camayoc.constants import SATELLITE_SCAN_TIMEOUT
+from camayoc.exceptions import ConfigFileNotFoundError
+from camayoc.qcs_models import (
+    Credential,
+    Source,
+    Scan
+)
+from camayoc.tests.qcs.api.v1.scans.utils import wait_until_state
+
+
+def sat_source():
+    """Gather Satellite source from config file.
+
+    If no config file is found, or no sources defined,
+    then an empty list will be returned.
+
+    If a test is parametrized on the sources in the config file, it will skip
+    if no source is found.
+    """
+    try:
+        src = [config.get_config()['satellite']]
+    except (ConfigFileNotFoundError, KeyError):
+        src = []
+    return src
+
+
+def prep_broken_sat_scan(cleanup):
+    """Return a scan that can be created but will fail to complete.
+
+    Create and return a source with a non-existent host and dummy credential.
+    It is returned ready to be POSTed to the server via the create() instance
+    method.
+    """
+    bad_cred = Credential(
+        username='broken',
+        password='broken',
+        cred_type='satellite'
+    )
+    bad_cred.create()
+    cleanup.append(bad_cred)
+    bad_src = Source(
+        source_type='satellite',
+        hosts=['1.0.0.0'],
+        credential_ids=[bad_cred._id],
+    )
+    bad_src.create()
+    cleanup.append(bad_src)
+    bad_scn = Scan(
+        source_ids=[bad_src._id],
+    )
+    return bad_scn
+
+
+def prep_sat_scan(source, cleanup, client):
+    """Given a source from config file, prep the scan.
+
+    Takes care of creating the Credential and Source objects on the server and
+    staging them for cleanup after the tests complete.
+    """
+    cfg = config.get_config()
+    cred_ids = []
+    for c in cfg['credentials']:
+        if c['name'] in source['credentials'] and c['type'] == 'satellite':
+            cred = Credential(
+                cred_type='satellite',
+                client=client,
+                password=c['password'],
+                username=c['username'],
+            )
+            cred.create()
+            cleanup.append(cred)
+            cred_ids.append(cred._id)
+    satsrc = Source(
+        source_type='satellite',
+        client=client,
+        hosts=[source['hostname']],
+        credential_ids=cred_ids,
+    )
+    satsrc.create()
+    cleanup.append(satsrc)
+    scan = Scan(source_ids=[satsrc._id])
+    return scan
+
+
+@pytest.mark.skip
+@pytest.mark.create
+@pytest.mark.parametrize('source', sat_source())
+def test_create(shared_client, cleanup, source):
+    """Run a scan on a system and confirm it completes.
+
+    :id: 52835270-dba9-4a68-bd36-225e0ef4679b
+    :description: Create a satellite scan and assert that it completes
+    :steps:
+        1) Create satellite credential
+        2) Create satellite source
+        3) Create a satellite scan
+        4) Assert that the scan completes
+    :expectedresults: A scan is run and reaches completion
+    :caseautomation: notautomated
+    """
+    scan = prep_sat_scan(source, cleanup, shared_client)
+    scan.create()
+    wait_until_state(scan, state='completed', timeout=SATELLITE_SCAN_TIMEOUT)
+
+
+@pytest.mark.skip
+@pytest.mark.parametrize('source', sat_source())
+def test_pause_cancel(shared_client, cleanup, source):
+    """Run a scan on a system and confirm we can pause and cancel it.
+
+    :id: 7d61014a-7791-4f35-8020-6081c7e31227
+    :description: Assert that scans can be paused and then canceled.
+    :steps:
+        1) Create satellite credential
+        2) Create satellite source
+        3) Create a satellite scan
+        4) Assert that the scan can be paused
+        5) Assert that the scan can be canceled
+    :expectedresults: A satellite scan can be paused and canceled
+    :caseautomation: notautomated
+    """
+    scan = prep_sat_scan(source, cleanup, shared_client)
+    scan.create()
+    wait_until_state(scan, state='running', timeout=SATELLITE_SCAN_TIMEOUT)
+    scan.pause()
+    wait_until_state(scan, state='paused', timeout=SATELLITE_SCAN_TIMEOUT)
+    scan.cancel()
+    wait_until_state(scan, state='canceled', timeout=SATELLITE_SCAN_TIMEOUT)
+
+
+@pytest.mark.skip
+@pytest.mark.parametrize('source', sat_source())
+def test_restart(shared_client, cleanup, source):
+    """Run a scan on a system and confirm we can pause and restart it.
+
+    :id: 6b20ec6e-83c5-4fcc-9f0b-21eacc8f732e
+    :description: Assert that scans can be paused and then restarted.
+    :steps:
+        1) Create satellite credential
+        2) Create satellite source
+        3) Create a satellite scan
+        4) Assert that the scan can be paused
+        5) Assert that the scan can be restarted
+        6) Assert that he scan completes
+    :expectedresults: A restarted scan completes
+    :caseautomation: notautomated
+    """
+    scan = prep_sat_scan(source, cleanup, shared_client)
+    scan.create()
+    wait_until_state(scan, state='running', timeout=SATELLITE_SCAN_TIMEOUT)
+    scan.pause()
+    wait_until_state(scan, state='paused', timeout=SATELLITE_SCAN_TIMEOUT)
+    scan.restart()
+    wait_until_state(scan, state='running', timeout=SATELLITE_SCAN_TIMEOUT)
+    wait_until_state(scan, state='completed', timeout=SATELLITE_SCAN_TIMEOUT)

--- a/camayoc/tests/qcs/api/v1/scans/test_vcenter_scans.py
+++ b/camayoc/tests/qcs/api/v1/scans/test_vcenter_scans.py
@@ -1,0 +1,139 @@
+# coding=utf-8
+"""Tests for ``Scan`` API endpoint for quipucords server.
+
+:caseautomation: automated
+:casecomponent: api
+:caseimportance: high
+:caselevel: integration
+:requirement: Sonar
+:testtype: functional
+:upstream: yes
+"""
+
+import pytest
+
+from camayoc import config
+from camayoc.constants import VCENTER_SCAN_TIMEOUT
+from camayoc.exceptions import ConfigFileNotFoundError
+from camayoc.qcs_models import (
+    Credential,
+    Source,
+    Scan
+)
+from camayoc.tests.qcs.api.v1.scans.utils import wait_until_state
+
+
+def vcenter_source():
+    """Gather vcenter sources from config file.
+
+    If no config file is found, or no sources defined,
+    then an empty list will be returned.
+
+    If a test is parametrized on the sources in the config file, it will skip
+    if no sources are found.
+    """
+    try:
+        src = [s for s in config.get_config()['qcs']['sources']
+               if s['type'] == 'vcenter']
+    except (ConfigFileNotFoundError, KeyError):
+        src = []
+    return src
+
+
+def prep_vcenter_scan(source, cleanup, client):
+    """Given a source from config file, prep the scan.
+
+    Takes care of creating the Credential and Source objects on the server and
+    staging them for cleanup after the tests complete.
+    """
+    cfg = config.get_config()
+    cred_ids = []
+    for c in cfg['credentials']:
+        if c['name'] in source['credentials'] and c['type'] == 'vcenter':
+            cred = Credential(
+                cred_type='vcenter',
+                client=client,
+                password=c['password'],
+                username=c['username'],
+            )
+            cred.create()
+            cleanup.append(cred)
+            cred_ids.append(cred._id)
+
+    vcentersrc = Source(
+        source_type='vcenter',
+        client=client,
+        hosts=source['hosts'],
+        credential_ids=cred_ids,
+    )
+    vcentersrc.create()
+    cleanup.append(vcentersrc)
+    scan = Scan(source_ids=[vcentersrc._id])
+    return scan
+
+
+@pytest.mark.create
+@pytest.mark.parametrize('source', vcenter_source())
+def test_create(shared_client, cleanup, source):
+    """Run a scan on a system and confirm it completes.
+
+    :id: e7d644c1-0a32-4eb4-a663-77b7607491db
+    :description: Create a vcenter scan and assert that it completes
+    :steps:
+        1) Create vcenter credential
+        2) Create vcenter source
+        3) Create a vcenter scan
+        4) Assert that the scan completes
+    :expectedresults: A scan is run and reaches completion
+    """
+    scan = prep_vcenter_scan(source, cleanup, shared_client)
+    scan.create()
+    wait_until_state(scan, state='completed', timeout=VCENTER_SCAN_TIMEOUT)
+
+
+@pytest.mark.parametrize('source', vcenter_source())
+def test_pause_cancel(shared_client, cleanup, source):
+    """Run a scan on a system and confirm we can pause and cancel it.
+
+    :id: 1e40a87f-0a99-49de-9d02-f3ced8005a89
+    :description: Assert that scans can be paused and then canceled.
+    :steps:
+        1) Create vcenter credential
+        2) Create vcenter source
+        3) Create a vcenter scan
+        4) Assert that the scan can be paused
+        5) Assert that the scan can be canceled
+    :expectedresults: A vcenter scan can be paused and canceled
+    """
+    scan = prep_vcenter_scan(source, cleanup, shared_client)
+    scan.create()
+    wait_until_state(scan, state='running', timeout=VCENTER_SCAN_TIMEOUT)
+    scan.pause()
+    wait_until_state(scan, state='paused', timeout=VCENTER_SCAN_TIMEOUT)
+    scan.cancel()
+    wait_until_state(scan, state='canceled', timeout=VCENTER_SCAN_TIMEOUT)
+
+
+@pytest.mark.parametrize('source', vcenter_source())
+def test_restart(shared_client, cleanup, source):
+    """Run a scan on a system and confirm we can pause and restart it.
+
+    :id: bc27c62a-683f-491b-9b99-1e4525594379
+    :description: Assert that scans can be paused and then restarted.
+    :steps:
+        1) Create vcenter credential
+        2) Create vcenter source
+        3) Create a vcenter scan
+        4) Assert that the scan can be paused
+        5) Assert that the scan can be restarted
+        6) Assert that he scan completes
+    :expectedresults: A restarted scan completes
+    """
+    scan = prep_vcenter_scan(source, cleanup, shared_client)
+    scan.create()
+    wait_until_state(scan, state='running', timeout=VCENTER_SCAN_TIMEOUT)
+    scan.pause()
+    wait_until_state(scan, state='paused', timeout=VCENTER_SCAN_TIMEOUT)
+    scan.restart()
+    wait_until_state(scan, state='running', timeout=VCENTER_SCAN_TIMEOUT)
+    wait_until_state(scan, state='completed', timeout=VCENTER_SCAN_TIMEOUT)

--- a/camayoc/tests/qcs/api/v1/scans/utils.py
+++ b/camayoc/tests/qcs/api/v1/scans/utils.py
@@ -1,0 +1,64 @@
+# coding=utf-8
+"""Shared utility functions for scan tests."""
+
+import time
+
+from camayoc.qcs_models import (
+    Credential,
+    Source,
+    Scan
+)
+from camayoc.exceptions import WaitTimeError
+
+
+def wait_until_state(scan, timeout=120, state='completed'):
+    """Wait until the scan has failed or reached desired state.
+
+    The default state is 'completed'.
+
+    This method should not be called on scan jobs that have not yet been
+    created, are paused, or are canceled.
+
+    The default timeout is set to 120 seconds, but can be overridden if it is
+    anticipated that a scan may take longer to complete.
+    """
+    while (
+        not scan.status() or not scan.status() in [
+            'failed',
+            state]) and timeout > 0:
+        time.sleep(5)
+        timeout -= 5
+        if timeout <= 0:
+            raise WaitTimeError(
+                'You have called wait_until_state() on a scan and the scan\n'
+                'timed out while waiting to achieve the state="{}" When the\n'
+                'scan timed out, it had the state="{}".\n'
+                .format(state, scan.status())
+            )
+
+
+def prep_broken_scan(scan_type, cleanup):
+    """Return a scan that can be created but will fail to complete.
+
+    Create and return a source with a non-existent host and dummy credential.
+    It is returned ready to be POSTed to the server via the create() instance
+    method.
+    """
+    bad_cred = Credential(
+        username='broken',
+        password='broken',
+        cred_type=scan_type
+    )
+    bad_cred.create()
+    cleanup.append(bad_cred)
+    bad_src = Source(
+        source_type=scan_type,
+        hosts=['1.0.0.0'],
+        credential_ids=[bad_cred._id],
+    )
+    bad_src.create()
+    cleanup.append(bad_src)
+    bad_scn = Scan(
+        source_ids=[bad_src._id],
+    )
+    return bad_scn

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -39,3 +39,5 @@ reference for developers, not a gospel.
     api/camayoc.tests.qcs.api.v1.sources.test_manager_sources.rst
     api/camayoc.tests.qcs.api.v1.sources.test_sources_common.rst
     api/camayoc.tests.qcs.api.v1.scans.test_network_scans.rst
+    api/camayoc.tests.qcs.api.v1.scans.test_satellite_scans.rst
+    api/camayoc.tests.qcs.api.v1.scans.test_vcenter_scans.rst

--- a/docs/api/camayoc.tests.qcs.api.v1.scans.rst
+++ b/docs/api/camayoc.tests.qcs.api.v1.scans.rst
@@ -12,4 +12,7 @@ Submodules
 .. toctree::
 
    camayoc.tests.qcs.api.v1.scans.test_network_scans
+   camayoc.tests.qcs.api.v1.scans.test_satellite_scans
+   camayoc.tests.qcs.api.v1.scans.test_vcenter_scans
+   camayoc.tests.qcs.api.v1.scans.utils
 

--- a/docs/api/camayoc.tests.qcs.api.v1.scans.test_satellite_scans.rst
+++ b/docs/api/camayoc.tests.qcs.api.v1.scans.test_satellite_scans.rst
@@ -1,0 +1,7 @@
+camayoc\.tests\.qcs\.api\.v1\.scans\.test\_satellite\_scans module
+==================================================================
+
+.. automodule:: camayoc.tests.qcs.api.v1.scans.test_satellite_scans
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/camayoc.tests.qcs.api.v1.scans.test_vcenter_scans.rst
+++ b/docs/api/camayoc.tests.qcs.api.v1.scans.test_vcenter_scans.rst
@@ -1,0 +1,7 @@
+camayoc\.tests\.qcs\.api\.v1\.scans\.test\_vcenter\_scans module
+================================================================
+
+.. automodule:: camayoc.tests.qcs.api.v1.scans.test_vcenter_scans
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/camayoc.tests.qcs.api.v1.scans.utils.rst
+++ b/docs/api/camayoc.tests.qcs.api.v1.scans.utils.rst
@@ -1,0 +1,7 @@
+camayoc\.tests\.qcs\.api\.v1\.scans\.utils module
+=================================================
+
+.. automodule:: camayoc.tests.qcs.api.v1.scans.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
Adds test for vcenter and satellite.

NOTES:

    * Satellite scans skip for now because they are not implemented yet.

    * Facts collected by the vcenter scan cannot yet be accepted by the
      server's fact endpoint, so we do not test for this -- but this should
      be done eventually.

Closes #92

In addition, just to prolong this config file fun, I propose the following change (and this PR currently depends on it, though it can be changed):

Main proposal is to get rid of rho section and just have auths section, so rho will use auths and inventory and vcenter (for remote jobs) and quipucords will use auths, qcs, and vcenter for scans that don't need to control powerstate of vCenter vm's and then will use inventory when we get around to doing remote scan tests.

What do you think? Here is an example

```yaml
auths:
    - name: root
      sshkeyfile: /home/user/.ssh/id_rsa
      username: root
    - name: basic
      sshkeyfile: /home/user/.ssh/id_rsa
      username: basic
    - name: jenkins
      sshkeyfile: /home/jenkins/.ssh/id_rsa
      username: jenkins

qcs:
    hostname: '127.0.0.1'
    https: False
    port: 8000
    sources:
    # these are for the 'local' scans, as opposed to remote scans
    # which we are not yet doing for quipucords
            - hosts:
                    - 'localhost'
              auths:
                      - jenkins
              name: 'local1'
            - hosts:
                    - '127.0.0.1'
              auths:
                      - jenkins
              name: 'local2'
            - hosts:
                    - '127.0.0.1/30'
              auths:
                      - jenkins
              name: 'local3'

vcenter:
    hostname: example.com
    password: 'foobarbizbaz'
    username: 'myusername'

satellite:
    hostname: '127.0.0.1'
    https: False
    port: 8000
    version: 6
    username: 'bob'
    password: 'amazing'

inventory:
    - hostname: sonar-example-machine
      ipv4: 10.10.XXX.XXX
      hypervisor: vcenter
      distribution:
          name: rhel
          version: '6.9'
      products:
          jboss-amq:
              install-process: zip
              version: '7.0.2'
          openjdk:
              version: '1.8'
```
  