### PR TITLE
Issues/338

### DIFF
--- a/camayoc/tests/conftest.py
+++ b/camayoc/tests/conftest.py
@@ -58,11 +58,20 @@ def vcenter_client():
 
 
 @pytest.fixture
-def isolated_filesystem():
+def isolated_filesystem(request):
     """Fixture that creates a temporary directory.
 
     Changes the current working directory to the created temporary directory
     for isolated filesystem tests.
     """
-    with utils.isolated_filesystem() as path:
+    # Setting up marker conditionals
+    mark = request.node.get_closest_marker('ssh_keyfile_path')
+    ssh_keyfile_path = None
+    if mark:
+        cfg = get_config().get("qpc", {})
+        ssh_keyfile_path = cfg.get("ssh_keyfile_path")
+        if not ssh_keyfile_path:
+            pytest.fail("QPC configuration 'ssh_keyfile_path' not provided or "
+                        "found")
+    with utils.isolated_filesystem(ssh_keyfile_path) as path:
         yield path

--- a/camayoc/tests/conftest.py
+++ b/camayoc/tests/conftest.py
@@ -64,7 +64,8 @@ def isolated_filesystem(request):
     Changes the current working directory to the created temporary directory
     for isolated filesystem tests.
     """
-    # Setting up marker conditionals
+    # Create isolated filesystem directory in the ssh_keyfile_path
+    # configuration location if marked with `ssh_keyfile_path`.
     mark = request.node.get_closest_marker('ssh_keyfile_path')
     ssh_keyfile_path = None
     if mark:

--- a/camayoc/tests/qpc/api/v1/credentials/test_network_creds.py
+++ b/camayoc/tests/qpc/api/v1/credentials/test_network_creds.py
@@ -24,6 +24,7 @@ from camayoc.tests.qpc.utils import assert_matches_server
 from camayoc.utils import uuid4
 
 
+@pytest.mark.ssh_keyfile_path
 def test_update_password_to_sshkeyfile(shared_client, cleanup, isolated_filesystem):
     """Create a network credential using password and switch it to use sshkey.
 
@@ -53,6 +54,7 @@ def test_update_password_to_sshkeyfile(shared_client, cleanup, isolated_filesyst
     assert_matches_server(cred)
 
 
+@pytest.mark.ssh_keyfile_path
 def test_update_sshkey_to_password(shared_client, cleanup, isolated_filesystem):
     """Create a network credential using password and switch it to use sshkey.
 
@@ -83,6 +85,7 @@ def test_update_sshkey_to_password(shared_client, cleanup, isolated_filesystem):
     assert_matches_server(cred)
 
 
+@pytest.mark.ssh_keyfile_path
 def test_negative_update_to_invalid(shared_client, cleanup, isolated_filesystem):
     """Attempt to update valid credential with invalid data.
 
@@ -132,6 +135,7 @@ def test_negative_update_to_invalid(shared_client, cleanup, isolated_filesystem)
     assert_matches_server(cred)
 
 
+@pytest.mark.ssh_keyfile_path
 def test_create_with_sshkey(shared_client, cleanup, isolated_filesystem):
     """Create a network credential with username and sshkey.
 

--- a/camayoc/tests/qpc/api/v1/sources/test_network_sources.py
+++ b/camayoc/tests/qpc/api/v1/sources/test_network_sources.py
@@ -59,6 +59,7 @@ def test_create_multiple_hosts(shared_client, cleanup, scan_host):
     assert_matches_server(src)
 
 
+@pytest.mark.ssh_keyfile_path
 @pytest.mark.parametrize("scan_host", CREATE_DATA)
 def test_create_multiple_creds(shared_client, cleanup, scan_host, isolated_filesystem):
     """Create a Network Source using multiple credentials.
@@ -99,6 +100,7 @@ def test_create_multiple_creds(shared_client, cleanup, scan_host, isolated_files
     assert_matches_server(src)
 
 
+@pytest.mark.ssh_keyfile_path
 @pytest.mark.parametrize("scan_host", MIXED_DATA)
 def test_create_multiple_creds_and_sources(
     shared_client, cleanup, scan_host, isolated_filesystem
@@ -149,6 +151,7 @@ def test_create_multiple_creds_and_sources(
     assert_matches_server(src)
 
 
+@pytest.mark.ssh_keyfile_path
 @pytest.mark.parametrize("scan_host", CREATE_DATA)
 def test_negative_update_invalid(
     shared_client, cleanup, isolated_filesystem, scan_host

--- a/camayoc/tests/qpc/cli/test_credentials.py
+++ b/camayoc/tests/qpc/cli/test_credentials.py
@@ -11,6 +11,7 @@
 """
 import json
 import os
+import pytest
 import random
 from io import BytesIO
 from pathlib import Path
@@ -123,6 +124,7 @@ def test_add_with_username_password_become_password(
     )
 
 
+@pytest.mark.ssh_keyfile_path
 def test_add_with_username_sshkeyfile(isolated_filesystem, qpc_server_config):
     """Add an auth with username and sshkeyfile.
 

--- a/camayoc/tests/qpc/cli/test_credentials.py
+++ b/camayoc/tests/qpc/cli/test_credentials.py
@@ -156,6 +156,7 @@ def test_add_with_username_sshkeyfile(isolated_filesystem, qpc_server_config):
     )
 
 
+@pytest.mark.ssh_keyfile_path
 def test_add_with_username_sshkeyfile_become_password(
     isolated_filesystem, qpc_server_config
 ):
@@ -250,6 +251,7 @@ def test_edit_username(isolated_filesystem, qpc_server_config, source_type):
     )
 
 
+@pytest.mark.ssh_keyfile_path
 def test_edit_username_negative(isolated_filesystem, qpc_server_config):
     """Edit the username of a not created auth entry.
 
@@ -332,6 +334,7 @@ def test_edit_password(isolated_filesystem, qpc_server_config, source_type):
     )
 
 
+@pytest.mark.ssh_keyfile_path
 def test_edit_password_negative(isolated_filesystem, qpc_server_config):
     """Edit the password of a not created auth entry.
 
@@ -359,6 +362,7 @@ def test_edit_password_negative(isolated_filesystem, qpc_server_config):
     assert qpc_cred_edit.exitstatus != 0
 
 
+@pytest.mark.ssh_keyfile_path
 def test_edit_sshkeyfile(isolated_filesystem, qpc_server_config):
     """Edit an auth's sshkeyfile.
 
@@ -412,6 +416,7 @@ def test_edit_sshkeyfile(isolated_filesystem, qpc_server_config):
     )
 
 
+@pytest.mark.ssh_keyfile_path
 def test_edit_sshkeyfile_negative(isolated_filesystem, qpc_server_config):
     """Edit the sshkeyfile of a not created auth entry.
 
@@ -447,6 +452,7 @@ def test_edit_sshkeyfile_negative(isolated_filesystem, qpc_server_config):
     assert qpc_cred_edit.exitstatus != 0
 
 
+@pytest.mark.ssh_keyfile_path
 def test_edit_become_password(isolated_filesystem, qpc_server_config):
     """Edit an auth's become password.
 
@@ -509,6 +515,7 @@ def test_edit_become_password(isolated_filesystem, qpc_server_config):
     )
 
 
+@pytest.mark.ssh_keyfile_path
 def test_edit_become_password_negative(isolated_filesystem, qpc_server_config):
     """Edit the become password of a not created auth entry.
 
@@ -537,6 +544,7 @@ def test_edit_become_password_negative(isolated_filesystem, qpc_server_config):
     assert qpc_cred_edit.exitstatus != 0
 
 
+@pytest.mark.ssh_keyfile_path
 def test_edit_no_credentials(isolated_filesystem, qpc_server_config):
     """Edit with no credentials created.
 
@@ -564,6 +572,7 @@ def test_edit_no_credentials(isolated_filesystem, qpc_server_config):
     assert qpc_cred_edit.exitstatus != 0
 
 
+@pytest.mark.ssh_keyfile_path
 def test_clear(isolated_filesystem, qpc_server_config):
     """Clear an auth.
 
@@ -603,6 +612,7 @@ def test_clear(isolated_filesystem, qpc_server_config):
     qpc_cred_show.close()
 
 
+@pytest.mark.ssh_keyfile_path
 def test_clear_with_source(isolated_filesystem, qpc_server_config):
     """Attempt to clear a credential being used by a source.
 
@@ -714,6 +724,7 @@ def test_clear_negative(isolated_filesystem, qpc_server_config):
     assert qpc_cred_clear.exitstatus == 1
 
 
+@pytest.mark.ssh_keyfile_path
 def test_clear_all(isolated_filesystem, qpc_server_config):
     """Clear all auth entries.
 

--- a/camayoc/utils.py
+++ b/camayoc/utils.py
@@ -56,16 +56,14 @@ def uuid4():
 
 
 @contextlib.contextmanager
-def isolated_filesystem():
+def isolated_filesystem(filesystem_path=None):
     """Context Manager that creates a temporary directory.
 
     Changes the current working directory to the created temporary directory
     for isolated filesystem tests.
     """
-    cfg = get_config().get("qpc", {})
-    isolated_filesystem_prefix = cfg.get("isolated_filesystem_prefix")
     cwd = os.getcwd()
-    path = tempfile.mkdtemp(dir=isolated_filesystem_prefix, prefix="")
+    path = tempfile.mkdtemp(dir=filesystem_path, prefix="")
     for envvar in _XDG_ENV_VARS:
         os.environ[envvar] = path
     os.chdir(path)

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -37,6 +37,7 @@ qpc:
     # credentials for logging into the server
     username: 'admin'
     password: 'pass'
+    ssh_keyfile_path: '/home/user/quipucords/server/volumes/sshkeyfiles/'
         sources:
         - hosts:
               - 'myfavnetwork.com'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 """Unit tests for :mod:`camayoc.utils`."""
 import os
+
+from tempfile import mkdtemp
 from unittest import mock
 
 import pytest
@@ -41,3 +43,19 @@ def test_get_qpc_url_no_hostname():
             'Make sure you have a "qpc" section and `hostname`is specified in '
             "the camayoc config file"
         ) in str(err.value)
+
+
+def test_isolated_filesystem():
+    """Test default ``camayoc.utils.isolated_filesystem``."""
+    with utils.isolated_filesystem() as path:
+        assert path.startswith('/tmp/'), "Make sure default isolated_filesystem "\
+            "creates the temp dir at '/tmp/'."
+
+
+def test_isolated_filesystem_w_path():
+    """Test ``camayoc.utils.isolated_filesystem`` with a provided
+    filesystem_path."""
+    test_path = mkdtemp(prefix="")
+    with utils.isolated_filesystem(test_path) as path:
+        assert path.startswith(test_path), "Make sure isolated_filesystem "\
+            "creates the temp dir under ``filesystem_path``, when provided."


### PR DESCRIPTION
A few minor changes have been made to `isolated_filesystem` so that it can now *optionally* use a directory location defined in the camayoc configuration file on a test-by-test basis. By default, `isolated_filesystem` will just use the default `/tmp/` to build the filesystem in. 

However, is a test is marked with `@pytest.mark.ssh_keyfile_path`, that any calls to `isolated_filesystem` within the scope of the test will use path defined by the camayoc `qpc` config value, `ssh_keyfile_path`.

This is mostly to fix some tests so that they can generate temporary test keyfiles in the proper `keyfiles` directory, inside the mounted container volume.

This PR also marks all tests effected by this issue with the `@pytest.mark.ssh_keyfile_path` pytest marker, resolving them.

Closes #338 