### PR TITLE
Update API tests to deal with pagination and new options

### DIFF
--- a/camayoc/qcs_models.py
+++ b/camayoc/qcs_models.py
@@ -13,6 +13,7 @@ from camayoc.constants import (
     QCS_CREDENTIALS_PATH,
     QCS_SOURCE_PATH,
     QCS_SCAN_PATH,
+    QCS_HOST_MANAGER_TYPES,
 )
 
 
@@ -330,9 +331,21 @@ class Source(QCSObject):
                         default_port)):
                     return False
             if key == 'options':
-                if self.source_type == 'satellite':
-                    if other.get(key).get('satellite_version') != '6.2':
+                if self.source_type in QCS_HOST_MANAGER_TYPES:
+                    if hasattr(self, 'options'):
+                        ssl_verify = self.options.get('ssl_cert_verify', True)
+                    else:
+                        ssl_verify = True
+                    if other.get(key, {}).get('ssl_cert_verify') != ssl_verify:
                         return False
+                if self.source_type == 'satellite':
+                    if hasattr(self, 'options'):
+                        sat_ver = self.options.get('satellite_version', '6.2')
+                    else:
+                        sat_ver = '6.2'
+                    if other.get(key, {}).get('satellite_version') != sat_ver:
+                        return False
+
             if key == 'credentials':
                 other_creds = other.get('credentials')
                 cred_ids = []

--- a/camayoc/tests/qcs/api/v1/credentials/test_creds_common.py
+++ b/camayoc/tests/qcs/api/v1/credentials/test_creds_common.py
@@ -144,7 +144,7 @@ def test_list(cred_type, shared_client, cleanup):
         assert_matches_server(cred)
         local_creds.append(cred)
 
-    remote_creds = Credential().list().json()
+    remote_creds = Credential().list().json()['results']
     for local in local_creds:
         match_exists = False
         for remote in remote_creds:

--- a/camayoc/tests/qcs/api/v1/scans/test_multi_source_scans.py
+++ b/camayoc/tests/qcs/api/v1/scans/test_multi_source_scans.py
@@ -40,7 +40,7 @@ def test_multi_source_create(shared_client, cleanup, scan_type):
     scan = prep_all_source_scan(cleanup, shared_client, scan_type)
     scan.create()
     if scan_type == 'inspect':
-        wait_until_state(scan, state='running')
+        wait_until_state(scan, state='running', timeout=600)
         assert 'connection_results' in scan.results().json().keys()
         assert 'inspection_results' in scan.results().json().keys()
     wait_until_state(scan, state='completed', timeout=600)

--- a/camayoc/tests/qcs/api/v1/sources/test_sources_common.py
+++ b/camayoc/tests/qcs/api/v1/sources/test_sources_common.py
@@ -267,16 +267,18 @@ def test_read_all(src_type, cleanup, shared_client):
     :expectedresults: All sources are present in data returned by API.
     """
     created_srcs = []
-    for _ in range(random.randint(2, 20)):
+    for _ in range(random.randint(2, 10)):
         # gen_valid_srcs will take care of cleanup
         created_srcs.append(gen_valid_source(cleanup, src_type, 'localhost'))
-    server_srcs = Source().list().json()
-    for sp in server_srcs:
-        for i, cp in enumerate(created_srcs):
-            if sp['id'] == cp.fields()['id'] and cp.equivalent(sp):
-                created_srcs.remove(cp)
+    server_srcs = Source().list().json()['results']
+    num_srcs = len(created_srcs)
+    for server_source in server_srcs:
+        for created_source in created_srcs:
+            if server_source['id'] == created_source.fields()['id']:
+                assert_matches_server(created_source)
+                num_srcs -= 1
     # if we found everything we created, then the list should be empty
-    assert len(created_srcs) == 0
+    assert num_srcs == 0
 
 
 @pytest.mark.parametrize('src_type', QCS_SOURCE_TYPES)

--- a/camayoc/tests/qcs/api/v1/utils.py
+++ b/camayoc/tests/qcs/api/v1/utils.py
@@ -209,6 +209,7 @@ def prep_all_source_scan(cleanup, client, scan_type='inspect'):
             client=client,
             hosts=s['hosts'],
             credential_ids=[creds[s['credentials'][0]]],
+            options=s.get('options')
         )
         src.create()
         all_sources.append(src._id)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -59,16 +59,19 @@ MOCK_SAT6_SOURCE = {
     'source_type': 'satellite',
     'name': 'e193081c-2423-4407-b9e2-05d20b6443dc',
     'port': 443,
-    'options': {'satellite_version': '6.2'},
+    'options': {
+            'satellite_version': '6.2',
+            'ssl_cert_verify': False
+    },
 }
 
 
 MOCK_SCAN = {
-   'id': 21,
-   'options': {'max_concurrency': 50},
-   'scan_type': 'connect',
-   'sources': [153],
-   'status': 'created'
+    'id': 21,
+    'options': {'max_concurrency': 50},
+    'scan_type': 'connect',
+    'sources': [153],
+    'status': 'created'
 }
 
 
@@ -190,7 +193,7 @@ class SourceTestCase(unittest.TestCase):
                 name=MOCK_SOURCE['name'],
                 hosts=MOCK_SOURCE['hosts'],
                 credential_ids=[MOCK_SOURCE['credentials'][0]['id']],
-                client=client
+                client=client,
             )
             src._id = MOCK_SOURCE['id']
             self.assertTrue(src.equivalent(MOCK_SOURCE))
@@ -207,7 +210,7 @@ class SourceTestCase(unittest.TestCase):
                 name=MOCK_SAT6_SOURCE['name'],
                 hosts=MOCK_SAT6_SOURCE['hosts'],
                 credential_ids=[MOCK_SAT6_SOURCE['credentials'][0]['id']],
-                options={'satellite_version': '6.2'},
+                options=MOCK_SAT6_SOURCE['options'],
                 port=443,
                 client=client,
             )
@@ -231,9 +234,9 @@ class ScanTestCase(unittest.TestCase):
         """If a hostname is specified in the config file, we use it."""
         with mock.patch.object(config, '_CONFIG', self.config):
             scn = Scan(
-                    source_ids=[153],
-                    scan_type='connect',
-                    )
+                source_ids=[153],
+                scan_type='connect',
+            )
             scn._id = MOCK_SCAN['id']
             self.assertTrue(scn.equivalent(MOCK_SCAN))
             self.assertTrue(scn.equivalent(scn))


### PR DESCRIPTION
Updates tests to allow the results of listing all credentials or sources to be
paginated. Also updates the equivlancy tests to set proper default values for
ssl_cert_verify and satellite version.

Closes #142