### PR TITLE
Test new delete workflow for sources and flesh out other stubs

### DIFF
--- a/camayoc/qcs_models.py
+++ b/camayoc/qcs_models.py
@@ -394,6 +394,7 @@ class Scan(QCSObject):
             source_ids=None,
             max_concurrency=50,
             scan_type='inspect',
+            name=None,
             _id=None):
         """Iniitalize a Scan object with given data.
 
@@ -407,20 +408,22 @@ class Scan(QCSObject):
 
         self.sources = source_ids
         self.endpoint = QCS_SCAN_PATH
+        self.name = uuid4() if name is None else name
 
         # valid scan types are 'host' and 'discovery'
         self.scan_type = scan_type
         self.options = {'max_concurrency': max_concurrency}
 
-    def delete(self):
-        """No delete method is implemented for scan objects.
+    def delete(self, **kwargs):
+        """Send DELETE request to the self.endpoint/{id} of this object.
 
-        Raise an exception to alert the user of this instead of doing anything.
+        :param ``**kwargs``: Additional arguments accepted by Requests's
+            `request.request()` method.
+
+        Returns a requests.models.Response. A successful delete has the return
+        code `204`.
         """
-        raise NotImplementedError(
-            'the DELETE method is not allowed for the scan endpoint, '
-            'so this method is not implemented for Scan objects.'
-        )
+        return self.client.delete(self.path(), **kwargs)
 
     def pause(self, **kwargs):
         """Send PUT request to self.endpoint/{id}/pause/ to pause a scan.

--- a/camayoc/tests/qcs/utils.py
+++ b/camayoc/tests/qcs/utils.py
@@ -40,19 +40,18 @@ def assert_source_update_fails(original_data, source):
     source.client = orig_client
 
 
-def gen_valid_source(cleanup, src_type, host):
-    """Create valid source and return it with echo_handler."""
-    client = api.Client()
-    cred = Credential(cred_type=src_type, client=client, password=uuid4())
+def gen_valid_source(cleanup, src_type, host, create=True):
+    """Create valid source."""
+    cred = Credential(cred_type=src_type, password=uuid4())
     cred.create()
     cleanup.append(cred)
-    source = Source(source_type=src_type,
-                    hosts=[host],
-                    credential_ids=[cred._id],
-                    client=client,
+    source = Source(
+            source_type=src_type,
+            hosts=[host],
+            credential_ids=[cred._id],
                     )
-    source.create()
-    cleanup.append(source)
-    assert_matches_server(source)
-    source.client.response_handler = api.echo_handler
+    if create:
+        source.create()
+        cleanup.append(source)
+        assert_matches_server(source)
     return source

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -70,6 +70,7 @@ MOCK_SAT6_SOURCE = {
 
 MOCK_SCAN = {
     'id': 21,
+    'name': 'testscan',
     'options': {'max_concurrency': 50},
     'scan_type': 'connect',
     'sources': [153],
@@ -286,6 +287,7 @@ class ScanTestCase(unittest.TestCase):
             scn = Scan(
                 source_ids=[153],
                 scan_type='connect',
+                name=MOCK_SCAN['name'],
             )
             scn._id = MOCK_SCAN['id']
             self.assertTrue(scn.equivalent(MOCK_SCAN))


### PR DESCRIPTION
Adds test cases for the new delete workflow that bars users from deleting
sources that are members of scans.

Also implements several pre-existing test stubs for sources.

Closes #165