### PR TITLE
Drop support to Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ cache: pip
 language: python
 sudo: false
 python:
-    - '3.4'
     - '3.5'
     - '3.6'
 install:

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Topic :: Software Development :: Quality Assurance'


### PR DESCRIPTION
pytest does not have the param function for its version available on
Python 3.4 and that is needed in order to xfail test data that is
related to bug. Also most of the current distros has Python 3.5+
installed.