### PR TITLE
Fix missing docs in sphinx build

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -43,3 +43,7 @@ reference for developers, not a gospel.
     api/camayoc.tests.qcs.api.v1.sources.test_network_sources.rst
     api/camayoc.tests.qcs.api.v1.sources.test_manager_sources.rst
     api/camayoc.tests.qcs.api.v1.sources.test_sources_common.rst
+    api/camayoc.tests.qcs.cli.test_credentials.rst
+    api/camayoc.tests.qcs.cli.test_sources.rst
+    api/camayoc.tests.qcs.cli.conftest.rst
+    api/camayoc.tests.qcs.cli.utils.rst


### PR DESCRIPTION
Not all the CLI test cases were being published to the RTD page because
of missing declaration in docs/api.rst. Opened #126 remember to automate this
process.