### PR TITLE
Don't wait as long for scans to start, pause, or cancel.

### DIFF
--- a/camayoc/tests/qpc/api/v1/scanjobs/test_pause_cancel_restart.py
+++ b/camayoc/tests/qpc/api/v1/scanjobs/test_pause_cancel_restart.py
@@ -43,11 +43,11 @@ def test_pause_cancel(shared_client, cleanup, source_type):
         )
     job = ScanJob(scan_id=scn._id)
     job.create()
-    util.wait_until_state(job, state='running')
+    util.wait_until_state(job, state='running', TIMEOUT=60)
     job.pause()
-    util.wait_until_state(job, state='paused')
+    util.wait_until_state(job, state='running', TIMEOUT=60)
     job.cancel()
-    util.wait_until_state(job, state='canceled')
+    util.wait_until_state(job, state='canceled', TIMEOUT=60)
 
 
 @mark_runs_scans
@@ -74,8 +74,8 @@ def test_restart(shared_client, cleanup, source_type):
         )
     job = ScanJob(scan_id=scn._id)
     job.create()
-    util.wait_until_state(job, state='running')
+    util.wait_until_state(job, state='running', TIMEOUT=60)
     job.pause()
-    util.wait_until_state(job, state='paused')
+    util.wait_until_state(job, state='running', TIMEOUT=60)
     job.restart()
     util.wait_until_state(job, state='completed')

--- a/camayoc/tests/qpc/cli/test_scanjobs.py
+++ b/camayoc/tests/qpc/cli/test_scanjobs.py
@@ -384,9 +384,9 @@ def test_scanjob_restart(isolated_filesystem, qpc_server_config):
     match = re.match(r'Scan "(\d+)" started.', result)
     assert match is not None
     scan_job_id = match.group(1)
-    wait_for_scan(scan_job_id, status='running')
+    wait_for_scan(scan_job_id, status='running', timeout=60)
     scan_pause({'id': scan_job_id})
-    wait_for_scan(scan_job_id, status='paused')
+    wait_for_scan(scan_job_id, status='paused', timeout=60)
     scan_restart({'id': scan_job_id})
     wait_for_scan(scan_job_id)
     result = scan_job({
@@ -430,9 +430,9 @@ def test_scanjob_cancel(isolated_filesystem, qpc_server_config):
     match = re.match(r'Scan "(\d+)" started.', result)
     assert match is not None
     scan_job_id = match.group(1)
-    wait_for_scan(scan_job_id, status='running')
+    wait_for_scan(scan_job_id, status='running', timeout=60)
     scan_cancel({'id': scan_job_id})
-    wait_for_scan(scan_job_id, status='canceled')
+    wait_for_scan(scan_job_id, status='canceled', timeout=60)
     result = scan_restart({'id': scan_job_id}, exitstatus=1)
     assert result.startswith(
         'Error: Scan cannot be restarted. The scan must be paused for it to '
@@ -465,11 +465,11 @@ def test_scanjob_cancel_paused(isolated_filesystem, qpc_server_config):
     match = re.match(r'Scan "(\d+)" started.', result)
     assert match is not None
     scan_job_id = match.group(1)
-    wait_for_scan(scan_job_id, status='running')
+    wait_for_scan(scan_job_id, status='running', timeout=60)
     scan_pause({'id': scan_job_id})
-    wait_for_scan(scan_job_id, status='paused')
+    wait_for_scan(scan_job_id, status='paused', timeout=60)
     scan_cancel({'id': scan_job_id})
-    wait_for_scan(scan_job_id, status='canceled')
+    wait_for_scan(scan_job_id, status='canceled', timeout=60)
     result = scan_restart({'id': scan_job_id}, exitstatus=1)
     assert result.startswith(
         'Error: Scan cannot be restarted. The scan must be paused for it to '


### PR DESCRIPTION
If all is well with the server, it should not take long for scans to start,
pause, or cancel because we are obtensibly waiting for all scans to complete
before starting a new test. If we do reach the timeout for these activities, it
is an indication that something is wrong.

Closes #242