### PR TITLE
Scan remote systems Issues/148

### DIFF
--- a/camayoc/constants.py
+++ b/camayoc/constants.py
@@ -329,6 +329,12 @@ QCS_SOURCE_PATH = 'sources/'
 QCS_SCAN_PATH = 'scans/'
 """The path to the scans endpoint for CRUD tasks."""
 
+QCS_SCAN_TERMINAL_STATES = ('completed', 'failed', 'paused', 'canceled')
+"""Scans to not change from these states without intervention."""
+
+QCS_SCAN_STATES = QCS_SCAN_TERMINAL_STATES + ('running',)
+"""All the states that a quipucords scan can take."""
+
 QCS_TOKEN_PATH = 'token/'
 """The path to the endpoint used for obtaining an authentication token."""
 

--- a/camayoc/tests/qcs/api/v1/utils.py
+++ b/camayoc/tests/qcs/api/v1/utils.py
@@ -10,6 +10,10 @@ from camayoc.exceptions import (
     FailedScanException,
     ConfigFileNotFoundError,
 )
+from camayoc.constants import (
+    QCS_SCAN_STATES,
+    QCS_SCAN_TERMINAL_STATES,
+)
 from camayoc.qcs_models import (
     Credential,
     Source,
@@ -22,14 +26,33 @@ def wait_until_state(scan, timeout=120, state='completed'):
 
     The default state is 'completed'.
 
+    Valid options for 'state': 'completed', 'failed', 'paused',
+    'canceled', 'running', 'stopped'.
+
+    If 'stopped' is selected, then any state other than 'running' will
+    cause `wait_until_state` to return.
+
     This method should not be called on scan jobs that have not yet been
     created, are paused, or are canceled.
 
     The default timeout is set to 120 seconds, but can be overridden if it is
     anticipated that a scan may take longer to complete.
     """
+    valid_states = QCS_SCAN_STATES + ('stopped',)
+    if state not in valid_states:
+        raise ValueError(
+            'You have called `wait_until_state` and specified an invalid\n'
+            'state={0}. Valid options for "state" are [ {1} ]'.format(
+                state,
+                pprint.pformat(valid_states),
+            )
+        )
+
     while (
             not scan.status() or not scan.status() == state) and timeout > 0:
+        if state == 'stopped' and scan.status() in QCS_SCAN_TERMINAL_STATES:
+            # scan is no longer running, so we will return
+            return
         time.sleep(5)
         timeout -= 5
         if timeout <= 0:
@@ -47,7 +70,7 @@ def wait_until_state(scan, timeout=120, state='completed'):
                     pprint.pformat(scan.results().json()),
                 )
             )
-        if state != 'failed' and scan.status() == 'failed':
+        if state not in ['stopped', 'failed'] and scan.status() == 'failed':
             raise FailedScanException(
                 'You have called wait_until_state() on a scan with ID={} and\n'
                 'the scan failed instead of acheiving state={}.\n'

--- a/camayoc/tests/qcs/cli/test_scans.py
+++ b/camayoc/tests/qcs/cli/test_scans.py
@@ -9,7 +9,6 @@
 :testtype: functional
 :upstream: yes
 """
-import operator
 import re
 import time
 from pprint import pformat
@@ -17,6 +16,7 @@ from pprint import pformat
 import pexpect
 import pytest
 
+from camayoc.utils import name_getter
 from .conftest import qpc_server_config
 from .utils import (
     cred_add,
@@ -34,10 +34,6 @@ from camayoc.exceptions import (
     FailedScanException,
     WaitTimeError,
 )
-
-
-name_getter = operator.itemgetter('name')
-"""Generate test IDs by fetching the ``name`` item."""
 
 
 def config_credentials():

--- a/camayoc/tests/remote/conftest.py
+++ b/camayoc/tests/remote/conftest.py
@@ -1,0 +1,54 @@
+# coding=utf-8
+"""Fixtures for tests that use remote infrastructure."""
+
+import ssl
+import os
+
+import pytest
+from pyVim.connect import SmartConnect, Disconnect
+
+from camayoc.config import get_config
+
+
+@pytest.fixture(scope='module')
+def vcenter_client():
+    """Create a vCenter client.
+
+    Get the client confifuration from environment variables and Camayoc's
+    configuration file in this order. Raise a KeyError if can't find the
+    expecting configuration.
+
+    The expected environment variables are VCHOSTNAME, VCUSER and VCPASS for
+    vcenter's hostname, username and password respectively.
+
+    The configuration in the Camayoc's configuration file should be as the
+    following::
+
+        vcenter:
+          hostname: vcenter.domain.example.com
+          username: gandalf
+          password: YouShallNotPass
+
+    The vcenter config can be mixed by using both environement variables and
+    the configuration file but environment variable takes precedence.
+    """
+    config = get_config()
+    vcenter_host = os.getenv('VCHOSTNAME', config['vcenter']['hostname'])
+    vcenter_user = os.getenv('VCUSER', config['vcenter']['username'])
+    vcenter_pwd = os.getenv('VCPASS', config['vcenter']['password'])
+
+    try:
+        c = SmartConnect(
+            host=vcenter_host,
+            user=vcenter_user,
+            pwd=vcenter_pwd,
+        )
+    except ssl.SSLError:
+        c = SmartConnect(
+            host=vcenter_host,
+            user=vcenter_user,
+            pwd=vcenter_pwd,
+            sslContext=ssl._create_unverified_context(),
+        )
+    yield c
+    Disconnect(c)

--- a/camayoc/tests/remote/quipucords/__init__.py
+++ b/camayoc/tests/remote/quipucords/__init__.py
@@ -1,0 +1,2 @@
+# coding=utf-8
+"""Module of tests for running quipucords against remote systems."""

--- a/camayoc/tests/remote/quipucords/test_scan.py
+++ b/camayoc/tests/remote/quipucords/test_scan.py
@@ -1,0 +1,357 @@
+# coding=utf-8
+"""Tests for  quipucords scans and reports.
+
+These tests are parametrized on the inventory listed in the config file.
+
+:caseautomation: automated
+:casecomponent: api
+:caseimportance: high
+:caselevel: integration
+:requirement: quipucords
+:testtype: functional
+:upstream: yes
+"""
+from pprint import pformat
+
+import requests
+import pytest
+
+from camayoc import utils
+from camayoc.qcs_models import (
+    Credential,
+    Source,
+    Scan
+)
+from camayoc.config import get_config
+from camayoc.constants import (
+    VCENTER_CLUSTER,
+    VCENTER_DATA_CENTER,
+    VCENTER_HOST,
+)
+from camayoc.exceptions import (
+    ConfigFileNotFoundError,
+    WaitTimeError,
+)
+from camayoc.tests.remote.utils import wait_until_live
+from camayoc.tests.qcs.api.v1.utils import wait_until_state
+
+
+SCAN_DATA = {}
+"""Cache to associate the named scans with their results."""
+
+
+@pytest.fixture(scope='module')
+def cleanup():
+    """Fixture that cleans up any created host credentials."""
+    trash = []
+
+    yield trash
+
+    for obj in trash:
+        obj.delete()
+
+
+def create_cred(cred_info, cleanup):
+    """Given info about cred from config file, create it and return id."""
+    c = Credential(
+        cred_type=cred_info['type'],
+        username=cred_info['username'],
+    )
+    if cred_info.get('sshkeyfile'):
+        c.ssh_keyfile = cred_info['sshkeyfile']
+    else:
+        c.password = cred_info['password']
+    c.create()
+    cleanup.append(c)
+    return c._id
+
+
+def create_source(source_info, cred_name_to_id_dict, cleanup):
+    """Given info about source from config file, create it and return id."""
+    cred_ids = [value for key, value in cred_name_to_id_dict.items(
+    ) if key in source_info['credentials']]
+    host = source_info.get('ipv4') if source_info.get(
+        'ipv4') else source_info.get('hostname')
+    src = Source(
+        source_type=source_info.get('type', 'network'),
+        hosts=[host],
+        credential_ids=cred_ids,
+        options=source_info.get('options')
+    )
+    src.create()
+    cleanup.append(src)
+    return src._id
+
+
+def run_scan(src_ids, scan_name, scan_type='inspect'):
+    """Scan a machine and cache any available results.
+
+    If errors are encountered, save those and they can be included
+    in test results.
+    """
+    SCAN_DATA[scan_name] = {
+        'id': None,            # scan id
+        'final_status': None,  # Did the scan contain any failed tasks?
+        'scan_results': None,  # Number of systems reached, etc
+        'report_id': None,     # so we can retrieve report
+        'connection_results': None,  # details about connection scan
+        'inspection_results': None,  # details about inspection scan
+        'errors': [],
+    }
+    try:
+        scan = Scan(source_ids=src_ids, scan_type=scan_type)
+        TIMEOUT = 500 * len(src_ids)
+        scan.create()
+        SCAN_DATA[scan_name]['id'] = scan._id
+        wait_until_state(scan, timeout=TIMEOUT, state='stopped')
+        SCAN_DATA[scan_name]['final_status'] = scan.status()
+        SCAN_DATA[scan_name]['scan_results'] = scan.read().json()
+        SCAN_DATA[scan_name]['report_id'] = scan.read().json().get('report_id')
+        SCAN_DATA[scan_name]['connection_results'] = scan.results(
+        ).json().get('connection_results')
+        SCAN_DATA[scan_name]['inspection_results'] = scan.results(
+        ).json().get('inspection_results')
+    except (requests.HTTPError, WaitTimeError) as e:
+        SCAN_DATA[scan_name]['errors'].append('{}'.format(pformat(str(e))))
+
+
+@pytest.fixture(scope='module', autouse=True)
+def run_all_scans(vcenter_client, cleanup):
+    """Run all configured scans caching the report id associated with each.
+
+    Run each scan defined in the ``qcs`` section of the configuration file.
+
+    Cache the report id of the scan, associating it with its scan.
+
+    The expected configuration in the Camayoc's configuration file is as
+    follows::
+
+        qcs:
+        # other needed qcs config data
+        #
+        # specific for scans:
+            - scans:
+                - name: network-vcenter-sat-mix
+                  sources:
+                      - sample-none-rhel-5-vc
+                      - sample-sat-6
+                      - sample-vcenter
+        inventory:
+          - hostname: sample-none-rhel-5-vc
+            ipv4: 10.10.10.1
+            hypervisor: vcenter
+            distribution:
+                name: rhel
+                version: '5.9'
+            products: {}
+            credentials:
+                - root
+          - hostname: sample-sat-6
+            type: 'vcenter'
+            options:
+                ssl_cert_verify: false
+                satellite_version: '6.2'
+            credentials:
+                - sat6_admin
+          - hostname: sample-vcenter
+            type: 'vcenter'
+            credentials:
+                - vcenter_admin
+
+        credentials:
+            - name: root
+              sshkeyfile: /path/to/.ssh/id_rsa
+              username: root
+              type: network
+
+            - name: sat6_admin
+              password: foo
+              username: admin
+              type: satellite
+
+            - name: vcenter_admin
+              password: foo
+              username: admin
+              type: vcenter
+
+    In the sample configuration file above, one machine will be turned on,
+    and one scan will be run against the three sources each created with
+    their own credential.
+    """
+    config = get_config()
+    creds = config['credentials']
+    scans = config.get('qcs', {}).get('scans', [])
+    if scans == []:
+        # if no scans are defined, no need to go any further
+        return
+    inventory = {
+        machine['hostname']: machine for machine in config['inventory']
+    }
+    vcenter_inventory = {
+        machine['hostname']: machine for machine in config['inventory']
+        if machine.get('hypervisor') == 'vcenter'
+    }
+    if not creds or not inventory:
+        raise ValueError(
+            'Make sure to have credentials and inventory'
+            ' items in the config file'
+        )
+    vcenter_hostnames = list(vcenter_inventory.keys())
+    host_folder = vcenter_client.content.rootFolder \
+        .childEntity[VCENTER_DATA_CENTER].hostFolder
+    host = host_folder.childEntity[VCENTER_CLUSTER].host[VCENTER_HOST]
+    cred_ids = {}
+    source_ids = {}
+    for cred in creds:
+        # create creds on server
+        # create dict that associates the name of the cred to the cred id
+        cred_ids[cred['name']] = create_cred(cred, cleanup)
+    for hostname, source in inventory.items():
+        # create sources on server, and keep track of source ids for each scan
+        # name of cred to cred id on server
+        source_ids[hostname] = create_source(source, cred_ids, cleanup)
+        for scan in scans:
+            for source in scan['sources']:
+                if hostname == source:
+                    scan.setdefault(
+                        'source_ids', []).append(
+                        source_ids[hostname])
+    for scan in scans:
+        # update the sources dict of each item in the scans list with the
+        # source id if hosts are marked as being hosted on vcenter, turn them
+        # on. then wait until they are live
+        # then run the scan, caching the report id associated with the scan
+        # and finally turn the managed machines off.
+        vcenter_vms = [
+            vm for vm in host.vm
+            if (vm.name in vcenter_hostnames) and (vm.name in scan['sources'])
+        ]
+        machines_to_wait = []
+        for vm in vcenter_vms:
+            if vm.runtime.powerState == 'poweredOff':
+                vm.PowerOnVM_Task()
+                machines_to_wait.append(inventory[vm.name])
+        wait_until_live(machines_to_wait)
+        # now all host should be live and we can run the scan
+        # all results will be saved in global cache
+        # if errors occur, they will be saved but scanning will go on
+        run_scan(scan['source_ids'], scan['name'])
+        for vm in vcenter_vms:
+            if vm.runtime.powerState == 'poweredOn':
+                vm.PowerOffVM_Task()
+
+
+def scan_info():
+    """Generate list of scan dict objects found in config file."""
+    try:
+        return get_config().get('qcs', {}).get('scans', [])
+    except (ConfigFileNotFoundError, KeyError):
+        return []
+
+
+def get_scan_result(scan_name):
+    """Collect scan results from global cache.
+
+    Raise an error if no results are available, because this means the scan
+    was not even attempted.
+    """
+    result = SCAN_DATA.get(scan_name)
+    if result is None:
+        raise RuntimeError(
+            'Absolutely no results available for scan named {scan_name},\n'
+            'because no scan was even attempted.\n'.format(
+                scan_name=scan_info['name'])
+        )
+    return result
+
+
+@pytest.mark.parametrize(
+    'scan_info', scan_info(), ids=utils.name_getter)
+def test_scan_complete(scan_info):
+    """Test that each scan completed without failures.
+
+    :id: 4e7a608e-a18d-48db-b263-a0d5474385dd
+    :description: Test if the scan completed.
+    :steps: Check the final status of the scan.
+    :expectedresults: Scans should complete and report their finished status.
+    """
+    result = get_scan_result(scan_info['name'])
+    if result['final_status'] != 'completed':
+        raise AssertionError(
+            'Scan did not complete. Its final status was {status}.\n'
+            ' A scan will be reported as failed if there were unreachable\n'
+            ' hosts. Any additional errors encountered are listed here: \n'
+            '{errors}\n'.format(
+                status=result['final_status'],
+                errors='\n'.join(result['errors']),
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    'scan_info', scan_info(), ids=utils.name_getter)
+def test_scan_connection_results(scan_info):
+    """Test the connection results of each scan.
+
+    :id: 8087fdc9-6626-476a-a11a-4783cbf501a0
+    :description: Test the connection results of the scan
+    :steps:
+        1) Iterate over sources that we have connection results for.
+        2) Inspect server arithmetic regarding number of systems scanned
+    :expectedresults: There are connection results for each source we scanned
+       and we get an accurate count of how many were reached and how many
+       failed.
+    """
+    result = get_scan_result(scan_info['name'])
+    connection_results = result['connection_results']
+    if connection_results is None:
+        raise AssertionError(
+            'Scan did not have connection results. Its final status was \n'
+            '{status}. It encountered the following errors: {errors}\n'.format(
+                status=result['final_status'],
+                errors=' '.join(result['errors']),
+            )
+        )
+    scanned_sources = []
+    for task in connection_results['task_results']:
+        scanned_sources.append(task['source'])
+
+    # assert we have connection info for each source
+    assert len(scanned_sources) == len(scan_info['sources'])
+
+    # assert arithmetic around number of systems scanned adds up
+    # this has been broken in the past
+    num_scanned = result['scan_results']['systems_count']
+    num_failed = result['scan_results']['systems_failed']
+    num_scanned = result['scan_results']['systems_scanned']
+    assert num_scanned == num_scanned + num_failed
+
+
+@pytest.mark.parametrize(
+    'scan_info', scan_info(), ids=utils.name_getter)
+def test_scan_inspection_results(scan_info):
+    """Test the inspection results of each scan.
+
+    :id: d29d9fd6-ac85-4110-9b1c-ac7c26205d16
+    :description: Test the inspection results of the scan
+    :steps:
+        1) Iterate over sources that we have connection results for.
+    :expectedresults: There are inspection results for each source we scanned.
+    """
+    result = get_scan_result(scan_info['name'])
+    inspection_results = result['inspection_results']
+    if inspection_results is None:
+        raise AssertionError(
+            'Scan did not have connection results. Its final status was \n'
+            '{status}. It encountered the following errors: {errors}\n'.format(
+                status=result['final_status'],
+                errors=' '.join(result['errors']),
+            )
+
+        )
+    scanned_sources = []
+    for task in inspection_results['task_results']:
+        scanned_sources.append(task['source'])
+
+    # assert we have connection info for each source
+    assert len(scanned_sources) == len(scan_info['sources'])

--- a/camayoc/tests/remote/utils.py
+++ b/camayoc/tests/remote/utils.py
@@ -1,0 +1,41 @@
+# coding=utf-8
+"""Shared utitlites for tests using remote infrastructure."""
+
+import time
+
+from camayoc import cli
+
+
+def is_live(client, server, num_pings=10):
+    """Test if server responds to ping.
+
+    Returns true if server is reachable, false otherwise.
+    """
+    client.response_handler = cli.echo_handler
+    ping = client.run(('ping', '-c', num_pings, server))
+    return ping.returncode == 0
+
+
+def wait_until_live(servers, timeout=60):
+    """Wait for servers to be live.
+
+    For each server in the "servers" list, verify if it is reachable.
+    Keep trying until a connection is made for all servers or the timeout
+    limit is reached.
+
+    If the timeout limit is reached, we exit even if there are unreached hosts.
+    This means tests could fail with "No auths valid for this profile" if every
+    host in the profile is unreachable. Otherwise, if there is at least one
+    valid host, the scan will go on and only facts about reached hosts will be
+    tested.
+
+    `See rho issue #302 <https://github.com/quipucords/rho/issues/302>`_
+    """
+    system = cli.System(hostname='localhost', transport='local')
+    client = cli.Client(system)
+
+    unreached = servers
+    while unreached and timeout > 0:
+        unreached = [host for host in unreached if not is_live(client, host)]
+        time.sleep(10)
+        timeout -= 10

--- a/camayoc/utils.py
+++ b/camayoc/utils.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """Utility functions."""
 import contextlib
+import operator
 import os
 import shutil
 import tempfile
@@ -13,6 +14,10 @@ from camayoc.config import get_config
 
 _XDG_ENV_VARS = ('XDG_DATA_HOME', 'XDG_CONFIG_HOME', 'XDG_CACHE_HOME')
 """Environment variables related to the XDG Base Directory specification."""
+
+
+name_getter = operator.itemgetter('name')
+"""Generate test IDs by fetching the ``name`` item."""
 
 
 def get_qcs_url():

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -50,8 +50,12 @@ reference for developers, not a gospel.
     api/camayoc.tests.qcs.ui.views
     api/camayoc.tests.qcs.utils
     api/camayoc.tests.remote
+    api/camayoc.tests.remote.conftest
+    api/camayoc.tests.remote.quipucords
+    api/camayoc.tests.remote.quipucords.test_scan
     api/camayoc.tests.remote.rho
     api/camayoc.tests.remote.rho.test_scan
+    api/camayoc.tests.remote.utils
     api/camayoc.tests.rho
     api/camayoc.tests.rho.test_auth
     api/camayoc.tests.rho.test_fact

--- a/docs/api/camayoc.tests.remote.conftest.rst
+++ b/docs/api/camayoc.tests.remote.conftest.rst
@@ -1,0 +1,7 @@
+camayoc\.tests\.remote\.conftest module
+=======================================
+
+.. automodule:: camayoc.tests.remote.conftest
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/camayoc.tests.remote.quipucords.rst
+++ b/docs/api/camayoc.tests.remote.quipucords.rst
@@ -1,0 +1,15 @@
+camayoc\.tests\.remote\.quipucords package
+==========================================
+
+.. automodule:: camayoc.tests.remote.quipucords
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Submodules
+----------
+
+.. toctree::
+
+   camayoc.tests.remote.quipucords.test_scan
+

--- a/docs/api/camayoc.tests.remote.quipucords.test_scan.rst
+++ b/docs/api/camayoc.tests.remote.quipucords.test_scan.rst
@@ -1,0 +1,7 @@
+camayoc\.tests\.remote\.quipucords\.test\_scan module
+=====================================================
+
+.. automodule:: camayoc.tests.remote.quipucords.test_scan
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/camayoc.tests.remote.rst
+++ b/docs/api/camayoc.tests.remote.rst
@@ -11,5 +11,14 @@ Subpackages
 
 .. toctree::
 
+    camayoc.tests.remote.quipucords
     camayoc.tests.remote.rho
+
+Submodules
+----------
+
+.. toctree::
+
+   camayoc.tests.remote.conftest
+   camayoc.tests.remote.utils
 

--- a/docs/api/camayoc.tests.remote.utils.rst
+++ b/docs/api/camayoc.tests.remote.utils.rst
@@ -1,0 +1,7 @@
+camayoc\.tests\.remote\.utils module
+====================================
+
+.. automodule:: camayoc.tests.remote.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/tests.test_utils.rst
+++ b/docs/api/tests.test_utils.rst
@@ -1,0 +1,7 @@
+tests\.test\_utils module
+=========================
+
+.. automodule:: tests.test_utils
+    :members:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
Push vcenter client fixture up a level so it can be shared across rho/quipucords remote scans.

This would entail another :disappointed: update to the config file -- putting vcenter and satellite sources we want to scan down in the inventory, and associating creds directly with the items in the inventory.

Really, it only adds info to the config, so doesn't seem to be breaking anything yet. I've run the rho remote scan test and seems to be working, just needed minor tweak to get('hypervisor') instead of directly accessing it and the extra `credentials` key does not seem to matter. 

I've gotten my "minimum viable" scan to run with the following config:

```
---
credentials:
    - name: root
      type: 'network'
      sshkeyfile: /sshkeys/id_sonar_jenkins_rsa
      username: root
    - name: 'vcenter'
      type: 'vcenter'
      password: 'foo'
      username: 'bar'
      rho: false
    - name: 'sat6'
      type: 'satellite'
      password: 'foo'
      username: 'bar'
      rho: false
qcs:
    hostname: '127.0.0.1'
    https: true
    port: 443
    ssl-verify: false
    username: 'admin'
    password: 'pass'
    sources:
          # this section is used by other qcs that don't rely being able
          # to turn on/off machines
          # could try and get rid of it
          # or it could stay. it is not that big
          # but it does contain some duplicate content
          # and the remote scan test does not use it at all
    scans:
        - name: mvp
          sources:
              - 'sonar-jbossamq-rhel-7-vc'
              - 'vcenter.example.com'
              - 'sat.six.example.com'

vcenter:
    hostname: vcenter.example.com
    password: "foo"
    username: bar

inventory:
    - hostname: 'vcenter.example.com'
      credentials:
          - 'vcenter'
      type: 'vcenter'
      options:
          ssl_cert_verify: false
    - hostname: 'sat.six.example.com'
      credentials:
          - 'sat6'
      name: 'sat6'
      type: 'satellite'
      options:
          satellite_version: '6.2'
          ssl_cert_verify: false
    - hostname: sonar-jbossamq-rhel-7-vc
      ipv4: 10.10.181.154
      hypervisor: vcenter
      distribution:
          name: rhel
          version: '7.4'
      products:
          jboss-amq:
              install-process: zip
              version: '7.0.2'
          openjdk:
              version: '1.8'
      credentials:
          - root
```

This yeilds:
```
========================================== test session starts ===========================================
platform linux -- Python 3.6.3, pytest-3.3.1, py-1.5.2, pluggy-0.6.0 -- /home/elijah/envs/camayoc/bin/python3.6
cachedir: ../../../../.cache
rootdir: /home/elijah/sfw/quipu/camayoc, inifile:
plugins: cov-2.5.1
collected 1 item                                                                                         

test_scan.py::test_scan[scan_info0] PASSED                                                         [100%]
```
What happens is this:
1) Create all creds, cache name to id relationship
2) Create a sources, using appropriate cred by looking up id with the name in cache created in step 1
3) For each scan, if a host is marked as having `vcenter` as its hypervisor and it is in the list of vms we got from vcenter, turn it on and wait for all these machines to be live
4) run the scan and cache the relationship between the name of the scan and the report id
5) turn off the machines we turned on
6) repeat if there are more scans.

This leaves it up to the config file writer to determine how many hosts get turned on for each scan.
Currently there is no mechanism for having a multi host network source be one of the sources.

I need to make this pretty/make the linter happy/work on doc strings but I wanted to get your feedback on the general idea so I could finish it up on Thursday.

Also want to assert on something in the report.

Thanks!
