### PR TITLE
Make API and CLI tests authenticate

### DIFF
--- a/camayoc/constants.py
+++ b/camayoc/constants.py
@@ -329,6 +329,9 @@ QCS_SOURCE_PATH = 'sources/'
 QCS_SCAN_PATH = 'scans/'
 """The path to the scans endpoint for CRUD tasks."""
 
+QCS_TOKEN_PATH = 'token/'
+"""The path to the endpoint used for obtaining an authentication token."""
+
 QCS_SOURCE_TYPES = ('vcenter', 'network')
 """Types of sources that the quipucords server supports."""
 

--- a/camayoc/tests/qcs/api/v1/authentication/__init__.py
+++ b/camayoc/tests/qcs/api/v1/authentication/__init__.py
@@ -1,0 +1,2 @@
+# coding=utf-8
+"""Tests for Quipucords server authentication."""

--- a/camayoc/tests/qcs/api/v1/authentication/test_login.py
+++ b/camayoc/tests/qcs/api/v1/authentication/test_login.py
@@ -1,0 +1,56 @@
+# coding=utf-8
+"""Test that we can log in and out of the server.
+
+:caseautomation: automated
+:casecomponent: api
+:caseimportance: high
+:caselevel: integration
+:requirement: Sonar
+:testtype: functional
+:upstream: yes
+"""
+import pytest
+import requests
+
+from camayoc import api
+from camayoc.constants import (
+    QCS_SOURCE_PATH,
+    QCS_CREDENTIALS_PATH,
+    QCS_SCAN_PATH,
+)
+
+
+def test_login():
+    """Test that we can login to the server.
+
+    :id: 2eb55229-4e1e-4d35-ac4a-4f2424d37cf6
+    :description: Test that we can login to the server
+    :steps: Send POST with username and password to the token endpoint
+    :expectedresults: Receive an authorization token that we can then use
+        to build our authentication headers and make authenticated requests.
+    """
+    client = api.Client(authenticate=False)
+    client.login()
+    client.get(QCS_SOURCE_PATH)
+
+
+@pytest.mark.parametrize(
+    'endpoint', [
+        QCS_SOURCE_PATH, QCS_CREDENTIALS_PATH, QCS_SCAN_PATH])
+def test_logout(endpoint):
+    """Test that we can't access the server without a token.
+
+    :id: ca51b2a0-1e33-491d-8bb2-5e81d135424d
+    :description: Test that  to the server
+    :steps:
+        1) Log into the server
+        2) "Logout" of the server (delete our token)
+        3) Try an access the server without our token
+    :expectedresults: Our request missing an auth token is rejected.
+    """
+    client = api.Client(authenticate=False)
+    client.login()
+    client.logout()
+    with pytest.raises(requests.HTTPError):
+        # now that we are logged out, we should get rejected
+        client.get(endpoint)

--- a/camayoc/tests/qcs/cli/conftest.py
+++ b/camayoc/tests/qcs/cli/conftest.py
@@ -22,6 +22,8 @@ def qpc_server_config():
     config = get_config()
     hostname = config.get('qcs', {}).get('hostname')
     port = config.get('qcs', {}).get('port')
+    username = config.get('qcs', {}).get('username', 'admin')
+    password = config.get('qcs', {}).get('password', 'pass')
     if not all([hostname, port]):
         raise ValueError(
             'Both hostname and port must be defined under the qcs section on '
@@ -33,6 +35,15 @@ def qpc_server_config():
     assert qpc_server_config.expect(pexpect.EOF) == 0
     qpc_server_config.close()
     assert qpc_server_config.exitstatus == 0
+
+    # now login to the server
+    command = 'qpc server login --username {}'.format(username)
+    qpc_server_login = pexpect.spawn(command)
+    assert qpc_server_login.expect('Password: ') == 0
+    qpc_server_login.sendline(password)
+    assert qpc_server_login.expect(pexpect.EOF) == 0
+    qpc_server_login.close()
+    assert qpc_server_login.exitstatus == 0
 
 
 @pytest.fixture(params=QCS_SOURCE_TYPES)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -41,3 +41,4 @@ reference for developers, not a gospel.
     api/camayoc.tests.qcs.api.v1.scans.test_network_scans.rst
     api/camayoc.tests.qcs.api.v1.scans.test_satellite_scans.rst
     api/camayoc.tests.qcs.api.v1.scans.test_vcenter_scans.rst
+    api/camayoc.tests.qcs.api.v1.authentication.test_login.rst

--- a/docs/api/camayoc.tests.qcs.api.v1.authentication.rst
+++ b/docs/api/camayoc.tests.qcs.api.v1.authentication.rst
@@ -1,0 +1,15 @@
+camayoc\.tests\.qcs\.api\.v1\.authentication package
+====================================================
+
+.. automodule:: camayoc.tests.qcs.api.v1.authentication
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Submodules
+----------
+
+.. toctree::
+
+   camayoc.tests.qcs.api.v1.authentication.test_login
+

--- a/docs/api/camayoc.tests.qcs.api.v1.authentication.test_login.rst
+++ b/docs/api/camayoc.tests.qcs.api.v1.authentication.test_login.rst
@@ -1,0 +1,7 @@
+camayoc\.tests\.qcs\.api\.v1\.authentication\.test\_login module
+================================================================
+
+.. automodule:: camayoc.tests.qcs.api.v1.authentication.test_login
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/camayoc.tests.qcs.api.v1.rst
+++ b/docs/api/camayoc.tests.qcs.api.v1.rst
@@ -11,6 +11,7 @@ Subpackages
 
 .. toctree::
 
+    camayoc.tests.qcs.api.v1.authentication
     camayoc.tests.qcs.api.v1.credentials
     camayoc.tests.qcs.api.v1.scans
     camayoc.tests.qcs.api.v1.sources


### PR DESCRIPTION
Adds necessary code to api.Client to have the client send authenticated
requests if desired. This is enabled by default, but can be disabled
by calling api.Client().logout() or by passing a flag to the constructor
to disable it from the start. Also adds API login and logout tests.

Also has the CLI client login to the server after configuring the host
and port. This has the effect of all CLI tests being authenticated.

Negative tests for unauthenticated qpc commands and logout tests for the
CLI should be added at another time.

Closes #93