### PR TITLE
Added 'vm_host_core_count' to expected summary fields

### DIFF
--- a/camayoc/tests/qpc/cli/test_reports.py
+++ b/camayoc/tests/qpc/cli/test_reports.py
@@ -75,6 +75,7 @@ SUMMARY_REPORT_FIELDS = (
     'vm_datacenter',
     'vm_dns_name',
     'vm_host',
+    'vm_host_core_count',
     'vm_host_socket_count',
     'vm_state',
     'vm_uuid',


### PR DESCRIPTION
The 'vm_host_core_count' field has to be added to the expected summary report fields list.