### PR TITLE
Switched to using multi search function added to oc.utils

### DIFF
--- a/camayoc/tests/qpc/yupana/test_connect.py
+++ b/camayoc/tests/qpc/yupana/test_connect.py
@@ -13,7 +13,8 @@
 import pytest
 import requests
 
-from camayoc.tests.qpc.yupana.utils import get_app_url, search_mult_pod_logs
+from camayoc.tests.qpc.yupana.utils import get_app_url
+from oc.utils import search_mult_pod_logs
 
 
 EXPECTED_APP_CONFIGS = (

--- a/camayoc/tests/qpc/yupana/utils.py
+++ b/camayoc/tests/qpc/yupana/utils.py
@@ -4,14 +4,11 @@
 
 import base64
 import json
-import multiprocessing as mp
 import re
 import requests
 import time
 
 from datetime import datetime
-from functools import partial
-from itertools import chain
 
 from oc import get_pods
 

--- a/camayoc/tests/qpc/yupana/utils.py
+++ b/camayoc/tests/qpc/yupana/utils.py
@@ -111,20 +111,6 @@ def get_timestamp(string, regex=PATTERN_DATE_TIME):
         return None
 
 
-def search_log(log_list, search_string):
-    """Search through a log list for lines containing the `search_string`.
-        Returns a list of the matched lines."""
-    return [log_line for log_line in log_list if search_string in log_line]
-
-
-def search_mult_pod_logs(pods_logs, search_string, pool_size=4):
-    """Search through the logs of each pod, and return the combined list."""
-    search_func = partial(search_log, search_string=search_string)
-    with mp.Pool(pool_size) as p:
-        search_results = p.map(search_func, pods_logs)
-    return list(chain(search_results))
-
-
 def filter_log(
     log_list,
     date_min=None,


### PR DESCRIPTION
Moved some of the `oc` helper functions from camayoc to `oc.utils`. This PR switches camayoc to import them from `oc.utils` now that they're in the `oc` install.