### PR TITLE
Issues/334

### DIFF
--- a/camayoc/tests/qpc/cli/test_credentials.py
+++ b/camayoc/tests/qpc/cli/test_credentials.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import pexpect
 
 from camayoc import utils
+from camayoc.utils import client_cmd
 from camayoc.constants import (
     BECOME_PASSWORD_INPUT,
     CONNECTION_PASSWORD_INPUT,
@@ -218,7 +219,7 @@ def test_edit_username(isolated_filesystem, qpc_server_config, source_type):
     )
 
     qpc_cred_edit = pexpect.spawn(
-        "qpc cred edit --name={} --username={}".format(name, new_username)
+        "{} cred edit --name={} --username={}".format(client_cmd, name, new_username)
     )
     qpc_cred_edit.logfile = BytesIO()
     assert qpc_cred_edit.expect('Credential "{}" was updated'.format(name)) == 0
@@ -258,7 +259,7 @@ def test_edit_username_negative(isolated_filesystem, qpc_server_config):
     name = utils.uuid4()
     username = utils.uuid4()
     qpc_cred_edit = pexpect.spawn(
-        "qpc cred edit --name={} --username={}".format(name, username)
+        "{} cred edit --name={} --username={}".format(client_cmd, name, username)
     )
     qpc_cred_edit.logfile = BytesIO()
     assert qpc_cred_edit.expect('Credential "{}" does not exist'.format(name)) == 0
@@ -297,7 +298,7 @@ def test_edit_password(isolated_filesystem, qpc_server_config, source_type):
     )
 
     qpc_cred_edit = pexpect.spawn(
-        "qpc cred edit --name={} --password".format(name, new_password)
+        "{} cred edit --name={} --password".format(client_cmd, name, new_password)
     )
     assert qpc_cred_edit.expect(CONNECTION_PASSWORD_INPUT) == 0
     qpc_cred_edit.sendline(new_password)
@@ -337,7 +338,7 @@ def test_edit_password_negative(isolated_filesystem, qpc_server_config):
     )
 
     name = utils.uuid4()
-    qpc_cred_edit = pexpect.spawn("qpc cred edit --name={} --password".format(name))
+    qpc_cred_edit = pexpect.spawn("{} cred edit --name={} --password".format(client_cmd, name))
     assert qpc_cred_edit.expect('Credential "{}" does not exist'.format(name)) == 0
     assert qpc_cred_edit.expect(pexpect.EOF) == 0
     qpc_cred_edit.close()
@@ -370,8 +371,8 @@ def test_edit_sshkeyfile(isolated_filesystem, qpc_server_config):
     )
 
     qpc_cred_edit = pexpect.spawn(
-        "qpc cred edit --name={} --sshkeyfile {}".format(
-            name, str(new_sshkeyfile.resolve())
+        "{} cred edit --name={} --sshkeyfile {}".format(
+            client_cmd, name, str(new_sshkeyfile.resolve())
         )
     )
     qpc_cred_edit.logfile = BytesIO()
@@ -413,8 +414,8 @@ def test_edit_sshkeyfile_negative(isolated_filesystem, qpc_server_config):
     sshkeyfile = Path(utils.uuid4())
     sshkeyfile.touch()
     qpc_cred_edit = pexpect.spawn(
-        "qpc cred edit --name={} --sshkeyfile {}".format(
-            name, str(sshkeyfile.resolve())
+        "{} cred edit --name={} --sshkeyfile {}".format(
+            client_cmd, name, str(sshkeyfile.resolve())
         )
     )
     qpc_cred_edit.logfile = BytesIO()
@@ -461,7 +462,7 @@ def test_edit_become_password(isolated_filesystem, qpc_server_config):
     )
 
     qpc_cred_edit = pexpect.spawn(
-        "qpc cred edit --name={} --become-password".format(name, new_become_password)
+        "{} cred edit --name={} --become-password".format(client_cmd, name, new_become_password)
     )
     assert qpc_cred_edit.expect(BECOME_PASSWORD_INPUT) == 0
     qpc_cred_edit.sendline(new_become_password)
@@ -501,7 +502,7 @@ def test_edit_become_password_negative(isolated_filesystem, qpc_server_config):
 
     name = utils.uuid4()
     qpc_cred_edit = pexpect.spawn(
-        "qpc cred edit --name={} --become-password".format(name)
+        "{} cred edit --name={} --become-password".format(client_cmd, name)
     )
     assert qpc_cred_edit.expect('Credential "{}" does not exist'.format(name)) == 0
     assert qpc_cred_edit.expect(pexpect.EOF) == 0
@@ -523,8 +524,8 @@ def test_edit_no_credentials(isolated_filesystem, qpc_server_config):
     sshkeyfile = Path(utils.uuid4())
     sshkeyfile.touch()
     qpc_cred_edit = pexpect.spawn(
-        "qpc cred edit --name={} --sshkeyfile {}".format(
-            name, str(sshkeyfile.resolve())
+        "{} cred edit --name={} --sshkeyfile {}".format(
+            client_cmd, name, str(sshkeyfile.resolve())
         )
     )
     qpc_cred_edit.logfile = BytesIO()
@@ -558,13 +559,13 @@ def test_clear(isolated_filesystem, qpc_server_config):
         ),
     )
 
-    qpc_cred_clear = pexpect.spawn("qpc cred clear --name={}".format(name))
+    qpc_cred_clear = pexpect.spawn("{} cred clear --name={}".format(client_cmd, name))
     assert qpc_cred_clear.expect('Credential "{}" was removed'.format(name)) == 0
     assert qpc_cred_clear.expect(pexpect.EOF) == 0
     qpc_cred_clear.close()
     assert qpc_cred_clear.exitstatus == 0
 
-    qpc_cred_show = pexpect.spawn("qpc cred show --name={}".format(name))
+    qpc_cred_show = pexpect.spawn("{} cred show --name={}".format(client_cmd, name))
     assert qpc_cred_show.expect('Credential "{}" does not exist'.format(name)) == 0
     assert qpc_cred_show.expect(pexpect.EOF) == 0
     qpc_cred_show.close()
@@ -621,7 +622,7 @@ def test_clear_with_source(isolated_filesystem, qpc_server_config):
     output = source_show({"name": source_name})
     output = json.loads(output)
     # try to delete credential
-    qpc_cred_clear = pexpect.spawn("qpc cred clear --name={}".format(cred_name))
+    qpc_cred_clear = pexpect.spawn("{} cred clear --name={}".format(client_cmd, cred_name))
     qpc_cred_clear.logfile = BytesIO()
     assert qpc_cred_clear.expect(pexpect.EOF) == 0
     assert (
@@ -638,19 +639,19 @@ def test_clear_with_source(isolated_filesystem, qpc_server_config):
     assert qpc_cred_clear.exitstatus == 1
     qpc_cred_clear.close()
     # delete the source using credential
-    qpc_source_clear = pexpect.spawn("qpc source clear --name={}".format(source_name))
+    qpc_source_clear = pexpect.spawn("{} source clear --name={}".format(client_cmd, source_name))
     assert qpc_source_clear.expect('Source "{}" was removed'.format(source_name)) == 0
     assert qpc_source_clear.expect(pexpect.EOF) == 0
     qpc_source_clear.close()
     assert qpc_source_clear.exitstatus == 0
     # successfully remove credential
-    qpc_cred_clear = pexpect.spawn("qpc cred clear --name={}".format(cred_name))
+    qpc_cred_clear = pexpect.spawn("{} cred clear --name={}".format(client_cmd, cred_name))
     assert qpc_cred_clear.expect('Credential "{}" was removed'.format(cred_name)) == 0
     assert qpc_cred_clear.expect(pexpect.EOF) == 0
     qpc_cred_clear.close()
     assert qpc_cred_clear.exitstatus == 0
     # try showing cred
-    qpc_cred_show = pexpect.spawn("qpc cred show --name={}".format(cred_name))
+    qpc_cred_show = pexpect.spawn("{} cred show --name={}".format(client_cmd, cred_name))
     assert qpc_cred_show.expect('Credential "{}" does not exist'.format(cred_name)) == 0
     assert qpc_cred_show.expect(pexpect.EOF) == 0
     qpc_cred_show.close()
@@ -667,7 +668,7 @@ def test_clear_negative(isolated_filesystem, qpc_server_config):
         be removed.
     """
     name = utils.uuid4()
-    qpc_cred_clear = pexpect.spawn("qpc cred clear --name={}".format(name))
+    qpc_cred_clear = pexpect.spawn("{} cred clear --name={}".format(client_cmd, name))
     qpc_cred_clear.logfile = BytesIO()
     assert qpc_cred_clear.expect(pexpect.EOF) == 0
     assert qpc_cred_clear.logfile.getvalue().strip().decode(
@@ -709,13 +710,13 @@ def test_clear_all(isolated_filesystem, qpc_server_config):
         )
 
     output, exitstatus = pexpect.run(
-        "qpc cred clear --all", encoding="utf-8", withexitstatus=True
+        "{} cred clear --all".format(client_cmd), encoding="utf-8", withexitstatus=True
     )
     assert "All credentials were removed." in output
     assert exitstatus == 0
 
     output, exitstatus = pexpect.run(
-        "qpc cred list", encoding="utf8", withexitstatus=True
+        "{} cred list".format(client_cmd), encoding="utf8", withexitstatus=True
     )
     assert "No credentials exist yet." in output
     assert exitstatus == 0

--- a/camayoc/tests/qpc/cli/test_scans.py
+++ b/camayoc/tests/qpc/cli/test_scans.py
@@ -14,7 +14,10 @@ import re
 
 import pytest
 
-from camayoc.utils import uuid4
+from camayoc.utils import (
+    client_cmd,
+    uuid4
+)
 
 from .utils import (
     config_sources,
@@ -129,7 +132,7 @@ def test_create_scan_with_disabled_products_negative(
             "sources": source_name,
             "disabled-optional-products": fail_cases,
         },
-        r"usage: qpc scan add(.|[\r\n])*",
+        r"usage: {} scan add(.|[\r\n])*".format(client_cmd),
         exitstatus=2,
     )
 
@@ -156,7 +159,7 @@ def test_create_scan_with_extended_products_negative(
             "sources": source_name,
             "enabled-ext-product-search": fail_cases,
         },
-        r"usage: qpc scan add(.|[\r\n])*",
+        r"usage: {} scan add(.|[\r\n])*".format(client_cmd),
         exitstatus=2,
     )
 
@@ -384,7 +387,7 @@ def test_edit_scan_negative(isolated_filesystem, qpc_server_config, source):
     # Edit scan options
     scan_edit_and_check(
         {"name": scan_name, "sources": ""},
-        r"usage: qpc scan edit(.|[\r\n])*",
+        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd),
         exitstatus=2,
     )
 
@@ -398,7 +401,7 @@ def test_edit_scan_negative(isolated_filesystem, qpc_server_config, source):
     # Edit scan options
     scan_edit_and_check(
         {"name": scan_name, "sources": source_name, "max-concurrency": "abc"},
-        r"usage: qpc scan edit(.|[\r\n])*",
+        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd),
         exitstatus=2,
     )
 
@@ -409,7 +412,7 @@ def test_edit_scan_negative(isolated_filesystem, qpc_server_config, source):
             "sources": "",
             "disabled-optional-products": "not_a_real_product",
         },
-        r"usage: qpc scan edit(.|[\r\n])*",
+        r"usage: {}{ scan edit(.|[\r\n])*".format(client_cmd),
         exitstatus=2,
     )
 
@@ -420,14 +423,14 @@ def test_edit_scan_negative(isolated_filesystem, qpc_server_config, source):
             "sources": "",
             "enabled-ext-product-search": "not_a_real_product",
         },
-        r"usage: qpc scan edit(.|[\r\n])*",
+        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd),
         exitstatus=2,
     )
 
     # Edit ext-product-search-dirs
     scan_edit_and_check(
         {"name": scan_name, "sources": "", "ext-product-search-dirs": "not-a-dir"},
-        r"usage: qpc scan edit(.|[\r\n])*",
+        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd),
         exitstatus=2,
     )
 

--- a/camayoc/tests/qpc/cli/test_sources.py
+++ b/camayoc/tests/qpc/cli/test_sources.py
@@ -19,6 +19,7 @@ import pexpect
 import pytest
 
 from camayoc import utils
+from camayoc.utils import client_cmd
 from camayoc.constants import CONNECTION_PASSWORD_INPUT, QPC_HOST_MANAGER_TYPES
 from camayoc.tests.qpc.cli.utils import (
     convert_ip_format,
@@ -143,8 +144,8 @@ def test_add_with_cred_hosts(
     )
 
     qpc_source_add = pexpect.spawn(
-        "qpc source add --name {} --cred {} --hosts {} --type {}".format(
-            name, cred_name, hosts, source_type
+        "{} source add --name {} --cred {} --hosts {} --type {}".format(
+            client_cmd, name, cred_name, hosts, source_type
         )
     )
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
@@ -199,8 +200,8 @@ def test_add_with_cred_hosts_file(
         handler.write(hosts.replace(" ", "\n") + "\n")
 
     qpc_source_add = pexpect.spawn(
-        "qpc source add --name {} --cred {} --hosts {} --type {}".format(
-            name, cred_name, "hosts_file", source_type
+        "{} source add --name {} --cred {} --hosts {} --type {}".format(
+            client_cmd, name, cred_name, "hosts_file", source_type
         )
     )
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
@@ -249,8 +250,8 @@ def test_add_with_port(isolated_filesystem, qpc_server_config, source_type):
     )
 
     qpc_source_add = pexpect.spawn(
-        "qpc source add --name {} --cred {} --hosts {} --port {} "
-        "--type {}".format(name, cred_name, hosts, port, source_type)
+        "{} source add --name {} --cred {} --hosts {} --port {} "
+        "--type {}".format(client_cmd, name, cred_name, hosts, port, source_type)
     )
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
@@ -297,8 +298,8 @@ def test_add_with_port_negative(isolated_filesystem, qpc_server_config, source_t
     )
 
     qpc_source_add = pexpect.spawn(
-        "qpc source add --name {} --cred {} --hosts {} --port {} --type {}".format(
-            name, cred_name, hosts, port, source_type
+        "{} source add --name {} --cred {} --hosts {} --port {} --type {}".format(
+            client_cmd, name, cred_name, hosts, port, source_type
         )
     )
     assert (
@@ -342,8 +343,8 @@ def test_add_with_ssl_cert_verify(
     )
 
     qpc_source_add = pexpect.spawn(
-        "qpc source add --name {} --cred {} --hosts {} --ssl-cert-verify {} "
-        "--type {}".format(name, cred_name, hosts, ssl_cert_verify, source_type)
+        "{} source add --name {} --cred {} --hosts {} --ssl-cert-verify {} "
+        "--type {}".format(client_cmd, name, cred_name, hosts, ssl_cert_verify, source_type)
     )
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
@@ -395,9 +396,9 @@ def test_add_with_ssl_cert_verify_negative(
     else:
         ssl_cert_verify = utils.uuid4()
         expected_error = (
-            "qpc source add: error: argument --ssl-cert-verify: invalid "
+            "{} source add: error: argument --ssl-cert-verify: invalid "
             "choice: '{}' \\(choose from 'True', 'False', 'true', "
-            "'false'\\)".format(ssl_cert_verify)
+            "'false'\\)".format(client_cmd, ssl_cert_verify)
         )
         exitstatus = 2
     cred_add_and_check(
@@ -411,9 +412,9 @@ def test_add_with_ssl_cert_verify_negative(
     )
 
     qpc_source_add = pexpect.spawn(
-        "qpc source add --name {} --cred {} --hosts {} --port {} "
+        "{} source add --name {} --cred {} --hosts {} --port {} "
         "--ssl-cert-verify {} --type {}".format(
-            name, cred_name, hosts, port, ssl_cert_verify, source_type
+            client_cmd, name, cred_name, hosts, port, ssl_cert_verify, source_type
         )
     )
     assert qpc_source_add.expect(expected_error) == 0
@@ -451,8 +452,8 @@ def test_add_with_ssl_protocol(
     )
 
     qpc_source_add = pexpect.spawn(
-        "qpc source add --name {} --cred {} --hosts {} --ssl-protocol {} "
-        "--type {}".format(name, cred_name, hosts, ssl_protocol, source_type)
+        "{} source add --name {} --cred {} --hosts {} --ssl-protocol {} "
+        "--type {}".format(client_cmd, name, cred_name, hosts, ssl_protocol, source_type)
     )
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
@@ -501,9 +502,9 @@ def test_add_with_ssl_protocol_negative(
     else:
         ssl_protocol = utils.uuid4()
         expected_error = (
-            "qpc source add: error: argument --ssl-protocol: invalid choice: "
+            "{} source add: error: argument --ssl-protocol: invalid choice: "
             "'{}' \\(choose from 'SSLv23', 'TLSv1', 'TLSv1_1', "
-            "'TLSv1_2'\\)".format(ssl_protocol)
+            "'TLSv1_2'\\)".format(client_cmd, ssl_protocol)
         )
         exitstatus = 2
     cred_add_and_check(
@@ -517,9 +518,9 @@ def test_add_with_ssl_protocol_negative(
     )
 
     qpc_source_add = pexpect.spawn(
-        "qpc source add --name {} --cred {} --hosts {} --port {} "
+        "{} source add --name {} --cred {} --hosts {} --port {} "
         "--ssl-protocol {} --type {}".format(
-            name, cred_name, hosts, port, ssl_protocol, source_type
+            client_cmd, name, cred_name, hosts, port, ssl_protocol, source_type
         )
     )
     assert qpc_source_add.expect(expected_error) == 0
@@ -557,8 +558,8 @@ def test_add_with_disable_ssl(
     )
 
     qpc_source_add = pexpect.spawn(
-        "qpc source add --name {} --cred {} --hosts {} --disable-ssl {} "
-        "--type {}".format(name, cred_name, hosts, disable_ssl, source_type)
+        "{} source add --name {} --cred {} --hosts {} --disable-ssl {} "
+        "--type {}".format(client_cmd, name, cred_name, hosts, disable_ssl, source_type)
     )
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
@@ -607,9 +608,9 @@ def test_add_with_disable_ssl_negative(
     else:
         disable_ssl = utils.uuid4()
         expected_error = (
-            "qpc source add: error: argument --disable-ssl: invalid "
+            "{} source add: error: argument --disable-ssl: invalid "
             "choice: '{}' \\(choose from 'True', 'False', 'true', "
-            "'false'\\)".format(disable_ssl)
+            "'false'\\)".format(client_cmd, disable_ssl)
         )
         exitstatus = 2
     cred_add_and_check(
@@ -623,9 +624,9 @@ def test_add_with_disable_ssl_negative(
     )
 
     qpc_source_add = pexpect.spawn(
-        "qpc source add --name {} --cred {} --hosts {} --port {} "
+        "{} source add --name {} --cred {} --hosts {} --port {} "
         "--disable-ssl {} --type {}".format(
-            name, cred_name, hosts, port, disable_ssl, source_type
+            client_cmd, name, cred_name, hosts, port, disable_ssl, source_type
         )
     )
     assert qpc_source_add.expect(expected_error) == 0
@@ -664,9 +665,9 @@ def test_add_with_exclude_hosts(
     )
 
     qpc_source_add = pexpect.spawn(
-        """qpc source add --name {} --cred {} --hosts {} --exclude-hosts {}
+        """{} source add --name {} --cred {} --hosts {} --exclude-hosts {}
         --type {}""".format(
-            name, cred_name, hosts, exclude_hosts, source_type
+            client_cmd, name, cred_name, hosts, exclude_hosts, source_type
         )
     )
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
@@ -725,9 +726,9 @@ def test_add_with_cred_hosts_exclude_file(
         handler.write(exclude_hosts.replace(" ", "\n") + "\n")
 
     qpc_source_add = pexpect.spawn(
-        """qpc source add --name {} --cred {} --hosts {} --exclude-hosts={}
+        """{} source add --name {} --cred {} --hosts {} --exclude-hosts={}
         --type {}""".format(
-            name, cred_name, hosts, "exclude_hosts_file", source_type
+            client_cmd, name, cred_name, hosts, "exclude_hosts_file", source_type
         )
     )
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
@@ -783,9 +784,9 @@ def test_add_exclude_hosts_negative(
     )
 
     qpc_source_add = pexpect.spawn(
-        """qpc source add --name {} --cred {} --hosts {} --exclude-hosts {}
+        """{} source add --name {} --cred {} --hosts {} --exclude-hosts {}
         --type {}""".format(
-            name, cred_name, hosts, exclude_hosts, source_type
+            client_cmd, name, cred_name, hosts, exclude_hosts, source_type
         )
     )
     assert (
@@ -822,8 +823,8 @@ def test_edit_cred(isolated_filesystem, qpc_server_config, source_type):
         )
 
     qpc_source_add = pexpect.spawn(
-        "qpc source add --name {} --cred {} --hosts {} --type {}".format(
-            name, cred_name, hosts, source_type
+        "{} source add --name {} --cred {} --hosts {} --type {}".format(
+            client_cmd, name, cred_name, hosts, source_type
         )
     )
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
@@ -845,7 +846,7 @@ def test_edit_cred(isolated_filesystem, qpc_server_config, source_type):
     )
 
     qpc_source_edit = pexpect.spawn(
-        "qpc source edit --name {} --cred {}".format(name, new_cred_name)
+        "{} source edit --name {} --cred {}".format(client_cmd, name, new_cred_name)
     )
     assert qpc_source_edit.expect('Source "{}" was updated'.format(name)) == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
@@ -889,8 +890,8 @@ def test_edit_cred_negative(isolated_filesystem, qpc_server_config, source_type)
     )
 
     qpc_source_add = pexpect.spawn(
-        "qpc source add --name {} --cred {} --hosts {} --type {}".format(
-            name, cred_name, hosts, source_type
+        "{} source add --name {} --cred {} --hosts {} --type {}".format(
+            client_cmd, name, cred_name, hosts, source_type
         )
     )
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
@@ -899,7 +900,7 @@ def test_edit_cred_negative(isolated_filesystem, qpc_server_config, source_type)
     assert qpc_source_add.exitstatus == 0
 
     qpc_source_edit = pexpect.spawn(
-        "qpc source edit --name {} --cred {}".format(invalid_name, utils.uuid4())
+        "{} source edit --name {} --cred {}".format(client_cmd, invalid_name, utils.uuid4())
     )
     qpc_source_edit.logfile = BytesIO()
     assert (
@@ -934,8 +935,8 @@ def test_edit_hosts(isolated_filesystem, qpc_server_config, new_hosts, source_ty
     )
 
     qpc_source_add = pexpect.spawn(
-        "qpc source add --name {} --cred {} --hosts {} --type {}".format(
-            name, cred_name, hosts, source_type
+        "{} source add --name {} --cred {} --hosts {} --type {}".format(
+            client_cmd, name, cred_name, hosts, source_type
         )
     )
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
@@ -957,7 +958,7 @@ def test_edit_hosts(isolated_filesystem, qpc_server_config, new_hosts, source_ty
     )
 
     qpc_source_edit = pexpect.spawn(
-        "qpc source edit --name {} --hosts {}".format(name, new_hosts)
+        "{} source edit --name {} --hosts {}".format(client_cmd, name, new_hosts)
     )
     assert qpc_source_edit.expect('Source "{}" was updated'.format(name)) == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
@@ -1005,8 +1006,8 @@ def test_edit_hosts_file(
     )
 
     qpc_source_add = pexpect.spawn(
-        "qpc source add --name {} --cred {} --hosts {} --type {}".format(
-            name, cred_name, hosts, source_type
+        "{} source add --name {} --cred {} --hosts {} --type {}".format(
+            client_cmd, name, cred_name, hosts, source_type
         )
     )
     qpc_source_add.logfile = BytesIO()
@@ -1032,7 +1033,7 @@ def test_edit_hosts_file(
         handler.write(new_hosts.replace(" ", "\n") + "\n")
 
     qpc_source_edit = pexpect.spawn(
-        "qpc source edit --name {} --hosts {}".format(name, "hosts_file")
+        "{} source edit --name {} --hosts {}".format(client_cmd, name, "hosts_file")
     )
     qpc_source_edit.logfile = BytesIO()
     assert qpc_source_edit.expect('Source "{}" was updated'.format(name)) == 0
@@ -1088,8 +1089,8 @@ def test_edit_hosts_negative(
     )
 
     qpc_source_add = pexpect.spawn(
-        "qpc source add --name {} --cred {} --hosts {} --type {}".format(
-            name, cred_name, hosts, source_type
+        "{} source add --name {} --cred {} --hosts {} --type {}".format(
+            client_cmd, name, cred_name, hosts, source_type
         )
     )
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
@@ -1098,7 +1099,7 @@ def test_edit_hosts_negative(
     assert qpc_source_add.exitstatus == 0
 
     qpc_source_edit = pexpect.spawn(
-        "qpc source edit --name {} --hosts {}".format(name, new_hosts)
+        "{} source edit --name {} --hosts {}".format(client_cmd, name, new_hosts)
     )
     qpc_source_edit.logfile = BytesIO()
     assert (
@@ -1261,8 +1262,8 @@ def test_edit_port(isolated_filesystem, qpc_server_config, source_type):
     )
 
     qpc_source_add = pexpect.spawn(
-        "qpc source add --name {} --cred {} --hosts {} --port {} --type {}".format(
-            name, cred_name, hosts, port, source_type
+        "{} source add --name {} --cred {} --hosts {} --port {} --type {}".format(
+            client_cmd, name, cred_name, hosts, port, source_type
         )
     )
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
@@ -1284,7 +1285,7 @@ def test_edit_port(isolated_filesystem, qpc_server_config, source_type):
     )
 
     qpc_source_edit = pexpect.spawn(
-        "qpc source edit --name {} --port {}".format(name, new_port)
+        "{} source edit --name {} --port {}".format(client_cmd, name, new_port)
     )
     assert qpc_source_edit.expect('Source "{}" was updated'.format(name)) == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
@@ -1332,8 +1333,8 @@ def test_edit_port_negative(isolated_filesystem, qpc_server_config, source_type)
     )
 
     qpc_source_add = pexpect.spawn(
-        "qpc source add --name {} --cred {} --hosts {} --port {} --type {}".format(
-            name, cred_name, hosts, port, source_type
+        "{} source add --name {} --cred {} --hosts {} --port {} --type {}".format(
+            client_cmd, name, cred_name, hosts, port, source_type
         )
     )
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
@@ -1342,7 +1343,7 @@ def test_edit_port_negative(isolated_filesystem, qpc_server_config, source_type)
     assert qpc_source_add.exitstatus == 0
 
     qpc_source_edit = pexpect.spawn(
-        "qpc source edit --name {} --port {}".format(invalid_name, new_port)
+        "{} source edit --name {} --port {}".format(client_cmd, invalid_name, new_port)
     )
     qpc_source_edit.logfile = BytesIO()
     assert (
@@ -1379,8 +1380,8 @@ def test_edit_ssl_cert_verify(isolated_filesystem, qpc_server_config, source_typ
     )
 
     qpc_source_add = pexpect.spawn(
-        "qpc source add --name {} --cred {} --hosts {} --ssl-cert-verify {} "
-        "--type {}".format(name, cred_name, hosts, ssl_cert_verify, source_type)
+        "{} source add --name {} --cred {} --hosts {} --ssl-cert-verify {} "
+        "--type {}".format(client_cmd, name, cred_name, hosts, ssl_cert_verify, source_type)
     )
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
@@ -1402,8 +1403,8 @@ def test_edit_ssl_cert_verify(isolated_filesystem, qpc_server_config, source_typ
     )
 
     qpc_source_edit = pexpect.spawn(
-        "qpc source edit --name {} --ssl-cert-verify {}".format(
-            name, new_ssl_cert_verify
+        "{} source edit --name {} --ssl-cert-verify {}".format(
+            client_cmd, name, new_ssl_cert_verify
         )
     )
     assert qpc_source_edit.expect('Source "{}" was updated'.format(name)) == 0
@@ -1451,8 +1452,8 @@ def test_edit_ssl_cert_verify_negative(
         "source_type": source_type,
     }
     if source_type == "network":
-        add_command = "qpc source add --name {} --cred {} --hosts {} --port {} --type {}".format(
-            name, cred_name, hosts, port, source_type
+        add_command = "{} source add --name {} --cred {} --hosts {} --port {} --type {}".format(
+            client_cmd, name, cred_name, hosts, port, source_type
         )
         new_ssl_cert_verify = random.choice(QPC_BOOLEAN_VALUES)
         expected_error = (
@@ -1462,16 +1463,16 @@ def test_edit_ssl_cert_verify_negative(
     else:
         ssl_cert_verify = random.choice(QPC_BOOLEAN_VALUES)
         add_command = (
-            "qpc source add --name {} --cred {} --hosts {} --port {} "
+            "{} source add --name {} --cred {} --hosts {} --port {} "
             "--ssl-cert-verify {} --type {}".format(
-                name, cred_name, hosts, port, ssl_cert_verify, source_type
+                client_cmd, name, cred_name, hosts, port, ssl_cert_verify, source_type
             )
         )
         new_ssl_cert_verify = utils.uuid4()
         expected_error = (
-            "qpc source edit: error: argument --ssl-cert-verify: invalid "
+            "{} source edit: error: argument --ssl-cert-verify: invalid "
             "choice: '{}' \\(choose from 'True', 'False', 'true', "
-            "'false'\\)".format(new_ssl_cert_verify)
+            "'false'\\)".format(client_cmd, new_ssl_cert_verify)
         )
         exitstatus = 2
         show_output_dict["options"] = {"ssl_cert_verify": ssl_cert_verify.lower()}
@@ -1491,8 +1492,8 @@ def test_edit_ssl_cert_verify_negative(
     assert qpc_source_add.exitstatus == 0
 
     qpc_source_edit = pexpect.spawn(
-        "qpc source edit --name {} --ssl-cert-verify {}".format(
-            name, new_ssl_cert_verify
+        "{} source edit --name {} --ssl-cert-verify {}".format(
+            client_cmd, name, new_ssl_cert_verify
         )
     )
     assert qpc_source_edit.expect(expected_error) == 0
@@ -1529,8 +1530,8 @@ def test_edit_ssl_protocol(isolated_filesystem, qpc_server_config, source_type):
     )
 
     qpc_source_add = pexpect.spawn(
-        "qpc source add --name {} --cred {} --hosts {} --ssl-protocol {} "
-        "--type {}".format(name, cred_name, hosts, ssl_protocol, source_type)
+        "{} source add --name {} --cred {} --hosts {} --ssl-protocol {} "
+        "--type {}".format(client_cmd, name, cred_name, hosts, ssl_protocol, source_type)
     )
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
@@ -1552,7 +1553,7 @@ def test_edit_ssl_protocol(isolated_filesystem, qpc_server_config, source_type):
     )
 
     qpc_source_edit = pexpect.spawn(
-        "qpc source edit --name {} --ssl-protocol {}".format(name, new_ssl_protocol)
+        "{} source edit --name {} --ssl-protocol {}".format(client_cmd, name, new_ssl_protocol)
     )
     assert qpc_source_edit.expect('Source "{}" was updated'.format(name)) == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
@@ -1599,8 +1600,8 @@ def test_edit_ssl_protocol_negative(
         "source_type": source_type,
     }
     if source_type == "network":
-        add_command = "qpc source add --name {} --cred {} --hosts {} --port {} --type {}".format(
-            name, cred_name, hosts, port, source_type
+        add_command = "{} source add --name {} --cred {} --hosts {} --port {} --type {}".format(
+            client_cmd, name, cred_name, hosts, port, source_type
         )
         new_ssl_protocol = random.choice(QPC_SSL_PROTOCOL_VALUES)
         expected_error = "Error: Invalid SSL options for network source: ssl_protocol"
@@ -1608,16 +1609,16 @@ def test_edit_ssl_protocol_negative(
     else:
         ssl_protocol = random.choice(QPC_SSL_PROTOCOL_VALUES)
         add_command = (
-            "qpc source add --name {} --cred {} --hosts {} --port {} "
+            "{} source add --name {} --cred {} --hosts {} --port {} "
             "--ssl-protocol {} --type {}".format(
-                name, cred_name, hosts, port, ssl_protocol, source_type
+                client_cmd, name, cred_name, hosts, port, ssl_protocol, source_type
             )
         )
         new_ssl_protocol = utils.uuid4()
         expected_error = (
-            "qpc source edit: error: argument --ssl-protocol: invalid "
+            "{} source edit: error: argument --ssl-protocol: invalid "
             "choice: '{}' \\(choose from 'SSLv23', 'TLSv1', "
-            "'TLSv1_1', 'TLSv1_2'\\)".format(new_ssl_protocol)
+            "'TLSv1_1', 'TLSv1_2'\\)".format(client_cmd, new_ssl_protocol)
         )
         exitstatus = 2
         show_output_dict["options"] = {"ssl_protocol": ssl_protocol}
@@ -1637,7 +1638,7 @@ def test_edit_ssl_protocol_negative(
     assert qpc_source_add.exitstatus == 0
 
     qpc_source_edit = pexpect.spawn(
-        "qpc source edit --name {} --ssl-protocol {}".format(name, new_ssl_protocol)
+        "{} source edit --name {} --ssl-protocol {}".format(client_cmd, name, new_ssl_protocol)
     )
     assert qpc_source_edit.expect(expected_error) == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
@@ -1673,8 +1674,8 @@ def test_edit_disable_ssl(isolated_filesystem, qpc_server_config, source_type):
     )
 
     qpc_source_add = pexpect.spawn(
-        "qpc source add --name {} --cred {} --hosts {} --disable-ssl {} "
-        "--type {}".format(name, cred_name, hosts, disable_ssl, source_type)
+        "{} source add --name {} --cred {} --hosts {} --disable-ssl {} "
+        "--type {}".format(client_cmd, name, cred_name, hosts, disable_ssl, source_type)
     )
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
@@ -1696,7 +1697,7 @@ def test_edit_disable_ssl(isolated_filesystem, qpc_server_config, source_type):
     )
 
     qpc_source_edit = pexpect.spawn(
-        "qpc source edit --name {} --disable-ssl {}".format(name, new_disable_ssl)
+        "{} source edit --name {} --disable-ssl {}".format(client_cmd, name, new_disable_ssl)
     )
     assert qpc_source_edit.expect('Source "{}" was updated'.format(name)) == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
@@ -1741,8 +1742,8 @@ def test_edit_disable_ssl_negative(isolated_filesystem, qpc_server_config, sourc
         "source_type": source_type,
     }
     if source_type == "network":
-        add_command = "qpc source add --name {} --cred {} --hosts {} --port {} --type {}".format(
-            name, cred_name, hosts, port, source_type
+        add_command = "{} source add --name {} --cred {} --hosts {} --port {} --type {}".format(
+            client_cmd, name, cred_name, hosts, port, source_type
         )
         new_disable_ssl = random.choice(QPC_BOOLEAN_VALUES)
         expected_error = "Error: Invalid SSL options for network source: disable_ssl"
@@ -1750,16 +1751,16 @@ def test_edit_disable_ssl_negative(isolated_filesystem, qpc_server_config, sourc
     else:
         disable_ssl = random.choice(QPC_BOOLEAN_VALUES)
         add_command = (
-            "qpc source add --name {} --cred {} --hosts {} --port {} "
+            "{} source add --name {} --cred {} --hosts {} --port {} "
             "--disable-ssl {} --type {}".format(
-                name, cred_name, hosts, port, disable_ssl, source_type
+                client_cmd, name, cred_name, hosts, port, disable_ssl, source_type
             )
         )
         new_disable_ssl = utils.uuid4()
         expected_error = (
-            "qpc source edit: error: argument --disable-ssl: invalid "
+            "{} source edit: error: argument --disable-ssl: invalid "
             "choice: '{}' \\(choose from 'True', 'False', 'true', "
-            "'false'\\)".format(new_disable_ssl)
+            "'false'\\)".format(client_cmd, new_disable_ssl)
         )
         exitstatus = 2
         show_output_dict["options"] = {"disable_ssl": disable_ssl.lower()}
@@ -1779,7 +1780,7 @@ def test_edit_disable_ssl_negative(isolated_filesystem, qpc_server_config, sourc
     assert qpc_source_add.exitstatus == 0
 
     qpc_source_edit = pexpect.spawn(
-        "qpc source edit --name {} --disable-ssl {}".format(name, new_disable_ssl)
+        "{} source edit --name {} --disable-ssl {}".format(client_cmd, name, new_disable_ssl)
     )
     assert qpc_source_edit.expect(expected_error) == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
@@ -1813,8 +1814,8 @@ def test_clear(isolated_filesystem, qpc_server_config, source_type):
     )
 
     qpc_source_add = pexpect.spawn(
-        "qpc source add --name {} --cred {} --hosts {} --type {}".format(
-            name, cred_name, hosts, source_type
+        "{} source add --name {} --cred {} --hosts {} --type {}".format(
+            client_cmd, name, cred_name, hosts, source_type
         )
     )
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
@@ -1835,19 +1836,19 @@ def test_clear(isolated_filesystem, qpc_server_config, source_type):
         ),
     )
 
-    qpc_source_clear = pexpect.spawn("qpc source clear --name={}".format(name))
+    qpc_source_clear = pexpect.spawn("{} source clear --name={}".format(client_cmd, name))
     assert qpc_source_clear.expect('Source "{}" was removed'.format(name)) == 0
     assert qpc_source_clear.expect(pexpect.EOF) == 0
     qpc_source_clear.close()
     assert qpc_source_clear.exitstatus == 0
 
-    qpc_source_clear = pexpect.spawn("qpc source clear --name={}".format(name))
+    qpc_source_clear = pexpect.spawn("{} source clear --name={}".format(client_cmd, name))
     assert qpc_source_clear.expect('Source "{}" was not found.'.format(name)) == 0
     assert qpc_source_clear.expect(pexpect.EOF) == 0
     qpc_source_clear.close()
     assert qpc_source_clear.exitstatus == 1
 
-    qpc_source_show = pexpect.spawn("qpc source show --name={}".format(name))
+    qpc_source_show = pexpect.spawn("{} source show --name={}".format(client_cmd, name))
     assert qpc_source_show.expect('Source "{}" does not exist.'.format(name)) == 0
     assert qpc_source_show.expect(pexpect.EOF) == 0
     qpc_source_show.close()
@@ -1883,8 +1884,8 @@ def test_clear_with_scans(isolated_filesystem, qpc_server_config, source_type):
     )
 
     qpc_source_add = pexpect.spawn(
-        "qpc source add --name {} --cred {} --hosts {} --type {}".format(
-            name, cred_name, hosts, source_type
+        "{} source add --name {} --cred {} --hosts {} --type {}".format(
+            client_cmd, name, cred_name, hosts, source_type
         )
     )
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
@@ -1911,7 +1912,7 @@ def test_clear_with_scans(isolated_filesystem, qpc_server_config, source_type):
     scan_show_result = scan_show({"name": scan_name})
     scan_show_result = json.loads(scan_show_result)
 
-    qpc_source_clear = pexpect.spawn("qpc source clear --name={}".format(name))
+    qpc_source_clear = pexpect.spawn("{} source clear --name={}".format(client_cmd, name))
 
     qpc_source_clear.logfile = BytesIO()
     assert qpc_source_clear.expect(pexpect.EOF) == 0
@@ -1922,24 +1923,24 @@ def test_clear_with_scans(isolated_filesystem, qpc_server_config, source_type):
         'Failed to remove source "%s".' % (scan_show_result["id"], scan_name, name)
     ).encode("utf-8")
 
-    qpc_scan_clear = pexpect.spawn("qpc scan clear --name={}".format(scan_name))
+    qpc_scan_clear = pexpect.spawn("{} scan clear --name={}".format(client_cmd, scan_name))
 
     assert qpc_scan_clear.expect('Scan "{}" was removed'.format(scan_name)) == 0
 
-    qpc_source_clear = pexpect.spawn("qpc source clear --name={}".format(name))
+    qpc_source_clear = pexpect.spawn("{} source clear --name={}".format(client_cmd, name))
 
     assert qpc_source_clear.expect('Source "{}" was removed'.format(name)) == 0
     assert qpc_source_clear.expect(pexpect.EOF) == 0
     qpc_source_clear.close()
     assert qpc_source_clear.exitstatus == 0
 
-    qpc_source_clear = pexpect.spawn("qpc source clear --name={}".format(name))
+    qpc_source_clear = pexpect.spawn("{} source clear --name={}".format(client_cmd, name))
     assert qpc_source_clear.expect('Source "{}" was not found.'.format(name)) == 0
     assert qpc_source_clear.expect(pexpect.EOF) == 0
     qpc_source_clear.close()
     assert qpc_source_clear.exitstatus == 1
 
-    qpc_source_show = pexpect.spawn("qpc source show --name={}".format(name))
+    qpc_source_show = pexpect.spawn("{} source show --name={}".format(client_cmd, name))
     assert qpc_source_show.expect('Source "{}" does not exist.'.format(name)) == 0
     assert qpc_source_show.expect(pexpect.EOF) == 0
     qpc_source_show.close()
@@ -1956,7 +1957,7 @@ def test_clear_negative(isolated_filesystem, qpc_server_config):
         can't be removed.
     """
     name = utils.uuid4()
-    qpc_source_clear = pexpect.spawn("qpc source clear --name={}".format(name))
+    qpc_source_clear = pexpect.spawn("{} source clear --name={}".format(client_cmd, name))
     qpc_source_clear.logfile = BytesIO()
     assert qpc_source_clear.expect(pexpect.EOF) == 0
     assert qpc_source_clear.logfile.getvalue().strip() == 'Source "{}" was not found.'.format(
@@ -1989,7 +1990,7 @@ def test_clear_all(isolated_filesystem, qpc_server_config, source_type):
         [(CONNECTION_PASSWORD_INPUT, utils.uuid4())],
     )
 
-    qpc_source_clear = pexpect.spawn("qpc source clear --all")
+    qpc_source_clear = pexpect.spawn("{} source clear --all".format(client_cmd))
     assert qpc_source_clear.expect(pexpect.EOF) == 0
     qpc_source_clear.close()
     assert qpc_source_clear.exitstatus >= 0
@@ -2011,8 +2012,8 @@ def test_clear_all(isolated_filesystem, qpc_server_config, source_type):
             source["options"] = {"ssl_cert_verify": True}
         sources.append(source)
         qpc_source_add = pexpect.spawn(
-            "qpc source add --name {} --cred {} --hosts {} --type {}".format(
-                name, cred_name, hosts, source_type
+            "{} source add --name {} --cred {} --hosts {} --type {}".format(
+                client_cmd, name, cred_name, hosts, source_type
             )
         )
         assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
@@ -2020,7 +2021,7 @@ def test_clear_all(isolated_filesystem, qpc_server_config, source_type):
         qpc_source_add.close()
         assert qpc_source_add.exitstatus == 0
 
-    qpc_source_list = pexpect.spawn("qpc source list")
+    qpc_source_list = pexpect.spawn("{} source list".format(client_cmd))
     logfile = BytesIO()
     qpc_source_list.logfile = logfile
     assert qpc_source_list.expect(pexpect.EOF) == 0
@@ -2036,13 +2037,13 @@ def test_clear_all(isolated_filesystem, qpc_server_config, source_type):
     name = operator.itemgetter("name")
     assert sorted(sources, key=name) == sorted(output, key=name)
 
-    qpc_source_clear = pexpect.spawn("qpc source clear --all")
+    qpc_source_clear = pexpect.spawn("{} source clear --all".format(client_cmd))
     assert qpc_source_clear.expect("All sources were removed") == 0
     assert qpc_source_clear.expect(pexpect.EOF) == 0
     qpc_source_clear.close()
     assert qpc_source_clear.exitstatus == 0
 
-    qpc_source_list = pexpect.spawn("qpc source list")
+    qpc_source_list = pexpect.spawn("{} source list".format(client_cmd))
     assert qpc_source_list.expect("No sources exist yet.") == 0
     assert qpc_source_list.expect(pexpect.EOF) == 0
     qpc_source_list.close()

--- a/camayoc/tests/qpc/cli/utils.py
+++ b/camayoc/tests/qpc/cli/utils.py
@@ -10,6 +10,7 @@ from pprint import pformat
 import pexpect
 
 from camayoc.config import get_config
+from camayoc.utils import client_cmd
 from camayoc.exceptions import (
     ConfigFileNotFoundError,
     FailedMergeReportException,
@@ -29,7 +30,7 @@ def clear_all_entities():
     output = []
     for command in ("scan", "source", "cred"):
         clear_output = pexpect.run(
-            "qpc {} clear --all".format(command), encoding="utf8"
+            "{} {} clear --all".format(client_cmd, command), encoding="utf8"
         )
         errors.extend(error_finder.findall(clear_output))
         output.append(clear_output)
@@ -175,7 +176,7 @@ def cred_add_and_check(options, inputs=None, exitstatus=0):
     if "type" not in options:
         options["type"] = "network"
     options.pop("rho", None)  # need to remove this data that is rho specific
-    command = "qpc cred add"
+    command = "{} cred add".format(client_cmd)
     for key, value in options.items():
         if value is None:
             command += " --{}".format(key)
@@ -209,7 +210,7 @@ def cred_show_and_check(options, output, exitstatus=0):
         network and \d+ respectively.
     :param exitstatus: Expected exit status code.
     """
-    command = "qpc cred show"
+    command = "{} cred show".format(client_cmd)
     for key, value in options.items():
         if value is None:
             command += " --{}".format(key)
@@ -222,16 +223,16 @@ def cred_show_and_check(options, output, exitstatus=0):
     assert qpc_cred_show.exitstatus == exitstatus
 
 
-report_detail = functools.partial(cli_command, "qpc report details")
+report_detail = functools.partial(cli_command, "{} report details".format(client_cmd))
 """Run ``qpc report detail`` with ``options`` and return output."""
 
-report_merge = functools.partial(cli_command, "qpc report merge")
+report_merge = functools.partial(cli_command, "{} report merge".format(client_cmd))
 """Run ``qpc report merge`` with ``options`` and return output."""
 
 
 def report_merge_status(options=None, exitstatus=0):
     """Run ``qpc report merge-status`` with ``options`` and return output."""
-    output = cli_command("qpc report merge-status", options, exitstatus)
+    output = cli_command("{} report merge-status".format(client_cmd), options, exitstatus)
     match = re.match(
         r"Report merge job (?P<id>\d+) is (?P<status>\w+)(.*id: "
         r'"(?P<report_id>\d+)")?',
@@ -241,10 +242,10 @@ def report_merge_status(options=None, exitstatus=0):
     return match.groupdict()
 
 
-report_deployments = functools.partial(cli_command, "qpc report deployments")
+report_deployments = functools.partial(cli_command, "{} report deployments".format(client_cmd))
 """Run ``qpc report deployments`` with ``options`` and return output."""
 
-report_download = functools.partial(cli_command, "qpc report download")
+report_download = functools.partial(cli_command, "{} report download".format(client_cmd))
 """Run ``qpc report download`` with ``options`` and return output."""
 
 
@@ -280,7 +281,7 @@ def source_add_and_check(options, inputs=None, exitstatus=0):
         options["exclude-hosts"] = " ".join(options["exclude-hosts"])
     if "type" not in options:
         options["type"] = "network"
-    command = "qpc source add"
+    command = "{} source add".format(client_cmd)
     for key, value in options.items():
         if value is None:
             command += " --{}".format(key)
@@ -315,7 +316,7 @@ def source_edit_and_check(options, inputs=None, exitstatus=0):
         options["hosts"] = " ".join(options["hosts"])
     if "exclude-hosts" in options:
         options["exclude-hosts"] = " ".join(options["exclude-hosts"])
-    command = "qpc source edit"
+    command = "{} source edit".format(client_cmd)
     for key, value in options.items():
         if value is None:
             command += " --{}".format(key)
@@ -344,7 +345,7 @@ def source_show_and_check(options, output, exitstatus=0):
         output. Make sure to escape any regular expression especial character.
     :param exitstatus: Expected exit status code.
     """
-    command = "qpc source show"
+    command = "{}{ source show".format(client_cmd)
     for key, value in options.items():
         if value is None:
             command += " --{}".format(key)
@@ -404,37 +405,37 @@ def scan_show_and_check(scan_name, expected_result=None):
         assert expected_result == scan_show_result
 
 
-scan_cancel = functools.partial(cli_command, "qpc scan cancel")
+scan_cancel = functools.partial(cli_command, "{} scan cancel".format(client_cmd))
 """Run ``qpc scan cancel`` command with ``options`` returning its output."""
 
-scan_pause = functools.partial(cli_command, "qpc scan pause")
+scan_pause = functools.partial(cli_command, "{} scan pause".format(client_cmd))
 """Run ``qpc scan pause`` command with ``options`` returning its output."""
 
-scan_restart = functools.partial(cli_command, "qpc scan restart")
+scan_restart = functools.partial(cli_command, "{} scan restart".format(client_cmd))
 """Run ``qpc scan restart`` command with ``options`` returning its output."""
 
-scan_add = functools.partial(cli_command, "qpc scan add")
+scan_add = functools.partial(cli_command, "{} scan add".format(client_cmd))
 """Run ``qpc scan add`` command with ``options`` returning its output."""
 
-scan_clear = functools.partial(cli_command, "qpc scan clear")
+scan_clear = functools.partial(cli_command, "{} scan clear".format(client_cmd))
 """Run ``qpc scan clear`` returning its output."""
 
-scan_edit = functools.partial(cli_command, "qpc scan edit")
+scan_edit = functools.partial(cli_command, "{} scan edit".format(client_cmd))
 """Run ``qpc scan edit`` command with ``options`` returning its output."""
 
-scan_show = functools.partial(cli_command, "qpc scan show")
+scan_show = functools.partial(cli_command, "{} scan show".format(client_cmd))
 """Run ``qpc scan show`` command with ``options`` returning its output."""
 
-scan_start = functools.partial(cli_command, "qpc scan start")
+scan_start = functools.partial(cli_command, "{} scan start".format(client_cmd))
 """Run ``qpc scan start`` command with ``options`` returning its output."""
 
-source_show = functools.partial(cli_command, "qpc source show")
+source_show = functools.partial(cli_command, "{} source show".format(client_cmd))
 """Run ``qpc source show`` command with ``options`` returning its output."""
 
 
 def scan_job(options=None, exitstatus=0):
     """Run ``qpc scan job`` command with ``options`` returning its output."""
-    return json.loads(cli_command("qpc scan job", options, exitstatus))
+    return json.loads(cli_command("{} scan job".format(client_cmd), options, exitstatus))
 
 
 def setup_qpc():
@@ -482,8 +483,8 @@ def setup_qpc():
     else:
         ssl_verify = ""
 
-    command = "qpc server config --host {} --port {}{}{}".format(
-        hostname, port, https, ssl_verify
+    command = "{} server config --host {} --port {}{}{}".format(
+        client_cmd, hostname, port, https, ssl_verify
     )
     output, exitstatus = pexpect.run(command, encoding="utf8", withexitstatus=True)
     assert exitstatus == 0, output
@@ -491,7 +492,7 @@ def setup_qpc():
     # now login to the server
     username = qpc_config.get("username", "admin")
     password = qpc_config.get("password", "pass")
-    command = "qpc server login --username {}".format(username)
+    command = "{} server login --username {}".format(client_cmd, username)
     output, exitstatus = pexpect.run(
         command,
         encoding="utf8",

--- a/camayoc/tests/qpc/cli/utils.py
+++ b/camayoc/tests/qpc/cli/utils.py
@@ -345,7 +345,7 @@ def source_show_and_check(options, output, exitstatus=0):
         output. Make sure to escape any regular expression especial character.
     :param exitstatus: Expected exit status code.
     """
-    command = "{}{ source show".format(client_cmd)
+    command = "{} source show".format(client_cmd)
     for key, value in options.items():
         if value is None:
             command += " --{}".format(key)

--- a/camayoc/tests/qpc/conftest.py
+++ b/camayoc/tests/qpc/conftest.py
@@ -28,15 +28,3 @@ def shared_client():
     """
     client = api.Client()
     yield client
-
-
-def pytest_addoption(parser):
-    parser.addoption(
-        "--client", action="store", default="qpc", help="CLI Client Command:\
-        qpc or dsc."
-    )
-
-
-@pytest.fixture
-def client_cmd(request):
-    return request.config.getoption("--client")

--- a/camayoc/tests/qpc/conftest.py
+++ b/camayoc/tests/qpc/conftest.py
@@ -28,3 +28,15 @@ def shared_client():
     """
     client = api.Client()
     yield client
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--client", action="store", default="qpc", help="CLI Client Command:\
+        qpc or dsc."
+    )
+
+
+@pytest.fixture
+def client_cmd(request):
+    return request.config.getoption("--client")

--- a/camayoc/utils.py
+++ b/camayoc/utils.py
@@ -20,6 +20,10 @@ name_getter = operator.itemgetter("name")
 """Generate test IDs by fetching the ``name`` item."""
 
 
+client_cmd = os.environ.get("CAMAYOC_CLIENT_CMD", "qpc")
+"""Check for the client command environment variable to use during tests. Defaults to `qpc`."""
+
+
 def run_scans():
     """Check for run scans environment variable."""
     result = True


### PR DESCRIPTION
The hard-coded `qpc` commands in the camayoc tests have been abstracted out to a `client_cmd` variable. This is set by exporting the `CAMAYOC_CLIENT_CMD`  environment variable, before running the camayoc tests. By default, `client_cmd` will be set to `qpc` if the environment var is not provided.

This allows the camayoc test set to be run using either the upstream (`qpc`) *or* downstream (`dsc`) client commands (or any other compatible client names in the future).

For example, to run the cli tests using `dsc` instead of `qpc`:

```bash
export CAMAYOC_CLIENT_CMD="dsc"
make test-qpc-cli
```

Closes #334 