### PR TITLE
Add camayoc.inventory module - host based inventory

### DIFF
--- a/camayoc/inventory.py
+++ b/camayoc/inventory.py
@@ -2,8 +2,6 @@
 """Host Based Inventory (HBI) API."""
 
 import requests
-import json
-import base64
 import urllib3
 
 INVENTORY_HOSTS_PATH = "/hosts"
@@ -79,21 +77,3 @@ def find_hosts(host_id_list, api_url, auth=None, x_rh_identity=None):
                      'get',
                      lambda status: status == 200)
     return results
-
-
-def create_identity(account_number, org_id=None):
-    """Base64-encoded JSON identity."""
-    identity = {'identity': {'account_number': account_number}}
-    if org_id:
-        identity['identity']['internal'] = {'org_id': org_id}
-    identity = json.dumps(identity)
-    identity = base64.standard_b64encode(identity.encode('ascii'))
-    identity = identity.decode('ascii')
-    return identity
-
-
-def create_x_rh_identity(account_number):
-    """"Base64-encoded JSON identity header provided by 3Scale."""
-    identity = create_identity(account_number)
-    x_rh_identity = {'x-rh-identity': identity}
-    return x_rh_identity

--- a/camayoc/inventory.py
+++ b/camayoc/inventory.py
@@ -1,0 +1,99 @@
+# coding=utf-8
+"""Host Based Inventory (HBI) API."""
+
+import requests
+import json
+import base64
+import urllib3
+
+INVENTORY_HOSTS_PATH = "/hosts"
+"""The path to the endpoint used for obaining hosts facts."""
+
+
+# Suppress HTTPS warnings against our test server without a cert
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+def _request(method, url, **kwargs):
+    response = requests.request(method, url, **kwargs)
+    return response
+
+
+def _parse_response(response, cond=lambda status: 200 <= status < 400):
+    if cond(response.status_code):
+        return True, response.json()
+    return False, response.text
+
+
+def client(url,
+           auth,
+           x_rh_identity=None,
+           method='get',
+           cond=lambda status: 200 <= status < 400):
+    """Simple REST API client."""
+    headers = {}
+    if x_rh_identity:
+        headers = x_rh_identity
+    in_pagination = True
+    params = {}
+    count = 0
+    results = []
+    while in_pagination:
+        response = _request(method,
+                            url,
+                            auth=auth,
+                            params=params,
+                            headers=headers,
+                            verify=False)
+        ok, info = _parse_response(response, cond)
+        if not ok:
+            raise RuntimeError(info)
+        count += info['count']
+        if info['total'] <= count:
+            in_pagination = False
+        else:
+            page = info['page'] + 1
+            params = {'page': page}
+        results.extend(info['results'])
+    return results
+
+
+def get_hosts(api_url, auth=None, x_rh_identity=None):
+    """Read the entire list of hosts."""
+    url = f'{api_url}/{INVENTORY_HOSTS_PATH}'
+    results = client(url,
+                     auth,
+                     x_rh_identity,
+                     'get',
+                     lambda status: status == 200)
+    return results
+
+
+def find_hosts(host_id_list, api_url, auth=None, x_rh_identity=None):
+    """Find one or more hosts by their ID."""
+    hosts = ','.join(host_id_list)
+    url = f'{api_url}/{INVENTORY_HOSTS_PATH}/{hosts}'
+    results = client(url,
+                     auth,
+                     x_rh_identity,
+                     'get',
+                     lambda status: status == 200)
+    return results
+
+
+def create_identity(account_number, org_id=None):
+    """Base64-encoded JSON identity."""
+    identity = {'identity': {'account_number': account_number}}
+    if org_id:
+        identity['identity']['internal'] = {'org_id': org_id}
+    identity = json.dumps(identity)
+    identity = base64.standard_b64encode(identity.encode('ascii'))
+    identity = identity.decode('ascii')
+    return identity
+
+
+def create_x_rh_identity(account_number):
+    """"Base64-encoded JSON identity header provided by 3Scale."""
+    identity = create_identity(account_number)
+    x_rh_identity = {'x-rh-identity': identity}
+    return x_rh_identity

--- a/camayoc/tests/qpc/yupana/conftest.py
+++ b/camayoc/tests/qpc/yupana/conftest.py
@@ -6,13 +6,13 @@ import time
 
 from camayoc.tests.qpc.yupana.utils import (
     get_app_pods,
-    get_x_rh_identity,
     post_file,
     time_diff,
 )
 
 from camayoc.config import get_config
 from camayoc.exceptions import ConfigFileNotFoundError
+from camayoc.utils import create_identity
 
 
 @pytest.fixture(scope="session")
@@ -46,16 +46,17 @@ def mult_pod_logs(yupana_config):
     pod_names = [
         pod[0] for pod in get_app_pods(yupana_config["yupana-app"]["app_name"])
     ]
+    rh_identity = create_identity(
+        upload_service_config["rh_account_number"],
+        upload_service_config["rh_org_id"]
+    )
     start_time = time.time()
     response = post_file(
         upload_service_config["file_upload_src"],
         upload_service_config["api_url"],
         upload_service_config["rh_username"],
         upload_service_config["rh_password"],
-        get_x_rh_identity(
-            upload_service_config["rh_account_number"],
-            upload_service_config["rh_org_id"],
-        ),
+        rh_identity,
         upload_service_config["rh_insights_request_id"],
     )
     assert response.status_code == 202, response.text

--- a/camayoc/tests/qpc/yupana/utils.py
+++ b/camayoc/tests/qpc/yupana/utils.py
@@ -2,8 +2,6 @@
 """Utility functions for yupana tests."""
 
 
-import base64
-import json
 import re
 import requests
 import time
@@ -17,15 +15,6 @@ PATTERN_DATE_TIME = r"(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})"
 
 
 # Functions
-def get_x_rh_identity(account_num, org_id):
-    """Return the base64 encoded x-rh-identity string from credentials."""
-    login_data = {
-        "identity": {"account_number": account_num, "internal": {"org_id": org_id}}
-    }
-    json_str = json.dumps(login_data)
-    return base64.b64encode(json_str.encode("ascii"))
-
-
 def get_app_url(yupana_config, protocol="http://"):
     """Build and return the URI from the config to access the yupana API"""
     config = yupana_config["yupana-app"]

--- a/camayoc/utils.py
+++ b/camayoc/utils.py
@@ -6,6 +6,8 @@ import os
 import shutil
 import tempfile
 import uuid
+import json
+import base64
 from urllib.parse import urlunparse
 
 from camayoc import exceptions
@@ -77,3 +79,21 @@ def isolated_filesystem():
             shutil.rmtree(path)
         except (OSError, IOError):
             pass
+
+
+def create_identity(account_number, org_id=None):
+    """Base64-encoded JSON identity."""
+    identity = {'identity': {'account_number': account_number}}
+    if org_id is not None:
+        identity['identity']['internal'] = {'org_id': org_id}
+    identity = json.dumps(identity)
+    identity = base64.standard_b64encode(identity.encode('ascii'))
+    identity = identity.decode('ascii')
+    return identity
+
+
+def create_x_rh_identity(account_number, org_id=None):
+    """"Base64-encoded JSON identity header provided by 3Scale."""
+    identity = create_identity(account_number, org_id)
+    x_rh_identity = {'x-rh-identity': identity}
+    return x_rh_identity

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -143,3 +143,9 @@ yupana:
     oc:
       url: "OC_API_URL"
       token: "SECRET_TOKEN"
+    inventory:
+      api_url: "https://qa.cloud.com/api/inventory/v1/"
+      rh_username: "USERNAME"
+      rh_password: "PASSWORD"
+      rh_account_number: "000000"
+      rh_org_id: "0000000"


### PR DESCRIPTION
This module allows one to query the host based inventory, like this:

```Python
>>> from camayoc import config 
>>> from camayoc import inventory
>>> cfg = config.get_config()
>>> cfg['yupana']['inventory']
{'api_url': 'https://ci.example.com/api/inventory/v1/',
 'rh_username': 'test',
 'rh_password': 'example',
 'rh_account_number': '000001',
 'rh_org_id': '0000001'}
>>> cfg_inv  = cfg['yupana']['inventory']
```

Then we can get the whole host inventory as a list:
```Python
>>> auth = (cfg_inv['rh_username'], cfg_Inv['rh_password'])
>>> url = cfg_inv['api_url']
>>> inventory.get_hosts(url=url, auth=auth)
```

If something is wrong, then an exception of kind `RuntimeError()` will be raised.
There is also a function to query for a list of host ids, use `inventory.find_hosts` for that.
There is also support for passing account number and org id in these functions.

```
>>> from camayoc import utils
>>> x_rh_id = utils.create_indentity(cfg_inv['account_number])
>>> x_rh_id = utils.create_indentity(cfg_inv['account_number], cfg_inv['org_id'])
>>> inventory.get_hosts(url=url, auth=auth, x_rh_identity=x_rh_id)
```

This PR closes #332 