### PR TITLE
Test new delete workflow for credentials

### DIFF
--- a/camayoc/tests/qcs/conftest.py
+++ b/camayoc/tests/qcs/conftest.py
@@ -2,6 +2,11 @@
 import pytest
 
 from camayoc import api
+from camayoc.qcs_models import (
+    Credential,
+    Scan,
+    Source,
+)
 
 
 @pytest.fixture
@@ -11,8 +16,26 @@ def cleanup():
 
     yield trash
 
+    creds = []
+    sources = []
+    scans = []
+
+    # first sort into types because we have to delete scans before sources
+    # and sources before scans
     for obj in trash:
-        obj.delete()
+        if isinstance(obj, Credential):
+            creds.append(obj)
+            continue
+        if isinstance(obj, Source):
+            sources.append(obj)
+            continue
+        if isinstance(obj, Scan):
+            scans.append(obj)
+            continue
+
+    for collection in [scans, sources, creds]:
+        for obj in collection:
+            obj.delete()
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
Update existing tests and fixtures to deal with the fact that we must delete
all scans before we delete sources involved in them, and that we must delete
all sources before we delete credentials that depend on them.

Reworks how a couple tests work through paginated data from API because they
were failing to advance pages correctly.

Finally adds a test case confirming that we get denied if we attempt to delete
a credential if a source depends on it, and that we can then update the source
to use a new credential or we may delete the source and this then allows us to
delete the credential.

Closes #163