### PR TITLE
Add api test for pause, cancel, and restart of scanjobs

### DIFF
--- a/camayoc/tests/qpc/api/v1/conftest.py
+++ b/camayoc/tests/qpc/api/v1/conftest.py
@@ -1,5 +1,4 @@
 """Pytest customizations and fixtures for the quipucords tests."""
-import os
 from pprint import pformat
 
 import pytest
@@ -21,19 +20,11 @@ from camayoc.qpc_models import (
 )
 from camayoc.tests.qpc.api.v1.utils import wait_until_state
 from camayoc.tests.utils import wait_until_live
+from camayoc.utils import run_scans
 
 
 SCAN_DATA = {}
 """Cache to associate the named scans with their results."""
-
-
-def run_scans():
-    """Check for run scans environment variable."""
-    result = True
-    run_scans = os.environ.get('RUN_SCANS', 'true')
-    if run_scans.lower() == 'false':
-        result = False
-    return result
 
 
 def create_cred(cred_info, session_cleanup):

--- a/camayoc/tests/qpc/api/v1/scanjobs/test_pause_cancel_restart.py
+++ b/camayoc/tests/qpc/api/v1/scanjobs/test_pause_cancel_restart.py
@@ -1,0 +1,80 @@
+# coding=utf-8
+"""Tests for  quipucords scans and reports.
+
+These tests are parametrized on the inventory listed in the config file.
+
+:caseautomation: automated
+:casecomponent: api
+:caseimportance: high
+:caselevel: integration
+:requirement: quipucords
+:testtype: functional
+:upstream: yes
+"""
+import pytest
+
+import camayoc.tests.qpc.api.v1.utils as util
+from camayoc.constants import QPC_SOURCE_TYPES
+from camayoc.qpc_models import ScanJob
+from camayoc.tests.qpc.utils import mark_runs_scans
+
+
+@mark_runs_scans
+@pytest.mark.parametrize('source_type', QPC_SOURCE_TYPES)
+def test_pause_cancel(shared_client, cleanup, source_type):
+    """Run a scan on a system and confirm we can pause and cancel it.
+
+    :id: 4d4b9839-1672-4183-bd27-11864787eb8e
+    :description: Assert that scans can be paused and then canceled.
+    :steps:
+        1) Create necessary credentials and sources
+        2) Create the scan configuration
+        3) Create a scan job
+        4) Assert that the scan can be paused
+        5) Assert that the scan can be canceled
+    :expectedresults: A scan can be paused and canceled
+    """
+    scn = util.get_scan(source_type, cleanup)
+    if not scn:
+        pytest.skip(
+            'No {0} type source was found in the config file.'
+            .format(source_type)
+        )
+    job = ScanJob(scan_id=scn._id)
+    job.create()
+    util.wait_until_state(job, state='running')
+    job.pause()
+    util.wait_until_state(job, state='paused')
+    job.cancel()
+    util.wait_until_state(job, state='canceled')
+
+
+@mark_runs_scans
+@pytest.mark.parametrize('source_type', QPC_SOURCE_TYPES)
+def test_restart(shared_client, cleanup, source_type):
+    """Run a scan on a system and confirm we can pause and restart it.
+
+    :id: 6d81121d-500e-4188-8195-2e469ca606c0
+    :description: Assert that scans can be paused and then restarted.
+    :steps:
+        1) Create necessary credentials and sources
+        2) Create the scan configuration
+        3) Create a scan job
+        4) Assert that the scan can be paused
+        5) Assert that the scan can be restarted
+        6) Assert that the scan completes
+    :expectedresults: A restarted scan completes
+    """
+    scn = util.get_scan(source_type, cleanup)
+    if not scn:
+        pytest.skip(
+            'No {0} type source was found in the config file.'
+            .format(source_type)
+        )
+    job = ScanJob(scan_id=scn._id)
+    job.create()
+    util.wait_until_state(job, state='running')
+    job.pause()
+    util.wait_until_state(job, state='paused')
+    job.restart()
+    util.wait_until_state(job, state='completed')

--- a/camayoc/tests/qpc/api/v1/scanjobs/test_pause_cancel_restart.py
+++ b/camayoc/tests/qpc/api/v1/scanjobs/test_pause_cancel_restart.py
@@ -1,7 +1,8 @@
 # coding=utf-8
 """Tests for  quipucords scans and reports.
 
-These tests are parametrized on the inventory listed in the config file.
+These tests are parametrized on QCS_SOURCE_TYPES. If no source is availble of a
+type in the config file, the test will skip.
 
 :caseautomation: automated
 :casecomponent: api
@@ -34,7 +35,7 @@ def test_pause_cancel(shared_client, cleanup, source_type):
         5) Assert that the scan can be canceled
     :expectedresults: A scan can be paused and canceled
     """
-    scn = util.get_scan(source_type, cleanup)
+    scn = util.prepare_scan(source_type, cleanup)
     if not scn:
         pytest.skip(
             'No {0} type source was found in the config file.'
@@ -65,7 +66,7 @@ def test_restart(shared_client, cleanup, source_type):
         6) Assert that the scan completes
     :expectedresults: A restarted scan completes
     """
-    scn = util.get_scan(source_type, cleanup)
+    scn = util.prepare_scan(source_type, cleanup)
     if not scn:
         pytest.skip(
             'No {0} type source was found in the config file.'

--- a/camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py
+++ b/camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py
@@ -49,9 +49,8 @@ def get_scan_result(scan_name):
     result = SCAN_DATA.get(scan_name)
     if result is None:
         raise RuntimeError(
-            'Absolutely no results available for scan named {scan_name},\n'
-            'because no scan was even attempted.\n'.format(
-                scan_name=scan_info['name'])
+            'Absolutely no results available for scan named {0},\n'
+            'because no scan was even attempted.\n'.format(scan_name)
         )
     return result
 

--- a/camayoc/tests/qpc/api/v1/utils.py
+++ b/camayoc/tests/qpc/api/v1/utils.py
@@ -23,10 +23,15 @@ from camayoc.qpc_models import (
 def get_source(source_type, cleanup):
     """Retrieve a single network source if available from config file.
 
-    Retreive one network source from the config file.
-    Sources listed under the following section are assumed to be available
-    on demand and do not require their power state to be managed.
+    :param source_type: The type of source to be created. This function
+        retreives one source of matching type from the config file.
 
+    :param cleanup: The "cleanup" list that tests use to destroy objects after
+        a test has run. The "cleanup" list is provided by the py.test fixture
+        of the same name defined in camayoc/tests/qpc/conftest.py.
+
+    Sources are retreived from the following section and are assumed to be
+    available on demand and do not require their power state to be managed.
     The expected configuration in the Camayoc's configuration file is as
     follows::
 
@@ -47,8 +52,10 @@ def get_source(source_type, cleanup):
     results of the scan, for example tests that assert we can pause and restart
     a scan.
 
-    :returns: camayoc.qpc_models.Source that has been created on server and has
-        all credentials listed in config file created and associtated with it.
+    :returns: camayoc.qpc_models.Source of the same type that was requested
+        with the 'source_type' parameter. The returned source has been created
+        on server and has all credentials listed in config file created and
+        associtated with it.
     """
     cfg = config.get_config()
     cred_list = cfg.get('credentials', [])
@@ -88,16 +95,20 @@ def get_source(source_type, cleanup):
 
         server_src.create()
         cleanup.append(server_src)
-    return server_src
+        return server_src
 
 
-def get_scan(source_type, cleanup):
+def prepare_scan(source_type, cleanup):
     """Prepare a scan from the 'sources' section of config file.
 
     :param source_type: The scan will be configured to use one source, of the
-        type specified with this parameter.
+        type specified with this parameter. Uses ``get_network_source`` to
+        retreive a source of this type from the config file.
 
-    Uses ``get_network_source`` to retreive a network source from config file.
+    :param cleanup: The "cleanup" list that tests use to destroy objects after
+        a test has run. The "cleanup" list is provided by the py.test fixture
+        of the same name defined in camayoc/tests/qpc/conftest.py.
+
     This scan is not meant for testing the results of the scan, rather for
     functional tests that test the ability to effect the state of the scan,
     for example if you can restart a paused scan.

--- a/camayoc/tests/qpc/utils.py
+++ b/camayoc/tests/qpc/utils.py
@@ -3,11 +3,11 @@ import pytest
 
 from camayoc import api
 from camayoc.qpc_models import Credential, Source
-from camayoc.tests.qpc.api.v1.conftest import run_scans
-from camayoc.utils import uuid4
+from camayoc.utils import run_scans, uuid4
 
 mark_runs_scans = pytest.mark.skipif(run_scans() is False,
                                      reason='RUN_SCANS set to False')
+"""Tests with this decorator applied will skip when RUN_SCANS is False."""
 
 
 def assert_matches_server(qpcobject):

--- a/camayoc/tests/qpc/utils.py
+++ b/camayoc/tests/qpc/utils.py
@@ -7,7 +7,7 @@ from camayoc.utils import run_scans, uuid4
 
 mark_runs_scans = pytest.mark.skipif(run_scans() is False,
                                      reason='RUN_SCANS set to False')
-"""Tests with this decorator applied will skip when RUN_SCANS is False."""
+"""Decorator that skips tests if RUN_SCANS environment variable is 'False'."""
 
 
 def assert_matches_server(qpcobject):
@@ -77,10 +77,10 @@ def gen_valid_source(cleanup, src_type, host, create=True):
     cred.create()
     cleanup.append(cred)
     source = Source(
-            source_type=src_type,
-            hosts=[host],
-            credential_ids=[cred._id],
-                    )
+        source_type=src_type,
+        hosts=[host],
+        credential_ids=[cred._id],
+    )
     if create:
         source.create()
         cleanup.append(source)

--- a/camayoc/utils.py
+++ b/camayoc/utils.py
@@ -20,6 +20,15 @@ name_getter = operator.itemgetter('name')
 """Generate test IDs by fetching the ``name`` item."""
 
 
+def run_scans():
+    """Check for run scans environment variable."""
+    result = True
+    run_scans = os.environ.get('RUN_SCANS', 'true')
+    if run_scans.lower() == 'false':
+        result = False
+    return result
+
+
 def get_qpc_url():
     """Return the base url for the qpc server."""
     cfg = get_config().get('qpc', {})

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -29,6 +29,7 @@ reference for developers, not a gospel.
     api/camayoc.tests.qpc.api.v1.reports
     api/camayoc.tests.qpc.api.v1.reports.test_reports
     api/camayoc.tests.qpc.api.v1.scanjobs
+    api/camayoc.tests.qpc.api.v1.scanjobs.test_pause_cancel_restart
     api/camayoc.tests.qpc.api.v1.scanjobs.test_run_scanjobs
     api/camayoc.tests.qpc.api.v1.scans
     api/camayoc.tests.qpc.api.v1.scans.test_scans_common

--- a/docs/api/camayoc.tests.qpc.api.v1.scanjobs.rst
+++ b/docs/api/camayoc.tests.qpc.api.v1.scanjobs.rst
@@ -11,5 +11,6 @@ Submodules
 
 .. toctree::
 
+   camayoc.tests.qpc.api.v1.scanjobs.test_pause_cancel_restart
    camayoc.tests.qpc.api.v1.scanjobs.test_run_scanjobs
 

--- a/docs/api/camayoc.tests.qpc.api.v1.scanjobs.test_pause_cancel_restart.rst
+++ b/docs/api/camayoc.tests.qpc.api.v1.scanjobs.test_pause_cancel_restart.rst
@@ -1,0 +1,7 @@
+camayoc\.tests\.qpc\.api\.v1\.scanjobs\.test\_pause\_cancel\_restart module
+===========================================================================
+
+.. automodule:: camayoc.tests.qpc.api.v1.scanjobs.test_pause_cancel_restart
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,25 @@
 # coding=utf-8
 """Unit tests for :mod:`camayoc.utils`."""
+import os
 from unittest import mock
 
 import pytest
 
 from camayoc import exceptions, utils
+
+
+def test_run_scans():
+    """Test the RUN_SCANS variable is correctly detected.
+
+    This environment variable allows users to disable tests that run
+    scans temporarily.
+    """
+    os.environ['RUN_SCANS'] = 'FALSE'
+    assert utils.run_scans() is False
+    os.environ.pop('RUN_SCANS')
+    assert utils.run_scans() is True
+    os.environ['RUN_SCANS'] = 'True'
+    assert utils.run_scans() is True
 
 
 def test_get_qpc_url():


### PR DESCRIPTION
Also adds some utility functions for creating a scan of sources available from
camayoc.config.get_config()['qpc']['sources'].

Adds decorator that can be used to skip a test if the user has set RUN_SCANS
variable to false so tests that runs scans will not be run.

Small bugfix in assertion error that came up during testing (wrong variable name).

Closes #175