### PR TITLE
Update CLI scan tests to use new scan job and report workflow

### DIFF
--- a/camayoc/tests/qcs/cli/conftest.py
+++ b/camayoc/tests/qcs/cli/conftest.py
@@ -60,3 +60,21 @@ def qpc_server_config():
 def source_type(request):
     """Fixture that returns the quipucords source types."""
     return request.param
+
+
+@pytest.fixture(scope='module', autouse=True)
+def cleanup_server():
+    """Cleanup objects on the server after each module runs.
+
+    We must delete all objects on the server in the correct order, first scans,
+    then sources, then credentials.
+    """
+    clear_scans = pexpect.spawn('qpc scan clear --all')
+    assert clear_scans.expect(pexpect.EOF) == 0
+    clear_scans.close()
+    clear_sources = pexpect.spawn('qpc source clear --all')
+    assert clear_sources.expect(pexpect.EOF) == 0
+    clear_sources.close()
+    clear_creds = pexpect.spawn('qpc cred clear --all')
+    assert clear_creds.expect(pexpect.EOF) == 0
+    clear_creds.close()

--- a/camayoc/tests/qcs/cli/test_credentials.py
+++ b/camayoc/tests/qcs/cli/test_credentials.py
@@ -21,7 +21,10 @@ from camayoc.constants import (
     MASKED_PASSWORD_OUTPUT,
     BECOME_PASSWORD_INPUT,
 )
-from camayoc.tests.qcs.cli.utils import cred_add, cred_show
+from camayoc.tests.qcs.cli.utils import (
+        cred_add,
+        cred_show,
+)
 
 
 def generate_show_output(data):
@@ -661,13 +664,12 @@ def test_clear_all(isolated_filesystem, qpc_server_config):
             'sshkeyfile': str(sshkeyfile.resolve()),
         })
 
-    qpc_cred_clear = pexpect.spawn(
+    clear = pexpect.spawn(
         'qpc cred clear --all'
     )
-    assert qpc_cred_clear.expect('All credentials were removed') == 0
-    assert qpc_cred_clear.expect(pexpect.EOF) == 0
-    qpc_cred_clear.close()
-    assert qpc_cred_clear.exitstatus == 0
+    assert clear.expect('All credentials were removed.') == 0
+    assert clear.expect(pexpect.EOF) == 0
+    clear.close()
 
     qpc_cred_list = pexpect.spawn('qpc cred list')
     assert qpc_cred_list.expect('No credentials exist yet.') == 0

--- a/camayoc/tests/qcs/cli/test_sources.py
+++ b/camayoc/tests/qcs/cli/test_sources.py
@@ -67,11 +67,9 @@ def generate_show_output(data):
     source_type = data['source_type']
     if source_type == 'satellite':
         output += (
-            '    "options": {{\r\n'
-            '        "satellite_version": "{}",\r\n'
+            '    "options": {\r\n'
             '        "ssl_cert_verify": true\r\n'
-            '    }},\r\n'
-            .format(data.get('satellite_version', '6.2'))
+            '    },\r\n'
         )
     if source_type == 'vcenter':
         output += (
@@ -844,7 +842,6 @@ def test_clear_all(isolated_filesystem, qpc_server_config, source_type):
         }
         if source_type == 'satellite':
             source['options'] = {
-                'satellite_version': '6.2',
                 'ssl_cert_verify': True,
             }
         if source_type == 'vcenter':

--- a/camayoc/tests/qcs/cli/utils.py
+++ b/camayoc/tests/qcs/cli/utils.py
@@ -160,10 +160,18 @@ scan_pause = functools.partial(cli_command, 'qpc scan pause')
 scan_restart = functools.partial(cli_command, 'qpc scan restart')
 """Run ``qpc scan restart`` command with ``options`` returning its output."""
 
+scan_add = functools.partial(cli_command, 'qpc scan add')
+"""Run ``qpc scan add`` command with ``options`` returning its output."""
+
 scan_start = functools.partial(cli_command, 'qpc scan start')
 """Run ``qpc scan start`` command with ``options`` returning its output."""
 
 
+def scan_detail_report(options=None, exitstatus=0):
+    """Run ``qpc report detail`` with ``options`` and return output."""
+    return cli_command('qpc report detail', options, exitstatus)
+
+
 def scan_show(options=None, exitstatus=0):
-    """Run ``qpc scan show`` command with ``options`` returning its output."""
-    return json.loads(cli_command('qpc scan show', options, exitstatus))
+    """Run ``qpc scan job`` command with ``options`` returning its output."""
+    return json.loads(cli_command('qpc scan job', options, exitstatus))


### PR DESCRIPTION
Adds cleanup_module fixture to clean up any credentials, sources, or scans
leftover after a module in the correct order to avoid causing spurious errors
in other tests now that users are blocked from deleting objects that other
objects depend on.

Updates expected output for satellite source show, because now the satellite
version is determined at run time and is not stored.

Closes #160