### PR TITLE
Make cleanup functions safer

### DIFF
--- a/camayoc/tests/qpc/cli/conftest.py
+++ b/camayoc/tests/qpc/cli/conftest.py
@@ -1,4 +1,5 @@
 """Test utilities for quipucords' ``qpc`` tests."""
+import re
 from io import BytesIO
 
 import pexpect
@@ -76,7 +77,14 @@ def cleanup_server():
     We must delete all objects on the server in the correct order, first scans,
     then sources, then credentials.
     """
+    error_finder = re.compile('internal server error')
+    errors = []
+    output = []
     for command in ('scan', 'source', 'cred'):
-        clear = pexpect.spawn('qpc {} clear --all'.format(command))
-        assert clear.expect(pexpect.EOF) == 0
-        clear.close()
+        clear_output = pexpect.run(
+                                    'qpc {} clear --all'.format(command),
+                                    encoding='utf8',
+                                    )
+        errors.extend(error_finder.findall(clear_output))
+        output.append(clear_output)
+    assert errors == [], output

--- a/camayoc/tests/qpc/conftest.py
+++ b/camayoc/tests/qpc/conftest.py
@@ -32,7 +32,11 @@ def sort_and_delete(trash):
             # It may have been a while since this object was created, so we
             # will log its client back in to the server and get a fresh token
             obj.client.login()
-            obj.delete()
+            # Only assert that we do not hit an internal server error, in case
+            # for some reason the object was allready cleaned up by the test
+            obj.client.response_handler = api.echo_handler
+            response = obj.delete()
+            assert response.status_code < 500
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
Some spurious failures have occurred because of attempts to clean up resources
that have allready been cleaned up. These changes make it so the cleanup
fixtures only raise errors if an internal server error occurs.

Closes # 248