### PR TITLE
Refactor csv report parsing (fixes #303)

### DIFF
--- a/camayoc/tests/qpc/cli/csv_report_parsing.py
+++ b/camayoc/tests/qpc/cli/csv_report_parsing.py
@@ -1,0 +1,101 @@
+# coding=utf-8
+"""Help functions for csv report tests"""
+
+import csv
+
+
+def normalize_csv_report(f, header_range, header_lines, report_type='summary'):
+    """ Extracts and normalizes csv report to match the returned JSON report.
+
+    :param f: A file object for the csv
+    :param header_range: An int specifing the range that the head extends into
+        the csv file.
+    :param header_lines: A list of tuples containg the index pairs for the
+        lines to be used as the key/value pairs of each header info dictionary
+        (ex: [(0,1), (3,4)] ).
+    :param report_type: A string that defines what type of report object to
+        return, 'summary' or 'detail'. Defaults to 'summary'.
+    """
+    # First grab the header information from the file object.
+    report_headers = [f.readline() for _ in range(header_range)]
+    # Next, extract header information into a list of dictonaries (1 dictionary
+    # per header set)
+    header_info = extract_key_value_lines(report_headers,
+                                          header_lines)
+    # Now that we extracted the report information we can use CSV reader to
+    # read the system fingerprints information
+    reader = csv.DictReader(f)
+    if report_type == 'summary':
+        report = normalize_summary_report(header_info, reader)
+    else:
+        report = normalize_detail_report(header_info, reader)
+    return report
+
+
+def normalize_summary_report(header_info, reader):
+    """Takes information from report_info dict, and reader and returns a
+    summary report"""
+    report_info = header_info[0]
+    report = {
+        'report_id': report_info['report_id'],
+        'report_type': report_info['report_type'],
+        'report_version': report_info['report_version'],
+        'report_platform_id': report_info['report_platform_id'],
+        'system_fingerprints': [row for row in reader],
+    }
+    return report
+
+
+def normalize_detail_report(header_info, reader):
+    """Takes information from report_info dict, and reader and returns a
+    detail format report"""
+    # The first dictionary grabbed contains the report info
+    report_info = header_info[0]
+    # The second contains the source header info
+    source_info = header_info[1]
+    report = {
+        'id': report_info['report_id'],
+        'report_type': report_info['report_type'],
+        'sources': [{
+            'facts': [row for row in reader],
+            'server_id': source_info['server_identifier'],
+            'source_name': source_info['source_name'],
+            'source_type': source_info['source_type'],
+        }],
+    }
+    return report
+
+
+def extract_key_value_lines(input_lines, line_pairs, delim=','):
+    """Extracts several line pairs into dictionaries, and returns a list of
+    all of them
+
+    :param input_lines: a list of csv line strings.
+    :param line_pairs: A list of tuples containg the index pairs for the lines
+        to be used as the key/value pairs of each dictionary
+        (ex: [(0,1), (3,4)] ).
+    :param delim: the delimiter to split the lines with (defaults to ',').
+    """
+    return [zip_line_pairs(input_lines, key_ind, value_ind, delim=delim)
+            for (key_ind, value_ind) in line_pairs]
+
+
+def zip_line_pairs(input_lines, key_ind, value_ind, delim=','):
+    """Takes a list of csv strings, and zips 2 of them into a dictionary.
+
+    :param input_lines: a list of csv lines
+    :param key_ind: the index value for which line in ``input_lines`` should be
+        used for the keys of the dictionary.
+    :param value_ind: the index value for which line in ``input_lines`` should
+        be used for the values of the dictionary.
+    :param delim: the delimiter to split the lines with (defaults to ',').
+    """
+    header_keys = input_lines[key_ind].strip().split(delim)
+    header_values = input_lines[value_ind].strip().split(delim)
+
+    # Dynamically Pull the header items into a dictionary.
+    paired_info = dict(map(lambda key, value:
+                           [key.lower().replace(' ', '_'), value],
+                           header_keys,
+                           header_values))
+    return paired_info

--- a/camayoc/tests/qpc/cli/csv_report_parsing.py
+++ b/camayoc/tests/qpc/cli/csv_report_parsing.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Help functions for csv report tests"""
+"""Helper functions for parsing csv reports"""
 
 import csv
 

--- a/camayoc/tests/qpc/cli/csv_report_parsing.py
+++ b/camayoc/tests/qpc/cli/csv_report_parsing.py
@@ -3,20 +3,16 @@
 
 import csv
 
-EXPECTED_SUMMARY_REPORT_ID_FIELDS = [
+EXPECTED_SUMMARY_REPORT_ID_FIELDS = (
     'Report ID',
     'Report Type',
     'Report Version',
     'Report Platform ID',
-]
+)
 
-EXPECTED_DETAIL_REPORT_ID_FIELDS = [
-    'Report ID',
-    'Report Type',
-    'Report Version',
-    'Report Platform ID',
-    'Number Sources'
-]
+EXPECTED_DETAIL_REPORT_ID_FIELDS = EXPECTED_SUMMARY_REPORT_ID_FIELDS + (
+    'Number Sources',
+)
 
 
 def normalize_csv_report(f, header_range, header_lines, report_type='summary'):
@@ -41,17 +37,21 @@ def normalize_csv_report(f, header_range, header_lines, report_type='summary'):
     # read the system fingerprints information
     reader = csv.DictReader(f)
     if report_type == 'summary':
-        report = normalize_summary_report(header_info, reader)
+        return normalize_summary_report(header_info, reader)
     else:
-        report = normalize_detail_report(header_info, reader)
-    return report
+        return normalize_detail_report(header_info, reader)
 
 
 def normalize_summary_report(header_info, reader):
     """Normalize report info into a summary report.
 
     Takes information from report_info dict, and reader and returns a
-    summary report
+    summary report.
+
+    :param header_info: A list of dictonaries, which each dictonary containing
+        the information of a header.
+    :param reader: A DictReader containing the parsed content (remainder after
+        header section) of a report.
     """
     report_info = header_info[0]
 
@@ -76,6 +76,11 @@ def normalize_detail_report(header_info, reader):
 
     Takes information from report_info dict, and reader and returns a
     detail format report
+
+    :param header_info: A list of dictonaries, which each dictonary containing
+        the information of a header.
+    :param reader: A DictReader containing the parsed content (remainder after
+        header section) of a report.
     """
     # The first dictionary grabbed contains the report info
     report_info = header_info[0]
@@ -127,9 +132,6 @@ def zip_line_pairs(input_lines, key_ind, value_ind, delim=','):
     header_keys = input_lines[key_ind].strip().split(delim)
     header_values = input_lines[value_ind].strip().split(delim)
 
-    # Dynamically Pull the header items into a dictionary.
-    paired_info = dict(map(lambda key, value:
-                           [key.lower().replace(' ', '_'), value],
-                           header_keys,
-                           header_values))
-    return paired_info
+    # Dynamically zip the header items into a dictionary.
+    return {key.lower().replace(' ', '_'): value for key, value in
+            zip(header_keys, header_values)}

--- a/camayoc/tests/qpc/cli/csv_report_parsing.py
+++ b/camayoc/tests/qpc/cli/csv_report_parsing.py
@@ -3,6 +3,21 @@
 
 import csv
 
+EXPECTED_SUMMARY_REPORT_ID_FIELDS = [
+    'Report ID',
+    'Report Type',
+    'Report Version',
+    'Report Platform ID',
+]
+
+EXPECTED_DETAIL_REPORT_ID_FIELDS = [
+    'Report ID',
+    'Report Type',
+    'Report Version',
+    'Report Platform ID',
+    'Number Sources'
+]
+
 
 def normalize_csv_report(f, header_range, header_lines, report_type='summary'):
     """ Extracts and normalizes csv report to match the returned JSON report.
@@ -36,6 +51,13 @@ def normalize_summary_report(header_info, reader):
     """Takes information from report_info dict, and reader and returns a
     summary report"""
     report_info = header_info[0]
+
+    # Ensure extracted fields match expected
+    expected_keys = [x.lower().replace(" ", "_") for x in
+                     EXPECTED_SUMMARY_REPORT_ID_FIELDS]
+    assert sorted(report_info.keys()) == sorted(expected_keys),\
+        "Extracted Report Fields didn't match expected list"
+
     report = {
         'report_id': report_info['report_id'],
         'report_type': report_info['report_type'],
@@ -53,6 +75,13 @@ def normalize_detail_report(header_info, reader):
     report_info = header_info[0]
     # The second contains the source header info
     source_info = header_info[1]
+
+    # Ensure extracted fields match expected
+    expected_keys = [x.lower().replace(" ", "_") for x in
+                     EXPECTED_DETAIL_REPORT_ID_FIELDS]
+    assert sorted(report_info.keys()) == sorted(expected_keys),\
+        "Extracted Report Fields didn't match expected list"
+
     report = {
         'id': report_info['report_id'],
         'report_type': report_info['report_type'],

--- a/camayoc/tests/qpc/cli/csv_report_parsing.py
+++ b/camayoc/tests/qpc/cli/csv_report_parsing.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Helper functions for parsing csv reports"""
+"""Helper functions for parsing csv reports."""
 
 import csv
 
@@ -20,7 +20,7 @@ EXPECTED_DETAIL_REPORT_ID_FIELDS = [
 
 
 def normalize_csv_report(f, header_range, header_lines, report_type='summary'):
-    """ Extracts and normalizes csv report to match the returned JSON report.
+    """Extract and normalize csv report to match the returned JSON report.
 
     :param f: A file object for the csv
     :param header_range: An int specifing the range that the head extends into
@@ -48,12 +48,15 @@ def normalize_csv_report(f, header_range, header_lines, report_type='summary'):
 
 
 def normalize_summary_report(header_info, reader):
-    """Takes information from report_info dict, and reader and returns a
-    summary report"""
+    """Normalize report info into a summary report.
+
+    Takes information from report_info dict, and reader and returns a
+    summary report
+    """
     report_info = header_info[0]
 
     # Ensure extracted fields match expected
-    expected_keys = [x.lower().replace(" ", "_") for x in
+    expected_keys = [x.lower().replace(' ', '_') for x in
                      EXPECTED_SUMMARY_REPORT_ID_FIELDS]
     assert sorted(report_info.keys()) == sorted(expected_keys),\
         "Extracted Report Fields didn't match expected list"
@@ -69,15 +72,18 @@ def normalize_summary_report(header_info, reader):
 
 
 def normalize_detail_report(header_info, reader):
-    """Takes information from report_info dict, and reader and returns a
-    detail format report"""
+    """Normalize report info into a detail report.
+
+    Takes information from report_info dict, and reader and returns a
+    detail format report
+    """
     # The first dictionary grabbed contains the report info
     report_info = header_info[0]
     # The second contains the source header info
     source_info = header_info[1]
 
     # Ensure extracted fields match expected
-    expected_keys = [x.lower().replace(" ", "_") for x in
+    expected_keys = [x.lower().replace(' ', '_') for x in
                      EXPECTED_DETAIL_REPORT_ID_FIELDS]
     assert sorted(report_info.keys()) == sorted(expected_keys),\
         "Extracted Report Fields didn't match expected list"
@@ -96,8 +102,7 @@ def normalize_detail_report(header_info, reader):
 
 
 def extract_key_value_lines(input_lines, line_pairs, delim=','):
-    """Extracts several line pairs into dictionaries, and returns a list of
-    all of them
+    """Extract multiple line pairs into list of dictionaries.
 
     :param input_lines: a list of csv line strings.
     :param line_pairs: A list of tuples containg the index pairs for the lines
@@ -110,7 +115,7 @@ def extract_key_value_lines(input_lines, line_pairs, delim=','):
 
 
 def zip_line_pairs(input_lines, key_ind, value_ind, delim=','):
-    """Takes a list of csv strings, and zips 2 of them into a dictionary.
+    """Take a list of csv strings, and combine 2 of them into a dictionary.
 
     :param input_lines: a list of csv lines
     :param key_ind: the index value for which line in ``input_lines`` should be

--- a/camayoc/tests/qpc/cli/test_reports.py
+++ b/camayoc/tests/qpc/cli/test_reports.py
@@ -20,6 +20,10 @@ import pytest
 
 from camayoc.utils import uuid4
 
+from camayoc.tests.qpc.cli.csv_report_parsing import (
+    normalize_csv_report
+)
+
 from .utils import (
     config_sources,
     report_detail,
@@ -32,10 +36,6 @@ from .utils import (
     scan_start,
     wait_for_report_merge,
     wait_for_scan,
-)
-
-from camayoc.tests.qpc.cli.csv_report_parsing import (
-    normalize_csv_report
 )
 
 # from csv_report_parsing import normalize_csv_report

--- a/camayoc/tests/qpc/cli/test_reports.py
+++ b/camayoc/tests/qpc/cli/test_reports.py
@@ -9,7 +9,6 @@
 :testtype: functional
 :upstream: yes
 """
-import csv
 import json
 import os
 import pprint
@@ -301,8 +300,8 @@ def test_summary_report(
             report = json.load(f)
             expected_fields = JSON_SUMMARY_REPORT_FIELDS
         else:
-            report = normalize_csv_report(f, header_range=5,
-                                          fingerprint_line=4)
+            report = normalize_csv_report(f, 5, [(0, 1)],
+                                          report_type='summary')
             expected_fields = CSV_SUMMARY_REPORT_FIELDS
 
     assert report['report_type'] == 'deployments'
@@ -346,28 +345,8 @@ def test_detail_report(
             # For CSV we need to massage the data a little bit. First ensure
             # there is a header with the report id, number of sources and
             # sources' information.
-            import pdb
-            pdb.set_trace()
-            headers = [f.readline() for _ in range(8)]
-            report_id, report_type, report_version, number_sources = (
-                headers[1].strip().split(',')
-            )
-            server_id, source_name, source_type = headers[6].strip().split(',')
-            # Now that we extracted the header we can call the CSV reader to
-            # read the report information
-            reader = csv.DictReader(f)
-            # Finally normalize the information to match what is returned by
-            # the JSON format so we can do assertion later.
-            report = {
-                'id': report_id,
-                'report_type': report_type,
-                'sources': [{
-                    'facts': [row for row in reader],
-                    'server_id': server_id,
-                    'source_name': source_name,
-                    'source_type': source_type,
-                }],
-            }
+            report = normalize_csv_report(f, 8, [(0, 1), (5, 6)],
+                                          report_type='detail')
 
     assert report['report_type'] == 'details'
     assert len(report['sources']) == len(scan['sources'])

--- a/camayoc/tests/qpc/cli/test_reports.py
+++ b/camayoc/tests/qpc/cli/test_reports.py
@@ -18,11 +18,8 @@ import tarfile
 
 import pytest
 
+from camayoc.tests.qpc.cli.csv_report_parsing import normalize_csv_report
 from camayoc.utils import uuid4
-
-from camayoc.tests.qpc.cli.csv_report_parsing import (
-    normalize_csv_report
-)
 
 from .utils import (
     config_sources,

--- a/camayoc/tests/qpc/cli/test_reports.py
+++ b/camayoc/tests/qpc/cli/test_reports.py
@@ -23,6 +23,7 @@ from camayoc.utils import uuid4
 
 from .utils import (
     config_sources,
+    normalize_csv_report,
     report_detail,
     report_download,
     report_merge,
@@ -300,25 +301,8 @@ def test_summary_report(
             report = json.load(f)
             expected_fields = JSON_SUMMARY_REPORT_FIELDS
         else:
-            # For CSV we need to massage the data a little bit. First extract
-            # the Report ID, Report Type, Report Version information.
-            headers = [f.readline() for _ in range(5)]
-            report_id, report_type, report_version = (
-                headers[1].strip().split(',')
-            )
-            # Ensure that the report has the System Fingerprints section
-            assert headers[4].strip() == 'System Fingerprints:'
-            # Now that we extracted the  report information we can use CSV
-            # reader to read the system fingerprints information
-            reader = csv.DictReader(f)
-            # Finally normalize the information to match what is returned by
-            # the JSON format so we can do assertions later.
-            report = {
-                'report_id': report_id,
-                'report_type': report_type,
-                'report_version': report_version,
-                'system_fingerprints': [row for row in reader],
-            }
+            report = normalize_csv_report(f, header_range=5,
+                                          fingerprint_line=4)
             expected_fields = CSV_SUMMARY_REPORT_FIELDS
 
     assert report['report_type'] == 'deployments'
@@ -362,6 +346,8 @@ def test_detail_report(
             # For CSV we need to massage the data a little bit. First ensure
             # there is a header with the report id, number of sources and
             # sources' information.
+            import pdb
+            pdb.set_trace()
             headers = [f.readline() for _ in range(8)]
             report_id, report_type, report_version, number_sources = (
                 headers[1].strip().split(',')

--- a/camayoc/tests/qpc/cli/test_reports.py
+++ b/camayoc/tests/qpc/cli/test_reports.py
@@ -22,7 +22,6 @@ from camayoc.utils import uuid4
 
 from .utils import (
     config_sources,
-    normalize_csv_report,
     report_detail,
     report_download,
     report_merge,
@@ -35,6 +34,11 @@ from .utils import (
     wait_for_scan,
 )
 
+from camayoc.tests.qpc.cli.csv_report_parsing import (
+    normalize_csv_report
+)
+
+# from csv_report_parsing import normalize_csv_report
 
 REPORT_OUTPUT_FORMATS = ('csv', 'json')
 """Valid report output formats."""

--- a/camayoc/tests/qpc/cli/utils.py
+++ b/camayoc/tests/qpc/cli/utils.py
@@ -501,31 +501,11 @@ def setup_qpc():
     assert exitstatus == 0, output
 
 
-def normalize_csv_report(f, header_range=5, fingerprint_line=4):
-    """Helper Function.
-
-    Extracts and normalizes csv report to match what is returned by the\
-    JSON format.
-
-    """
-    # For CSV we need to massage the data a little bit. First extract the
-    # Report information to use later.
-    report_headers = [f.readline() for _ in range(header_range)]
-    header_keys = report_headers[0].strip().split(',')
-    header_values = report_headers[1].strip().split(',')
-    # Dynamically Pull the header items into a dictionary.
-    report_info = dict(map(lambda key, value: [key.lower().replace(' ', '_'),
-                                               value], header_keys,
-                           header_values))
-
-    # Ensure that the report has the System Fingerprints section
-    assert report_headers[fingerprint_line].strip() == 'System Fingerprints:',\
-        "Report did contain 'System Fingerprints Section at the\
-         expected location.'"
-
-    # Now that we extracted the report information we can use CSV reader to
-    # read the system fingerprints information
-    reader = csv.DictReader(f)
+# I don't love the names of these functions...
+def normalize_summary_report(header_info, reader):
+    """Takes information from report_info dict, and reader and returns a
+    summary report"""
+    report_info = header_info[0]
     report = {
         'report_id': report_info['report_id'],
         'report_type': report_info['report_type'],
@@ -533,4 +513,71 @@ def normalize_csv_report(f, header_range=5, fingerprint_line=4):
         'report_platform_id': report_info['report_platform_id'],
         'system_fingerprints': [row for row in reader],
     }
+    return report
+
+
+def normalize_detail_report(header_info, reader):
+    """Takes information from report_info dict, and reader and returns a
+    detail format report"""
+    # import pdb; pdb.set_trace()
+    report_info = header_info[0]
+    source_info = header_info[1]
+    report = {
+        'id': report_info['report_id'],
+        'report_type': report_info['report_type'],
+        'sources': [{
+            'facts': [row for row in reader],
+            'server_id': source_info['server_identifier'],
+            'source_name': source_info['source_name'],
+            'source_type': source_info['source_type'],
+        }],
+    }
+    return report
+
+
+def extract_key_value_lines(input_lines, line_pairs):
+    """Extracts several line pairs into dictionaryies, and returns a list of
+    all of them"""
+    return [zip_line_pairs(input_lines, key_ind, value_ind)
+            for (key_ind, value_ind) in line_pairs]
+
+
+def zip_line_pairs(input_lines, key_ind, value_ind):
+    """get key_values from two lines and return dict"""
+    header_keys = input_lines[key_ind].strip().split(',')
+    header_values = input_lines[value_ind].strip().split(',')
+
+    # Dynamically Pull the header items into a dictionary.
+    paired_info = dict(map(lambda key, value:
+                           [key.lower().replace(' ', '_'), value],
+                           header_keys,
+                           header_values))
+    return paired_info
+
+
+def normalize_csv_report(f, header_range, header_lines, report_type='summary'):
+    """Helper Function.
+
+    Extracts and normalizes csv report to match what is returned by the\
+    JSON format.
+    """
+    # For CSV we need to massage the data a little bit. First extract the
+    # Report information to use later.
+    report_headers = [f.readline() for _ in range(header_range)]
+
+    header_info = extract_key_value_lines(report_headers,
+                                          header_lines)
+
+    # Ensure that the report has the System Fingerprints section
+    # assert report_headers[fingerprint_line].strip() == 'System Fingerprints:'\
+    #     "Report did contain 'System Fingerprints Section at the\
+    #      expected location.'"
+
+    # Now that we extracted the report information we can use CSV reader to
+    # read the system fingerprints information
+    reader = csv.DictReader(f)
+    if report_type == 'summary':
+        report = normalize_summary_report(header_info, reader)
+    else:
+        report = normalize_detail_report(header_info, reader)
     return report

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     install_requires=[
         'pexpect',
         'plumbum',
-        'pytest',
+        'pytest>=3.6',
         'pyvmomi',
         'pyxdg',
         'pyyaml',


### PR DESCRIPTION
The header information of reports used to be hard-coded in, parsing the csv lines and binding them to specific variables. This caused the tests to break when a new field was added because there were more items parsed than variables to bind them to.

I've edited the csv parsing so that it is dynamically parsed into a dictionary that can then be used to create the report objects. I have added asserts so that if new fields are added, the tests will still fail to notify that it is out of date, but will just require at minimum adding the field to the expected list.

The process of normalizing the csv reports to what the json parsing returns has also been extracted to it's own set of the function, to clean up the actual tests a bit.

The one issue with this fix is that it still is hard coded to only process one source for the detail reports, but the tests only handled one source previously, and was hard coded to do so. This should at least be a step in the right direction for if we every expand that.

Fixes #303 