### PR TITLE
Update to use new scan job results API

### DIFF
--- a/camayoc/qcs_models.py
+++ b/camayoc/qcs_models.py
@@ -561,13 +561,22 @@ class ScanJob(QCSObject):
         path = urljoin(self.path(), 'restart/')
         return self.client.put(path, {}, **kwargs)
 
-    def results(self, **kwargs):
-        """Send a GET self.endpoint/{id}/results/ to read scan details.
+    def connection_results(self, **kwargs):
+        """Send a GET self.endpoint/{id}/connection/ to read scan details.
 
         :param ``**kwargs``: Additional arguments accepted by Requests's
             `request.request()` method.
         """
-        path = urljoin(self.path(), 'results/')
+        path = urljoin(self.path(), 'connection/')
+        return self.client.get(path, **kwargs)
+
+    def inspection_results(self, **kwargs):
+        """Send a GET self.endpoint/{id}/inspection/ to read scan details.
+
+        :param ``**kwargs``: Additional arguments accepted by Requests's
+            `request.request()` method.
+        """
+        path = urljoin(self.path(), 'inspection/')
         return self.client.get(path, **kwargs)
 
     def status(self):

--- a/camayoc/tests/qcs/api/v1/utils.py
+++ b/camayoc/tests/qcs/api/v1/utils.py
@@ -73,8 +73,7 @@ def wait_until_state(scanjob, timeout=120, state='completed'):
                     scanjob_details=pprint.pformat(
                         scanjob.read().json()),
                     scanjob_results=pprint.pformat(
-                        scanjob.results().json()),
-                ))
+                        scanjob.read().json().get('tasks'))))
         if state not in ['stopped', 'failed'] and scanjob.status() == 'failed':
             raise FailedScanException(
                 'You have called wait_until_state() on a scanjob with\n'
@@ -92,8 +91,7 @@ def wait_until_state(scanjob, timeout=120, state='completed'):
                     scanjob_details=pprint.pformat(
                         scanjob.read().json()),
                     scanjob_results=pprint.pformat(
-                        scanjob.results().json()),
-                ))
+                        scanjob.read().json().get('tasks'))))
 
 
 def all_sources():


### PR DESCRIPTION
Now results for the connection and inspection tasks are available at seperate
endpoints.  Update test that was inspecting arithmetic for reached and
unreached hosts to get this data from the scan job detail, where it now lives.

Closes #181