### PR TITLE
Correct strings comparison bug and system count stats bug.

### DIFF
--- a/camayoc/tests/qpc/api/v1/reports/test_reports.py
+++ b/camayoc/tests/qpc/api/v1/reports/test_reports.py
@@ -308,10 +308,21 @@ def test_OS_found_deployment_report(scan_info):
             src_id = list(source_to_product_map.keys())[0]
             hostname = result['source_id_to_hostname'][src_id]
             ex_products = source_to_product_map[src_id]
-            expected_distro = ex_products['distribution'].get('name', '')
-            expected_version = ex_products['distribution'].get('version', '')
-            found_distro = entity.get('os_name', '')
-            found_version = entity.get('os_version', '')
+            expected_distro = ex_products['distribution'].get(
+                'name', '').lower()
+            expected_version = ex_products['distribution'].get(
+                'version', '').lower()
+            # The key may exist but the value be None
+            if entity.get('os_name') is None:
+                found_distro = ''
+            else:
+                found_distro = entity.get('os_name').lower()
+
+            if entity.get('os_version') is None:
+                found_version = ''
+            else:
+                found_version = entity.get('os_version').lower()
+
             if src_id in [s['id'] for s in entity['sources']]:
                 # We assert that the expected distro's name is at least
                 # contained in the found name.

--- a/camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py
+++ b/camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py
@@ -79,10 +79,11 @@ def test_scan_task_results(scan_info):
     for task in task_results:
         # assert arithmetic around number of systems scanned adds up
         # this has been broken in the past
-        sys_count = task['systems_count']
-        num_failed = task['systems_failed']
-        num_scanned = task['systems_scanned']
-        assert num_scanned == sys_count - num_failed
+        sys_count = task.get('systems_count', 0)
+        num_failed = task.get('systems_failed', 0)
+        num_scanned = task.get('systems_scanned', 0)
+        num_unreachable = task.get('systems_unreachable', 0)
+        assert num_scanned == (sys_count - num_failed - num_unreachable)
 
 
 @mark_runs_scans


### PR DESCRIPTION
String comparison needs to be case insenstive.
Also development version of quipucords now breaks out unreachable systems from
failed systems so the arithmetic needed to be updated.

Closes #236
Closes #237