### PR TITLE
Changes to allow for all scans to complete

### DIFF
--- a/camayoc/constants.py
+++ b/camayoc/constants.py
@@ -418,9 +418,3 @@ QPC_EAP_EXTENDED_FACTS = ('jboss_eap_find_jboss_modules_jar',
                           'jboss_eap_jar_ver',
                           'jboss_eap_run_jar_ver')
 """List of facts collected by JBoss EAP Extended tasks."""
-
-VCENTER_SCAN_TIMEOUT = 540
-"""Maximum amount of time to let vcenter scan run before timing out."""
-
-SATELLITE_SCAN_TIMEOUT = 360
-"""Maximum amount of time to let satellite scan run before timing out."""

--- a/camayoc/exceptions.py
+++ b/camayoc/exceptions.py
@@ -48,3 +48,12 @@ class FailedScanException(Exception):
     While waiting for the scan to acheive some other state, the scan failed.
     The test expected the scan to succeed, so this exception has been raised.
     """
+
+
+class StoppedScanException(Exception):
+    """A test has raised this exception because a scan unexpectly stopped.
+
+    While waiting for the scan to achieve some other state, the scan reached
+    a terminal state from which it could not progress, so this exception has
+    been raised instead of continuing to wait.
+    """

--- a/camayoc/tests/qpc/api/v1/conftest.py
+++ b/camayoc/tests/qpc/api/v1/conftest.py
@@ -95,14 +95,13 @@ def run_scan(scan, disabled_optional_products, enabled_extended_product_search,
             source_ids=src_ids, scan_type=scan_type,
             disabled_optional_products=disabled_optional_products,
             enabled_extended_product_search=enabled_extended_product_search)
-        TIMEOUT = 500 * len(src_ids)
         scan.create()
         cleanup.append(scan)
         scanjob = ScanJob(scan_id=scan._id)
         scanjob.create()
         SCAN_DATA[scan_name]['scan_id'] = scan._id
         SCAN_DATA[scan_name]['scan_job_id'] = scanjob._id
-        wait_until_state(scanjob, timeout=TIMEOUT, state='stopped')
+        wait_until_state(scanjob, state='stopped')
         SCAN_DATA[scan_name]['final_status'] = scanjob.status()
         SCAN_DATA[scan_name]['scan_results'] = scanjob.read().json()
         SCAN_DATA[scan_name]['report_id'] = scanjob.read(

--- a/camayoc/tests/qpc/api/v1/utils.py
+++ b/camayoc/tests/qpc/api/v1/utils.py
@@ -161,12 +161,9 @@ def wait_until_state(scanjob, timeout=3600, state='completed'):
 
     while (not scanjob.status() or not scanjob.status()
             == state) and timeout > 0:
-        if state in stopped_states and scanjob.status() in stopped_states:
+        current_status = scanjob.status()
+        if state in stopped_states and current_status in stopped_states:
             # scanjob is no longer running, so we will return
-            return
-        time.sleep(5)
-        timeout -= 5
-        if scanjob.status() == state:
             return
         if timeout <= 0:
             raise WaitTimeError(
@@ -182,13 +179,13 @@ def wait_until_state(scanjob, timeout=3600, state='completed'):
                     scanjob_id=scanjob._id,
                     scan_id=scanjob.scan_id,
                     expected_state=state,
-                    scanjob_state=scanjob.status(),
+                    scanjob_state=current_status,
                     scanjob_details=pprint.pformat(
                         scanjob.read().json()),
                     scanjob_results=pprint.pformat(
                         scanjob.read().json().get('tasks'))))
-        if state not in stopped_states and scanjob.status(
-        ) in QPC_SCAN_TERMINAL_STATES:
+        if state not in stopped_states and \
+                current_status in QPC_SCAN_TERMINAL_STATES:
             raise StoppedScanException(
                 'You have called wait_until_state() on a scanjob with\n'
                 'ID={scanjob_id} has stopped running instead of reaching \n'
@@ -201,8 +198,10 @@ def wait_until_state(scanjob, timeout=3600, state='completed'):
                     scanjob_id=scanjob._id,
                     scan_id=scanjob.scan_id,
                     expected_state=state,
-                    scanjob_state=scanjob.status(),
+                    scanjob_state=current_status,
                     scanjob_details=pprint.pformat(
                         scanjob.read().json()),
                     scanjob_results=pprint.pformat(
                         scanjob.read().json().get('tasks'))))
+        time.sleep(5)
+        timeout -= 5

--- a/camayoc/tests/qpc/conftest.py
+++ b/camayoc/tests/qpc/conftest.py
@@ -29,6 +29,9 @@ def sort_and_delete(trash):
 
     for collection in [scans, sources, creds]:
         for obj in collection:
+            # It may have been a while since this object was created, so we
+            # will log its client back in to the server and get a fresh token
+            obj.client.login()
             obj.delete()
 
 
@@ -52,9 +55,9 @@ def session_cleanup():
     sort_and_delete(trash)
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture()
 def shared_client():
-    """Yeild a single instance of api.Client() to many tests as fixture.
+    """Yeild a single instance of api.Client() to a test.
 
     yeilds an api.Client() instance with the standard return code handler.
 

--- a/camayoc/tests/utils.py
+++ b/camayoc/tests/utils.py
@@ -16,7 +16,7 @@ def is_live(client, server, num_pings=10):
     return ping.returncode == 0
 
 
-def wait_until_live(servers, timeout=60):
+def wait_until_live(servers, timeout=360):
     """Wait for servers to be live.
 
     For each server in the "servers" list, verify if it is reachable.


### PR DESCRIPTION
Several changes to allow all the scans that happen at the beginning of the test
session to complete before the test suite proceeds. This includes allowing
longer boot times (but we proceed if the machine is responsive), and longer
wait times for a scan to complete since it may be queued behind several other
scans.

Additionally, we provide a fresh client to each test so that it has a current
authentication token.

Closes #223