### PR TITLE
Fix CLI tests to allow for new config data

### DIFF
--- a/camayoc/tests/qcs/cli/utils.py
+++ b/camayoc/tests/qcs/cli/utils.py
@@ -47,6 +47,7 @@ def cred_add(options, inputs=None, exitstatus=0):
     """
     if 'type' not in options:
         options['type'] = 'network'
+    options.pop('rho', None)  # need to remove this data that is rho specific
     command = 'qpc cred add'
     for key, value in options.items():
         if value is None:


### PR DESCRIPTION
Updated rho tests to use the same config file format as quipucords, but forgot
to update qpc CLI tests to not use an extra field created to guard rho tests
from using some credentials.