### PR TITLE
Update qcs cli utils and conftest

### DIFF
--- a/camayoc/tests/qcs/cli/conftest.py
+++ b/camayoc/tests/qcs/cli/conftest.py
@@ -69,12 +69,7 @@ def cleanup_server():
     We must delete all objects on the server in the correct order, first scans,
     then sources, then credentials.
     """
-    clear_scans = pexpect.spawn('qpc scan clear --all')
-    assert clear_scans.expect(pexpect.EOF) == 0
-    clear_scans.close()
-    clear_sources = pexpect.spawn('qpc source clear --all')
-    assert clear_sources.expect(pexpect.EOF) == 0
-    clear_sources.close()
-    clear_creds = pexpect.spawn('qpc cred clear --all')
-    assert clear_creds.expect(pexpect.EOF) == 0
-    clear_creds.close()
+    for command in ('scan', 'source', 'cred'):
+        clear = pexpect.spawn('qpc {} clear --all'.format(command))
+        assert clear.expect(pexpect.EOF) == 0
+        clear.close()

--- a/camayoc/tests/qcs/cli/test_scans.py
+++ b/camayoc/tests/qcs/cli/test_scans.py
@@ -21,14 +21,14 @@ from camayoc.utils import name_getter, uuid4
 from .conftest import qpc_server_config
 from .utils import (
     cred_add,
-    source_add,
+    report_detail,
     scan_add,
     scan_cancel,
+    scan_job,
     scan_pause,
     scan_restart,
-    scan_detail_report,
-    scan_show,
     scan_start,
+    source_add,
 )
 from camayoc.config import get_config
 from camayoc.constants import BECOME_PASSWORD_INPUT, CONNECTION_PASSWORD_INPUT
@@ -119,7 +119,7 @@ def wait_for_scan(scan_job_id, status='completed', timeout=900):
     :param timeout: wait up to this amount of seconds. Default is 900.
     """
     while timeout > 0:
-        result = scan_show({'id': scan_job_id})
+        result = scan_job({'id': scan_job_id})
         if status != 'failed' and result['status'] == 'failed':
             raise FailedScanException(
                 'The scan with ID "{}" has failed unexpectedly.\n\n'
@@ -161,14 +161,14 @@ def test_scan(isolated_filesystem, qpc_server_config, source):
     assert match is not None
     scan_job_id = match.group(1)
     wait_for_scan(scan_job_id)
-    result = scan_show({
+    result = scan_job({
         'id': scan_job_id,
     })
     assert result['status'] == 'completed'
     report_id = result['report_id']
     assert report_id is not None
     output_file = 'out.json'
-    report = scan_detail_report({
+    report = report_detail({
         'json': None,
         'output-file': output_file,
         'report': report_id,
@@ -201,14 +201,14 @@ def test_scan_with_multiple_sources(isolated_filesystem, qpc_server_config):
     assert match is not None
     scan_job_id = match.group(1)
     wait_for_scan(scan_job_id, timeout=1200)
-    result = scan_show({
+    result = scan_job({
         'id': scan_job_id,
     })
     assert result['status'] == 'completed'
     report_id = result['report_id']
     assert report_id is not None
     output_file = 'out.json'
-    report = scan_detail_report({
+    report = report_detail({
         'json': None,
         'output-file': output_file,
         'report': report_id,
@@ -262,14 +262,14 @@ def test_scan_restart(isolated_filesystem, qpc_server_config):
     wait_for_scan(scan_job_id, status='paused')
     scan_restart({'id': scan_job_id})
     wait_for_scan(scan_job_id)
-    result = scan_show({
+    result = scan_job({
         'id': scan_job_id,
     })
     assert result['status'] == 'completed'
     report_id = result['report_id']
     assert report_id is not None
     output_file = 'out.json'
-    report = scan_detail_report({
+    report = report_detail({
         'json': None,
         'output-file': output_file,
         'report': report_id,

--- a/camayoc/tests/qcs/cli/utils.py
+++ b/camayoc/tests/qcs/cli/utils.py
@@ -93,6 +93,10 @@ def cred_show(options, output, exitstatus=0):
     assert qpc_cred_show.exitstatus == exitstatus
 
 
+report_detail = functools.partial(cli_command, 'qpc report detail')
+"""Run ``qpc report detail`` with ``options`` and return output."""
+
+
 def source_add(options, inputs=None, exitstatus=0):
     """Add a new source entry.
 
@@ -167,11 +171,6 @@ scan_start = functools.partial(cli_command, 'qpc scan start')
 """Run ``qpc scan start`` command with ``options`` returning its output."""
 
 
-def scan_detail_report(options=None, exitstatus=0):
-    """Run ``qpc report detail`` with ``options`` and return output."""
-    return cli_command('qpc report detail', options, exitstatus)
-
-
-def scan_show(options=None, exitstatus=0):
+def scan_job(options=None, exitstatus=0):
     """Run ``qpc scan job`` command with ``options`` returning its output."""
     return json.loads(cli_command('qpc scan job', options, exitstatus))


### PR DESCRIPTION
Use a for loop to clear the server on conftest and rename helper
functions to match the cli commands they are for.