### PR TITLE
Remove all references to satellite version

### DIFF
--- a/camayoc/qcs_models.py
+++ b/camayoc/qcs_models.py
@@ -341,13 +341,6 @@ class Source(QCSObject):
                         ssl_verify = True
                     if other.get(key, {}).get('ssl_cert_verify') != ssl_verify:
                         return False
-                if self.source_type == 'satellite':
-                    if hasattr(self, 'options'):
-                        sat_ver = self.options.get('satellite_version', '6.2')
-                    else:
-                        sat_ver = '6.2'
-                    if other.get(key, {}).get('satellite_version') != sat_ver:
-                        return False
 
             if key == 'credentials':
                 other_creds = other.get('credentials')

--- a/camayoc/tests/qcs/api/v1/scanjobs/test_run_scanjobs.py
+++ b/camayoc/tests/qcs/api/v1/scanjobs/test_run_scanjobs.py
@@ -145,7 +145,6 @@ def run_all_scans(vcenter_client, module_cleanup):
             type: 'vcenter'
             options:
                 ssl_cert_verify: false
-                satellite_version: '6.2'
             credentials:
                 - sat6_admin
           - hostname: sample-vcenter

--- a/camayoc/tests/qcs/api/v1/sources/test_manager_sources.py
+++ b/camayoc/tests/qcs/api/v1/sources/test_manager_sources.py
@@ -48,23 +48,3 @@ def test_negative_update_invalid(src_type, shared_client, cleanup, scan_host):
     :caseautomation: notautomated
     """
     pass
-
-
-@pytest.mark.skip
-@pytest.mark.parametrize('src_type', 'satellite')
-def test_negative_create_satellite(
-        src_type,
-        shared_client,
-        cleanup,
-        scan_host):
-    """Attempt to create a satellite source with an invalid version.
-
-    :id: d59891e6-b232-4ae0-b605-f0adf74ccc86
-    :description: Attempt to create satellite with non-supported or invalid
-        version.
-    :steps:
-        1) Attempt to create a satellite source with invalid version.
-    :expectedresults: An error is thrown and no new host is created.
-    :caseautomation: notautomated
-    """
-    pass


### PR DESCRIPTION
The satellite version is now determined at runtime and this data is not stored
or exposed to the user.  This PR removes all tests that set and or checked the
satellite version of a satellite source.

Closes #152