### PR TITLE
Issues/336

### DIFF
--- a/camayoc/tests/qpc/api/v1/credentials/test_network_creds.py
+++ b/camayoc/tests/qpc/api/v1/credentials/test_network_creds.py
@@ -11,11 +11,13 @@
 """
 from pathlib import Path
 
+import os
 import pytest
 
 import requests
 
 from camayoc import api
+from camayoc import utils
 from camayoc.constants import QPC_BECOME_METHODS
 from camayoc.qpc_models import Credential
 from camayoc.tests.qpc.utils import assert_matches_server
@@ -40,10 +42,12 @@ def test_update_password_to_sshkeyfile(shared_client, cleanup, isolated_filesyst
     cleanup.append(cred)
     assert_matches_server(cred)
 
-    sshkeyfile = Path(uuid4())
+    sshkeyfile_name = utils.uuid4()
+    tmp_dir = os.path.basename(os.getcwd())
+    sshkeyfile = Path(sshkeyfile_name)
     sshkeyfile.touch()
 
-    cred.ssh_keyfile = str(sshkeyfile.resolve())
+    cred.ssh_keyfile = f"/sshkeys/{tmp_dir}/{sshkeyfile_name}"
     cred.password = None
     cred.update()
     assert_matches_server(cred)
@@ -62,10 +66,12 @@ def test_update_sshkey_to_password(shared_client, cleanup, isolated_filesystem):
         3) Confirm network credential has been updated.
     :expectedresults: The network credential is updated.
     """
-    ssh_keyfile = Path(uuid4())
-    ssh_keyfile.touch()
+    sshkeyfile_name = utils.uuid4()
+    tmp_dir = os.path.basename(os.getcwd())
+    sshkeyfile = Path(sshkeyfile_name)
+    sshkeyfile.touch()
 
-    cred = Credential(cred_type="network", ssh_keyfile=str(ssh_keyfile.resolve()))
+    cred = Credential(cred_type="network", ssh_keyfile=f"/sshkeys/{tmp_dir}/{sshkeyfile_name}")
     cred.create()
     # add the id to the list to destroy after the test is done
     cleanup.append(cred)
@@ -91,13 +97,15 @@ def test_negative_update_to_invalid(shared_client, cleanup, isolated_filesystem)
     :expectedresults: Error codes are returned and the network credentials are
         not updated.
     """
-    ssh_keyfile = Path(uuid4())
-    ssh_keyfile.touch()
+    sshkeyfile_name = utils.uuid4()
+    tmp_dir = os.path.basename(os.getcwd())
+    sshkeyfile = Path(sshkeyfile_name)
+    sshkeyfile.touch()
 
     cred = Credential(
         cred_type="network",
         client=shared_client,
-        ssh_keyfile=str(ssh_keyfile.resolve()),
+        ssh_keyfile=f"/sshkeys/{tmp_dir}/{sshkeyfile_name}",
     )
     cred.create()
     # add the id to the list to destroy after the test is done
@@ -132,13 +140,15 @@ def test_create_with_sshkey(shared_client, cleanup, isolated_filesystem):
     :steps: Send POST with necessary data to documented api endpoint.
     :expectedresults: A new network credential entry is created with the data.
     """
-    ssh_keyfile = Path(uuid4())
-    ssh_keyfile.touch()
+    sshkeyfile_name = utils.uuid4()
+    tmp_dir = os.path.basename(os.getcwd())
+    sshkeyfile = Path(sshkeyfile_name)
+    sshkeyfile.touch()
 
     cred = Credential(
         cred_type="network",
         client=shared_client,
-        ssh_keyfile=str(ssh_keyfile.resolve()),
+        ssh_keyfile=f"/sshkeys/{tmp_dir}/{sshkeyfile_name}",
     )
     cred.create()
     # add the id to the list to destroy after the test is done

--- a/camayoc/tests/qpc/api/v1/sources/test_network_sources.py
+++ b/camayoc/tests/qpc/api/v1/sources/test_network_sources.py
@@ -10,11 +10,14 @@
 :upstream: yes
 """
 import copy
+import os
+
 from pathlib import Path
 
 import pytest
 
 from camayoc import api
+from camayoc import utils
 from camayoc.qpc_models import Credential, Source
 from camayoc.tests.qpc.utils import assert_matches_server, assert_source_update_fails
 from camayoc.utils import uuid4
@@ -67,13 +70,15 @@ def test_create_multiple_creds(shared_client, cleanup, scan_host, isolated_files
         2) Send POST with data to create network source using the credentials
     :expectedresults: The source is created.
     """
-    ssh_keyfile = Path(uuid4())
-    ssh_keyfile.touch()
+    sshkeyfile_name = utils.uuid4()
+    tmp_dir = os.path.basename(os.getcwd())
+    sshkeyfile = Path(sshkeyfile_name)
+    sshkeyfile.touch()
 
     ssh_key_cred = Credential(
         cred_type=NETWORK_TYPE,
         client=shared_client,
-        ssh_keyfile=str(ssh_keyfile.resolve()),
+        ssh_keyfile=f"/sshkeys/{tmp_dir}/{sshkeyfile_name}",
     )
     ssh_key_cred.create()
     pwd_cred = Credential(
@@ -109,13 +114,15 @@ def test_create_multiple_creds_and_sources(
            CIDR, individual IPv4 address, etc.)
     :expectedresults: The source is created.
     """
-    ssh_keyfile = Path(uuid4())
-    ssh_keyfile.touch()
+    sshkeyfile_name = utils.uuid4()
+    tmp_dir = os.path.basename(os.getcwd())
+    sshkeyfile = Path(sshkeyfile_name)
+    sshkeyfile.touch()
 
     ssh_key_cred = Credential(
         cred_type=NETWORK_TYPE,
         client=shared_client,
-        ssh_keyfile=str(ssh_keyfile.resolve()),
+        ssh_keyfile=f"/sshkeys/{tmp_dir}/{sshkeyfile_name}",
     )
     ssh_key_cred.create()
     pwd_cred = Credential(
@@ -156,13 +163,15 @@ def test_negative_update_invalid(
         2) Attempt to update with multiple invalid {hosts, credentials}
     :expectedresults: An error is thrown and no new host is created.
     """
-    ssh_keyfile = Path(uuid4())
-    ssh_keyfile.touch()
+    sshkeyfile_name = utils.uuid4()
+    tmp_dir = os.path.basename(os.getcwd())
+    sshkeyfile = Path(sshkeyfile_name)
+    sshkeyfile.touch()
 
     net_cred = Credential(
         cred_type=NETWORK_TYPE,
         client=shared_client,
-        ssh_keyfile=str(ssh_keyfile.resolve()),
+        ssh_keyfile=f"/sshkeys/{tmp_dir}/{sshkeyfile_name}",
     )
     net_cred.create()
     sat_cred = Credential(cred_type="satellite", client=shared_client, password=uuid4())

--- a/camayoc/tests/qpc/cli/test_credentials.py
+++ b/camayoc/tests/qpc/cli/test_credentials.py
@@ -140,14 +140,12 @@ def test_add_with_username_sshkeyfile(isolated_filesystem, qpc_server_config):
     sshkeyfile = '/sshkeys/id_rsa'
 
     cred_add_and_check(
-# {"name": name, "username": username, "sshkeyfile": str(sshkeyfile.resolve())}
         {"name": name, "username": username, "sshkeyfile": sshkeyfile}
     )
 
     cred_show_and_check(
         {"name": name},
         generate_show_output(
-# {"name": name, "ssh_keyfile": sshkeyfile.resolve(), "username": username}
             {"name": name, "ssh_keyfile": sshkeyfile, "username": username}
         ),
     )

--- a/camayoc/tests/qpc/cli/test_credentials.py
+++ b/camayoc/tests/qpc/cli/test_credentials.py
@@ -135,17 +135,20 @@ def test_add_with_username_sshkeyfile(isolated_filesystem, qpc_server_config):
     """
     name = utils.uuid4()
     username = utils.uuid4()
-    #sshkeyfile = Path(utils.uuid4())
-    #sshkeyfile.touch()
+    # sshkeyfile = Path(utils.uuid4())
+    # sshkeyfile.touch()
     sshkeyfile = '/sshkeys/id_rsa'
+
     cred_add_and_check(
-        {"name": name, "username": username, "sshkeyfile": str(sshkeyfile.resolve())}
+# {"name": name, "username": username, "sshkeyfile": str(sshkeyfile.resolve())}
+        {"name": name, "username": username, "sshkeyfile": sshkeyfile}
     )
 
     cred_show_and_check(
         {"name": name},
         generate_show_output(
-            {"name": name, "ssh_keyfile": sshkeyfile.resolve(), "username": username}
+# {"name": name, "ssh_keyfile": sshkeyfile.resolve(), "username": username}
+            {"name": name, "ssh_keyfile": sshkeyfile, "username": username}
         ),
     )
 

--- a/camayoc/tests/qpc/cli/test_credentials.py
+++ b/camayoc/tests/qpc/cli/test_credentials.py
@@ -10,6 +10,7 @@
 :upstream: yes
 """
 import json
+import os
 import random
 from io import BytesIO
 from pathlib import Path
@@ -136,18 +137,19 @@ def test_add_with_username_sshkeyfile(isolated_filesystem, qpc_server_config):
     name = utils.uuid4()
     username = utils.uuid4()
     sshkeyfile_name = utils.uuid4()
+    tmp_dir = os.path.basename(os.getcwd())
     sshkeyfile = Path(sshkeyfile_name)
     sshkeyfile.touch()
 #    sshkeyfile = '/sshkeys/id_rsa'
 
     cred_add_and_check(
-        {"name": name, "username": username, "sshkeyfile": "/sshkeys/" + sshkeyfile_name}
+        {"name": name, "username": username, "sshkeyfile": "/sshkeys/" + tmp_dir + "/" + sshkeyfile_name}
     )
 
     cred_show_and_check(
         {"name": name},
         generate_show_output(
-            {"name": name, "ssh_keyfile": "/sshkeys/" + sshkeyfile_name, "username": username}
+            {"name": name, "ssh_keyfile": "/sshkeys/" + tmp_dir + "/" + sshkeyfile_name, "username": username}
         ),
     )
 

--- a/camayoc/tests/qpc/cli/test_credentials.py
+++ b/camayoc/tests/qpc/cli/test_credentials.py
@@ -141,13 +141,13 @@ def test_add_with_username_sshkeyfile(isolated_filesystem, qpc_server_config):
 #    sshkeyfile = '/sshkeys/id_rsa'
 
     cred_add_and_check(
-        {"name": name, "username": username, "sshkeyfile": sshkeyfile_name}
+        {"name": name, "username": username, "sshkeyfile": "/sshkeys/" + sshkeyfile_name}
     )
 
     cred_show_and_check(
         {"name": name},
         generate_show_output(
-            {"name": name, "ssh_keyfile": sshkeyfile_name, "username": username}
+            {"name": name, "ssh_keyfile": "/sshkeys/" + sshkeyfile_name, "username": username}
         ),
     )
 

--- a/camayoc/tests/qpc/cli/test_credentials.py
+++ b/camayoc/tests/qpc/cli/test_credentials.py
@@ -143,13 +143,13 @@ def test_add_with_username_sshkeyfile(isolated_filesystem, qpc_server_config):
 #    sshkeyfile = '/sshkeys/id_rsa'
 
     cred_add_and_check(
-        {"name": name, "username": username, "sshkeyfile": "/sshkeys/" + tmp_dir + "/" + sshkeyfile_name}
+        {"name": name, "username": username, "sshkeyfile": f"/sshkeys/{tmp_dir}/{sshkeyfile_name}"}
     )
 
     cred_show_and_check(
         {"name": name},
         generate_show_output(
-            {"name": name, "ssh_keyfile": "/sshkeys/" + tmp_dir + "/" + sshkeyfile_name, "username": username}
+            {"name": name, "ssh_keyfile": f"/sshkeys/{tmp_dir}/{sshkeyfile_name}", "username": username}
         ),
     )
 

--- a/camayoc/tests/qpc/cli/test_credentials.py
+++ b/camayoc/tests/qpc/cli/test_credentials.py
@@ -723,4 +723,4 @@ def test_clear_all(isolated_filesystem, qpc_server_config):
         "{} cred list".format(client_cmd), encoding="utf8", withexitstatus=True
     )
     assert "No credentials exist yet." in output
-    ssert exitstatus == 0
+    assert exitstatus == 0

--- a/camayoc/tests/qpc/cli/test_credentials.py
+++ b/camayoc/tests/qpc/cli/test_credentials.py
@@ -421,18 +421,21 @@ def test_edit_sshkeyfile_negative(isolated_filesystem, qpc_server_config):
     """
     name = utils.uuid4()
     username = utils.uuid4()
-    sshkeyfile = Path(utils.uuid4())
+    tmp_dir = os.path.basename(os.getcwd())
+    sshkeyfile_name = utils.uuid4()
+    sshkeyfile = Path(sshkeyfile_name)
     sshkeyfile.touch()
     cred_add_and_check(
-        {"name": name, "username": username, "sshkeyfile": str(sshkeyfile.resolve())}
+        {"name": name, "username": username, "sshkeyfile": f"/sshkeys/{tmp_dir}/{sshkeyfile_name}"}
     )
 
     name = utils.uuid4()
-    sshkeyfile = Path(utils.uuid4())
+    sshkeyfile_name = utils.uuid4()
+    sshkeyfile = Path(sshkeyfile_name)
     sshkeyfile.touch()
     qpc_cred_edit = pexpect.spawn(
         "{} cred edit --name={} --sshkeyfile {}".format(
-            client_cmd, name, str(sshkeyfile.resolve())
+            client_cmd, name, f"/sshkeys/{tmp_dir}/{sshkeyfile_name}"
         )
     )
     qpc_cred_edit.logfile = BytesIO()
@@ -452,7 +455,10 @@ def test_edit_become_password(isolated_filesystem, qpc_server_config):
     """
     name = utils.uuid4()
     username = utils.uuid4()
-    sshkeyfile = Path(utils.uuid4())
+
+    tmp_dir = os.path.basename(os.getcwd())
+    sshkeyfile_name = utils.uuid4()
+    sshkeyfile = Path(sshkeyfile_name)
     sshkeyfile.touch()
     become_password = utils.uuid4()
     new_become_password = utils.uuid4()
@@ -460,7 +466,7 @@ def test_edit_become_password(isolated_filesystem, qpc_server_config):
         {
             "name": name,
             "username": username,
-            "sshkeyfile": str(sshkeyfile.resolve()),
+            "sshkeyfile": f"/sshkeys/{tmp_dir}/{sshkeyfile_name}",
             "become-password": None,
         },
         [(BECOME_PASSWORD_INPUT, become_password)],
@@ -472,7 +478,7 @@ def test_edit_become_password(isolated_filesystem, qpc_server_config):
             {
                 "become_password": MASKED_PASSWORD_OUTPUT,
                 "name": name,
-                "ssh_keyfile": sshkeyfile.resolve(),
+                "ssh_keyfile": f"/sshkeys/{tmp_dir}/{sshkeyfile_name}",
                 "username": username,
             }
         ),
@@ -494,7 +500,7 @@ def test_edit_become_password(isolated_filesystem, qpc_server_config):
             {
                 "become_password": MASKED_PASSWORD_OUTPUT,
                 "name": name,
-                "ssh_keyfile": sshkeyfile.resolve(),
+                "ssh_keyfile": f"/sshkeys/{tmp_dir}/{sshkeyfile_name}",
                 "username": username,
             }
         ),
@@ -511,10 +517,12 @@ def test_edit_become_password_negative(isolated_filesystem, qpc_server_config):
     """
     name = utils.uuid4()
     username = utils.uuid4()
-    sshkeyfile = Path(utils.uuid4())
+    tmp_dir = os.path.basename(os.getcwd())
+    sshkeyfile_name = utils.uuid4()
+    sshkeyfile = Path(sshkeyfile_name)
     sshkeyfile.touch()
     cred_add_and_check(
-        {"name": name, "username": username, "sshkeyfile": str(sshkeyfile.resolve())}
+        {"name": name, "username": username, "sshkeyfile": f"/sshkeys/{tmp_dir}/{sshkeyfile_name}"}
     )
 
     name = utils.uuid4()
@@ -538,11 +546,13 @@ def test_edit_no_credentials(isolated_filesystem, qpc_server_config):
     :expectedresults: The command should fail with a proper message.
     """
     name = utils.uuid4()
-    sshkeyfile = Path(utils.uuid4())
+    tmp_dir = os.path.basename(os.getcwd())
+    sshkeyfile_name = utils.uuid4()
+    sshkeyfile = Path(sshkeyfile_name)
     sshkeyfile.touch()
     qpc_cred_edit = pexpect.spawn(
         "{} cred edit --name={} --sshkeyfile {}".format(
-            client_cmd, name, str(sshkeyfile.resolve())
+            client_cmd, name, f"/sshkeys/{tmp_dir}/{sshkeyfile_name}"
         )
     )
     qpc_cred_edit.logfile = BytesIO()
@@ -563,16 +573,19 @@ def test_clear(isolated_filesystem, qpc_server_config):
     """
     name = utils.uuid4()
     username = utils.uuid4()
-    sshkeyfile = Path(utils.uuid4())
+
+    tmp_dir = os.path.basename(os.getcwd())
+    sshkeyfile_name = utils.uuid4()
+    sshkeyfile = Path(sshkeyfile_name)
     sshkeyfile.touch()
     cred_add_and_check(
-        {"name": name, "username": username, "sshkeyfile": str(sshkeyfile.resolve())}
+        {"name": name, "username": username, "sshkeyfile": f"/sshkeys/{tmp_dir}/{sshkeyfile_name}"}
     )
 
     cred_show_and_check(
         {"name": name},
         generate_show_output(
-            {"name": name, "ssh_keyfile": sshkeyfile.resolve(), "username": username}
+            {"name": name, "ssh_keyfile": f"/sshkeys/{tmp_dir}/{sshkeyfile_name}", "username": username}
         ),
     )
 
@@ -613,14 +626,17 @@ def test_clear_with_source(isolated_filesystem, qpc_server_config):
     source_name = utils.uuid4()
     hosts = ["127.0.0.1"]
     username = utils.uuid4()
-    sshkeyfile = Path(utils.uuid4())
+
+    tmp_dir = os.path.basename(os.getcwd())
+    sshkeyfile_name = utils.uuid4()
+    sshkeyfile = Path(sshkeyfile_name)
     sshkeyfile.touch()
     cred_add_and_check(
         {
             "name": cred_name,
             "type": cred_type,
             "username": username,
-            "sshkeyfile": str(sshkeyfile.resolve()),
+            "sshkeyfile": f"/sshkeys/{tmp_dir}/{sshkeyfile_name}",
         }
     )
 
@@ -629,7 +645,7 @@ def test_clear_with_source(isolated_filesystem, qpc_server_config):
         generate_show_output(
             {
                 "name": cred_name,
-                "ssh_keyfile": sshkeyfile.resolve(),
+                "ssh_keyfile": f"/sshkeys/{tmp_dir}/{sshkeyfile_name}",
                 "username": username,
             }
         ),
@@ -708,12 +724,15 @@ def test_clear_all(isolated_filesystem, qpc_server_config):
     for _ in range(random.randint(2, 3)):
         name = utils.uuid4()
         username = utils.uuid4()
-        sshkeyfile = Path(utils.uuid4())
+
+        tmp_dir = os.path.basename(os.getcwd())
+        sshkeyfile_name = utils.uuid4()
+        sshkeyfile = Path(sshkeyfile_name)
         sshkeyfile.touch()
         auth = {
             "name": name,
             "password": None,
-            "ssh_keyfile": str(sshkeyfile.resolve()),
+            "ssh_keyfile": f"/sshkeys/{tmp_dir}/{sshkeyfile_name}",
             "become_password": None,
             "username": username,
         }
@@ -722,7 +741,7 @@ def test_clear_all(isolated_filesystem, qpc_server_config):
             {
                 "name": name,
                 "username": username,
-                "sshkeyfile": str(sshkeyfile.resolve()),
+                "sshkeyfile": f"/sshkeys/{tmp_dir}/{sshkeyfile_name}",
             }
         )
 

--- a/camayoc/tests/qpc/cli/test_credentials.py
+++ b/camayoc/tests/qpc/cli/test_credentials.py
@@ -169,13 +169,16 @@ def test_add_with_username_sshkeyfile_become_password(
     """
     name = utils.uuid4()
     username = utils.uuid4()
-    sshkeyfile = Path(utils.uuid4())
+    sshkeyfile_name = utils.uuid4()
+    tmp_dir = os.path.basename(os.getcwd())
+    sshkeyfile = Path(sshkeyfile_name)
     sshkeyfile.touch()
+
     cred_add_and_check(
         {
             "name": name,
             "username": username,
-            "sshkeyfile": str(sshkeyfile.resolve()),
+            "sshkeyfile": f"/sshkeys/{tmp_dir}/{sshkeyfile_name}",
             "become-password": None,
         },
         [(BECOME_PASSWORD_INPUT, utils.uuid4())],
@@ -187,7 +190,7 @@ def test_add_with_username_sshkeyfile_become_password(
             {
                 "become_password": MASKED_PASSWORD_OUTPUT,
                 "name": name,
-                "ssh_keyfile": sshkeyfile.resolve(),
+                "sshkeyfile": f"/sshkeys/{tmp_dir}/{sshkeyfile_name}",
                 "username": username,
             }
         ),
@@ -255,10 +258,12 @@ def test_edit_username_negative(isolated_filesystem, qpc_server_config):
     """
     name = utils.uuid4()
     username = utils.uuid4()
-    sshkeyfile = Path(utils.uuid4())
+    sshkeyfile_name = utils.uuid4()
+    tmp_dir = os.path.basename(os.getcwd())
+    sshkeyfile = Path(sshkeyfile_name)
     sshkeyfile.touch()
     cred_add_and_check(
-        {"name": name, "username": username, "sshkeyfile": str(sshkeyfile.resolve())}
+        {"name": name, "username": username, "sshkeyfile": f"/sshkeys/{tmp_dir}/{sshkeyfile_name}"}
     )
 
     name = utils.uuid4()
@@ -336,10 +341,12 @@ def test_edit_password_negative(isolated_filesystem, qpc_server_config):
     """
     name = utils.uuid4()
     username = utils.uuid4()
-    sshkeyfile = Path(utils.uuid4())
+    sshkeyfile_name = utils.uuid4()
+    tmp_dir = os.path.basename(os.getcwd())
+    sshkeyfile = Path(sshkeyfile_name)
     sshkeyfile.touch()
     cred_add_and_check(
-        {"name": name, "username": username, "sshkeyfile": str(sshkeyfile.resolve())}
+        {"name": name, "username": username, "sshkeyfile": f"/sshkeys/{tmp_dir}/{sshkeyfile_name}"}
     )
 
     name = utils.uuid4()
@@ -360,24 +367,29 @@ def test_edit_sshkeyfile(isolated_filesystem, qpc_server_config):
     """
     name = utils.uuid4()
     username = utils.uuid4()
-    sshkeyfile = Path(utils.uuid4())
+
+    tmp_dir = os.path.basename(os.getcwd())
+    sshkeyfile_name = utils.uuid4()
+    sshkeyfile = Path(sshkeyfile_name)
     sshkeyfile.touch()
-    new_sshkeyfile = Path(utils.uuid4())
+    new_sshkeyfile_name = utils.uuid4()
+    new_sshkeyfile = Path(new_sshkeyfile_name)
     new_sshkeyfile.touch()
+
     cred_add_and_check(
-        {"name": name, "username": username, "sshkeyfile": str(sshkeyfile.resolve())}
+        {"name": name, "username": username, "sshkeyfile": f"/sshkeys/{tmp_dir}/{sshkeyfile_name}"}
     )
 
     cred_show_and_check(
         {"name": name},
         generate_show_output(
-            {"name": name, "ssh_keyfile": sshkeyfile.resolve(), "username": username}
+            {"name": name, "ssh_keyfile": f"/sshkeys/{tmp_dir}/{sshkeyfile_name}", "username": username}
         ),
     )
 
     qpc_cred_edit = pexpect.spawn(
         "{} cred edit --name={} --sshkeyfile {}".format(
-            client_cmd, name, str(new_sshkeyfile.resolve())
+            client_cmd, name, f"/sshkeys/{tmp_dir}/{new_sshkeyfile_name}"
         )
     )
     qpc_cred_edit.logfile = BytesIO()
@@ -391,7 +403,7 @@ def test_edit_sshkeyfile(isolated_filesystem, qpc_server_config):
         generate_show_output(
             {
                 "name": name,
-                "ssh_keyfile": new_sshkeyfile.resolve(),
+                "ssh_keyfile": f"/sshkeys/{tmp_dir}/{new_sshkeyfile_name}",
                 "username": username,
             }
         ),

--- a/camayoc/tests/qpc/cli/test_credentials.py
+++ b/camayoc/tests/qpc/cli/test_credentials.py
@@ -135,8 +135,9 @@ def test_add_with_username_sshkeyfile(isolated_filesystem, qpc_server_config):
     """
     name = utils.uuid4()
     username = utils.uuid4()
-    sshkeyfile = Path(utils.uuid4())
-    sshkeyfile.touch()
+    #sshkeyfile = Path(utils.uuid4())
+    #sshkeyfile.touch()
+    sshkeyfile = '/sshkeys/id_rsa'
     cred_add_and_check(
         {"name": name, "username": username, "sshkeyfile": str(sshkeyfile.resolve())}
     )

--- a/camayoc/tests/qpc/cli/test_credentials.py
+++ b/camayoc/tests/qpc/cli/test_credentials.py
@@ -142,7 +142,7 @@ def test_add_with_username_sshkeyfile(isolated_filesystem, qpc_server_config):
 
     cred_add_and_check(
         {"name": name, "username": username, "sshkeyfile":
-         str(sshkeyfile.reslove())}
+         str(sshkeyfile.resolve())}
     )
 
     cred_show_and_check(
@@ -723,4 +723,4 @@ def test_clear_all(isolated_filesystem, qpc_server_config):
         "{} cred list".format(client_cmd), encoding="utf8", withexitstatus=True
     )
     assert "No credentials exist yet." in output
-    assert exitstatus == 0
+    ssert exitstatus == 0

--- a/camayoc/tests/qpc/cli/test_credentials.py
+++ b/camayoc/tests/qpc/cli/test_credentials.py
@@ -141,14 +141,13 @@ def test_add_with_username_sshkeyfile(isolated_filesystem, qpc_server_config):
 #    sshkeyfile = '/sshkeys/id_rsa'
 
     cred_add_and_check(
-        {"name": name, "username": username, "sshkeyfile":
-         str(sshkeyfile.resolve())}
+        {"name": name, "username": username, "sshkeyfile": sshkeyfile_name}
     )
 
     cred_show_and_check(
         {"name": name},
         generate_show_output(
-            {"name": name, "ssh_keyfile": sshkeyfile.resolve(), "username": username}
+            {"name": name, "ssh_keyfile": sshkeyfile_name, "username": username}
         ),
     )
 

--- a/camayoc/tests/qpc/cli/test_credentials.py
+++ b/camayoc/tests/qpc/cli/test_credentials.py
@@ -135,18 +135,20 @@ def test_add_with_username_sshkeyfile(isolated_filesystem, qpc_server_config):
     """
     name = utils.uuid4()
     username = utils.uuid4()
-    # sshkeyfile = Path(utils.uuid4())
-    # sshkeyfile.touch()
-    sshkeyfile = '/sshkeys/id_rsa'
+    sshkeyfile_name = utils.uuid4()
+    sshkeyfile = Path(sshkeyfile_name)
+    sshkeyfile.touch()
+#    sshkeyfile = '/sshkeys/id_rsa'
 
     cred_add_and_check(
-        {"name": name, "username": username, "sshkeyfile": sshkeyfile}
+        {"name": name, "username": username, "sshkeyfile":
+         str(sshkeyfile.reslove())}
     )
 
     cred_show_and_check(
         {"name": name},
         generate_show_output(
-            {"name": name, "ssh_keyfile": sshkeyfile, "username": username}
+            {"name": name, "ssh_keyfile": sshkeyfile.resolve(), "username": username}
         ),
     )
 

--- a/camayoc/utils.py
+++ b/camayoc/utils.py
@@ -65,7 +65,7 @@ def isolated_filesystem():
     cfg = get_config().get("qpc", {})
     isolated_filesystem_prefix = cfg.get("isolated_filesystem_prefix")
     cwd = os.getcwd()
-    path = tempfile.mkdtemp(prefix=isolated_filesystem_prefix)
+    path = tempfile.mkdtemp(dir=isolated_filesystem_prefix)
     for envvar in _XDG_ENV_VARS:
         os.environ[envvar] = path
     os.chdir(path)

--- a/camayoc/utils.py
+++ b/camayoc/utils.py
@@ -62,8 +62,10 @@ def isolated_filesystem():
     Changes the current working directory to the created temporary directory
     for isolated filesystem tests.
     """
+    cfg = get_config().get("qpc", {})
+    isolated_filesystem_prefix = cfg.get("isolated_filesystem_prefix")
     cwd = os.getcwd()
-    path = tempfile.mkdtemp()
+    path = tempfile.mkdtemp(prefix=isolated_filesystem_prefix)
     for envvar in _XDG_ENV_VARS:
         os.environ[envvar] = path
     os.chdir(path)

--- a/camayoc/utils.py
+++ b/camayoc/utils.py
@@ -65,7 +65,7 @@ def isolated_filesystem():
     cfg = get_config().get("qpc", {})
     isolated_filesystem_prefix = cfg.get("isolated_filesystem_prefix")
     cwd = os.getcwd()
-    path = tempfile.mkdtemp(dir=isolated_filesystem_prefix)
+    path = tempfile.mkdtemp(dir=isolated_filesystem_prefix, prefix="")
     for envvar in _XDG_ENV_VARS:
         os.environ[envvar] = path
     os.chdir(path)


### PR DESCRIPTION
This PR applies changes to fix the CLI and API tests that are failing due to the `sshkeyfile` not being defined using the container's path. Since moving to using the installer for test setup, these tests haven't worked due to them using a path-name on the host.

This fix utilizes some temporary changes to `isolated_filesystem` to switch the location of the temporary files to a location defined in the camayoc config. In this instance, the `sshkeys` directory of the container's mounted volume. Tests which create/use credentials that include ssh keyfiles were also updated to provide the `qpc` commands the proper path: relative to the container, and containing the correctly temp_dir and filenames generated by `uuid4`.

This fix is likely the first step towards a more permanent solution. While this fixes the problem, it would be clean to have `isolated_filesystem` default to a normal temp location, and _optionally_ switch to the sshkeys mounted volume for tests which require it. (See Camayoc Issue #338).

Closes #336 