### PR TITLE
Fix key error in rho remote scan

### DIFF
--- a/camayoc/tests/remote/rho/test_scan.py
+++ b/camayoc/tests/remote/rho/test_scan.py
@@ -229,7 +229,7 @@ def test_scan(machine, auth):
         auth.
     :expectedresults: The generate report must have the expected fact values.
     """
-    profile_name = machine['hostname'] + '-' + auth['name']
+    profile_name = machine + '-' + auth['name']
     result = SCAN_RESULTS[profile_name]
     if result is None:
         with open(profile_name) as handler:


### PR DESCRIPTION
It appears this change in the type expected fell through the cracks with the
updates to the quipucords remote scans.

This appears to fix it based on local testing, where the error that the
automated jobs were having was reproducable.