### PR TITLE
Update API client

### DIFF
--- a/camayoc/api.py
+++ b/camayoc/api.py
@@ -98,9 +98,10 @@ class Client(object):
         """
         self.url = url
         self.token = None
+        cfg = config.get_config().get('qcs', {})
+        self.verify = cfg.get('ssl-verify', False)
 
         if not self.url:
-            cfg = config.get_config().get('qcs', {})
             hostname = cfg.get('hostname')
 
             if not hostname:
@@ -161,58 +162,32 @@ class Client(object):
     def delete(self, endpoint, **kwargs):
         """Send an HTTP DELETE request."""
         url = urljoin(self.url, endpoint)
-        return self.request(
-            'DELETE',
-            url,
-            headers=self.default_headers(),
-            **kwargs)
+        return self.request('DELETE', url, **kwargs)
 
     def get(self, endpoint, **kwargs):
         """Send an HTTP GET request."""
         url = urljoin(self.url, endpoint)
-        return self.request(
-            'GET',
-            url,
-            headers=self.default_headers(),
-            **kwargs)
+        return self.request('GET', url, **kwargs)
 
     def options(self, endpoint, **kwargs):
         """Send an HTTP OPTIONS request."""
         url = urljoin(self.url, endpoint)
-        return self.request(
-            'OPTIONS',
-            url,
-            headers=self.default_headers(),
-            **kwargs)
+        return self.request('OPTIONS', url, **kwargs)
 
     def head(self, endpoint, **kwargs):
         """Send an HTTP HEAD request."""
         url = urljoin(self.url, endpoint)
-        return self.request(
-            'HEAD',
-            url,
-            headers=self.default_headers(),
-            **kwargs)
+        return self.request('HEAD', url, **kwargs)
 
     def post(self, endpoint, payload, **kwargs):
         """Send an HTTP POST request."""
         url = urljoin(self.url, endpoint)
-        return self.request(
-            'POST',
-            url,
-            headers=self.default_headers(),
-            json=payload,
-            **kwargs)
+        return self.request('POST', url, json=payload, **kwargs)
 
     def put(self, endpoint, payload, **kwargs):
         """Send an HTTP PUT request."""
         url = urljoin(self.url, endpoint)
-        return self.request(
-            'PUT',
-            url,
-            headers=self.default_headers(),
-            json=payload,
-            **kwargs)
+        return self.request('PUT', url, json=payload, **kwargs)
 
     def request(self, method, url, **kwargs):
         """Send an HTTP request.
@@ -226,4 +201,8 @@ class Client(object):
         #
         #     request(method, url, **kwargs)
         #
+        headers = self.default_headers()
+        headers.update(kwargs.get('headers', {}))
+        kwargs['headers'] = headers
+        kwargs.setdefault('verify', self.verify)
         return self.response_handler(requests.request(method, url, **kwargs))

--- a/camayoc/tests/qcs/cli/conftest.py
+++ b/camayoc/tests/qcs/cli/conftest.py
@@ -24,19 +24,22 @@ def qpc_server_config():
     port = config.get('qcs', {}).get('port')
     username = config.get('qcs', {}).get('username', 'admin')
     password = config.get('qcs', {}).get('password', 'pass')
-    ssl_verify = config.get('qcs', {}).get('ssl-verify', False)
-    if not ssl_verify:
-        ssl_verify = ' --use-http'
-    elif ssl_verify is True:  # When ssl verify is not a path
-        ssl_verify = ''
+    https = config.get('qcs', {}).get('https', False)
+    if not https:
+        https = ' --use-http'
     else:
+        https = ''
+    ssl_verify = config.get('qcs', {}).get('ssl-verify', False)
+    if ssl_verify not in (True, False):
         ssl_verify = ' --ssl-verify={}'.format(ssl_verify)
+    else:
+        ssl_verify = ''
     if not all([hostname, port]):
         raise ValueError(
             'Both hostname and port must be defined under the qcs section on '
             'the Camayoc\'s configuration file.')
-    command = 'qpc server config --host {} --port {}{}'.format(
-        hostname, port, ssl_verify)
+    command = 'qpc server config --host {} --port {}{}{}'.format(
+        hostname, port, https, ssl_verify)
     qpc_server_config = pexpect.spawn(command)
     qpc_server_config.logfile = BytesIO()
     assert qpc_server_config.expect(pexpect.EOF) == 0


### PR DESCRIPTION
Make the API client verify HTTPS connection based on the configuration
file's ssl-verify option. Also centralize where the default headers are
set so it will be easy to update in the future if needed.

Close #136