### PR TITLE
Fix missing test cases in quipucords api tests

### DIFF
--- a/camayoc/constants.py
+++ b/camayoc/constants.py
@@ -338,6 +338,18 @@ QCS_SOURCE_TYPES = ('vcenter', 'network', 'satellite')
 QCS_HOST_MANAGER_TYPES = ('vcenter', 'satellite')
 """Types of host managers that the quipucords server supports."""
 
+QCS_BECOME_METHODS = (
+    'doas',
+    'dzdo',
+    'ksu',
+    'pbrun',
+    'pfexec',
+    'runas',
+    'su',
+    'sudo',
+)
+"""Supported become methods for quipucords server."""
+
 VCENTER_SCAN_TIMEOUT = 540
 """Maximum amount of time to let vcenter scan run before timing out."""
 

--- a/camayoc/tests/qcs/api/v1/credentials/test_creds_common.py
+++ b/camayoc/tests/qcs/api/v1/credentials/test_creds_common.py
@@ -24,7 +24,7 @@ from camayoc.tests.qcs.utils import assert_matches_server
 def test_create_with_password(cred_type, shared_client, cleanup):
     """Create a credential with username and password.
 
-    :id: d04e3e1b-c7f1-4cc2-a4a4-a3d3317f95ce
+    :id: bcc6a15f-a5b5-4939-9602-e5bccf4a75ca
     :description: Create a credential with a user name and password
     :steps: Send POST with necessary data to documented api endpoint.
     :expectedresults: A new credential entry is created with the data.

--- a/camayoc/tests/qcs/api/v1/credentials/test_manager_creds.py
+++ b/camayoc/tests/qcs/api/v1/credentials/test_manager_creds.py
@@ -1,0 +1,47 @@
+# coding=utf-8
+"""Tests for the ``Credential`` API endpoint.
+
+:caseautomation: automated
+:casecomponent: api
+:caseimportance: high
+:caselevel: integration
+:requirement: Sonar
+:testtype: functional
+:upstream: yes
+"""
+import requests
+
+import pytest
+
+from camayoc.constants import (
+    QCS_HOST_MANAGER_TYPES,
+    QCS_BECOME_METHODS,
+)
+from camayoc.qcs_models import Credential
+from camayoc.utils import uuid4
+
+
+@pytest.mark.parametrize('method', QCS_BECOME_METHODS)
+@pytest.mark.parametrize('cred_type', QCS_HOST_MANAGER_TYPES)
+def test_negative_create_with_become(
+        cred_type, shared_client, cleanup, method):
+    """Attempt to pass 'become' options to host manager credentials.
+
+    :id: d04e3e1b-c7f1-4cc2-a4a4-a3d3317f95ce
+    :description: Attempt to pass 'become' options that are only valid for
+        network credentials to create host manager credentials.
+    :steps: Attempt to create a host manager credential sending valid data
+        along with the extra invalid become options.
+    :expectedresults: An error is thrown and no new credential is created.
+    """
+    cred = Credential(
+        cred_type=cred_type,
+        client=shared_client,
+        password=uuid4(),
+        become_method=method,
+        become_password=uuid4(),
+        become_user=uuid4(),
+    )
+    with pytest.raises(requests.HTTPError):
+        cred.create()
+        cleanup.append(cred)

--- a/camayoc/tests/qcs/api/v1/scans/test_multi_source_scans.py
+++ b/camayoc/tests/qcs/api/v1/scans/test_multi_source_scans.py
@@ -1,0 +1,48 @@
+# coding=utf-8
+"""Tests for ``Scan`` API endpoint for quipucords server.
+
+:caseautomation: automated
+:casecomponent: api
+:caseimportance: high
+:caselevel: integration
+:requirement: Sonar
+:testtype: functional
+:upstream: yes
+"""
+
+import pytest
+
+from camayoc.tests.qcs.api.v1.utils import (
+    prep_all_source_scan,
+    wait_until_state,
+)
+
+
+@pytest.mark.parametrize('scan_type', ['connect', 'inspect'])
+def test_multi_source_create(shared_client, cleanup, scan_type):
+    """Run a scan on a collection of sources and confirm it completes.
+
+    :id: 43624cc1-6c41-4c2d-9919-c3d0aae83165
+    :description: Create sources for each source specified in the
+        config file and then create a scan that scans all the sources.
+        Provided that the resources are specified in the config file, this
+        will test that scans including multiple sources of mixed types can
+        be created and complete.
+    :steps:
+        1) Create all credentials specified in config file
+        2) Create all sources specified in config file, using appropriate
+           credentials
+        3) Create a scan using all sources
+        4) Assert that the scan completes and a fact id is generated
+    :expectedresults: A scan is run and has facts associated with it
+        Also, scan results should be available during the scan.
+    """
+    scan = prep_all_source_scan(cleanup, shared_client, scan_type)
+    scan.create()
+    if scan_type == 'inspect':
+        wait_until_state(scan, state='running')
+        assert 'connection_results' in scan.results().json().keys()
+        assert 'inspection_results' in scan.results().json().keys()
+    wait_until_state(scan, state='completed', timeout=600)
+    if scan_type == 'inspect':
+        assert scan.read().json().get('fact_collection_id') > 0

--- a/camayoc/tests/qcs/api/v1/scans/test_satellite_scans.py
+++ b/camayoc/tests/qcs/api/v1/scans/test_satellite_scans.py
@@ -114,9 +114,14 @@ def test_create(shared_client, cleanup, source, scan_type):
         3) Create a satellite scan
         4) Assert that the scan completes
     :expectedresults: A scan is run and reaches completion
+        Also, scan results should be available during the scan.
     """
     scan = prep_sat_scan(source, cleanup, shared_client, scan_type)
     scan.create()
+    if scan_type == 'inspect':
+        wait_until_state(scan, state='running')
+        assert 'connection_results' in scan.results().json().keys()
+        assert 'inspection_results' in scan.results().json().keys()
     wait_until_state(scan, state='completed', timeout=SATELLITE_SCAN_TIMEOUT)
 
 

--- a/camayoc/tests/qcs/api/v1/sources/test_manager_sources.py
+++ b/camayoc/tests/qcs/api/v1/sources/test_manager_sources.py
@@ -48,3 +48,23 @@ def test_negative_update_invalid(src_type, shared_client, cleanup, scan_host):
     :caseautomation: notautomated
     """
     pass
+
+
+@pytest.mark.skip
+@pytest.mark.parametrize('src_type', 'satellite')
+def test_negative_create_satellite(
+        src_type,
+        shared_client,
+        cleanup,
+        scan_host):
+    """Attempt to create a satellite source with an invalid version.
+
+    :id: d59891e6-b232-4ae0-b605-f0adf74ccc86
+    :description: Attempt to create satellite with non-supported or invalid
+        version.
+    :steps:
+        1) Attempt to create a satellite source with invalid version.
+    :expectedresults: An error is thrown and no new host is created.
+    :caseautomation: notautomated
+    """
+    pass

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -35,11 +35,13 @@ reference for developers, not a gospel.
     api/camayoc.tests.qcs.api.v1.rst
     api/camayoc.tests.qcs.api.v1.authentication.test_login.rst
     api/camayoc.tests.qcs.api.v1.credentials.test_network_creds.rst
+    api/camayoc.tests.qcs.api.v1.credentials.test_manager_creds.rst
     api/camayoc.tests.qcs.api.v1.credentials.test_creds_common.rst
     api/camayoc.tests.qcs.api.v1.reports.test_reports.rst
     api/camayoc.tests.qcs.api.v1.scans.test_network_scans.rst
     api/camayoc.tests.qcs.api.v1.scans.test_satellite_scans.rst
     api/camayoc.tests.qcs.api.v1.scans.test_vcenter_scans.rst
+    api/camayoc.tests.qcs.api.v1.scans.test_multi_source_scans.rst
     api/camayoc.tests.qcs.api.v1.sources.test_network_sources.rst
     api/camayoc.tests.qcs.api.v1.sources.test_manager_sources.rst
     api/camayoc.tests.qcs.api.v1.sources.test_sources_common.rst

--- a/docs/api/camayoc.tests.qcs.api.v1.credentials.rst
+++ b/docs/api/camayoc.tests.qcs.api.v1.credentials.rst
@@ -12,5 +12,6 @@ Submodules
 .. toctree::
 
    camayoc.tests.qcs.api.v1.credentials.test_creds_common
+   camayoc.tests.qcs.api.v1.credentials.test_manager_creds
    camayoc.tests.qcs.api.v1.credentials.test_network_creds
 

--- a/docs/api/camayoc.tests.qcs.api.v1.credentials.test_manager_creds.rst
+++ b/docs/api/camayoc.tests.qcs.api.v1.credentials.test_manager_creds.rst
@@ -1,0 +1,7 @@
+camayoc\.tests\.qcs\.api\.v1\.credentials\.test\_manager\_creds module
+======================================================================
+
+.. automodule:: camayoc.tests.qcs.api.v1.credentials.test_manager_creds
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/camayoc.tests.qcs.api.v1.scans.rst
+++ b/docs/api/camayoc.tests.qcs.api.v1.scans.rst
@@ -11,6 +11,7 @@ Submodules
 
 .. toctree::
 
+   camayoc.tests.qcs.api.v1.scans.test_multi_source_scans
    camayoc.tests.qcs.api.v1.scans.test_network_scans
    camayoc.tests.qcs.api.v1.scans.test_satellite_scans
    camayoc.tests.qcs.api.v1.scans.test_vcenter_scans

--- a/docs/api/camayoc.tests.qcs.api.v1.scans.test_multi_source_scans.rst
+++ b/docs/api/camayoc.tests.qcs.api.v1.scans.test_multi_source_scans.rst
@@ -1,0 +1,7 @@
+camayoc\.tests\.qcs\.api\.v1\.scans\.test\_multi\_source\_scans module
+======================================================================
+
+.. automodule:: camayoc.tests.qcs.api.v1.scans.test_multi_source_scans
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -185,18 +185,18 @@ class SourceTestCase(unittest.TestCase):
         """If a hostname is specified in the config file, we use it."""
         with mock.patch.object(config, '_CONFIG', self.config):
             client = api.Client(authenticate=False)
-            p = Source(
+            src = Source(
                 source_type='network',
                 name=MOCK_SOURCE['name'],
                 hosts=MOCK_SOURCE['hosts'],
                 credential_ids=[MOCK_SOURCE['credentials'][0]['id']],
                 client=client
             )
-            p._id = MOCK_SOURCE['id']
-            self.assertTrue(p.equivalent(MOCK_SOURCE))
-            self.assertTrue(p.equivalent(p))
+            src._id = MOCK_SOURCE['id']
+            self.assertTrue(src.equivalent(MOCK_SOURCE))
+            self.assertTrue(src.equivalent(src))
             with self.assertRaises(TypeError):
-                p.equivalent([])
+                src.equivalent([])
 
     def test_equivalent_satellite(self):
         """If a hostname is specified in the config file, we use it."""


### PR DESCRIPTION
Adds test cases that were missing because of missing functionality at
the original time of writing the tests. This includes:
 - Tests for become methods with credentials
 - Scans that scan multiple sources and source types
 - A scan job that has a source that is expected to fail as well as a
source that should succeed
 - Test case for satellite version options

Closes #130