### PR TITLE
dropped pydocstyle to 3.0.0 until upstream bug is fixed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,8 @@ setup(
             "wheel",
             # For `make package-upload`
             "twine",
+            # pydocstyle specific version till bug fixed
+            "pydocstyle==3.0.0",
             # For `make test-coverage`
             "pytest-cov",
             # For `make validate-docstrings`

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
             # For `make package-upload`
             "twine",
             # pydocstyle specific version till bug fixed
+            # See here: https://gitlab.com/pycqa/flake8-docstrings/issues/36
             "pydocstyle==3.0.0",
             # For `make test-coverage`
             "pytest-cov",


### PR DESCRIPTION
Requiring `pydocstyle==3.0.0` until upstream bug is fixed.

Related:
https://gitlab.com/pycqa/flake8-docstrings/issues/36