### PR TITLE
Issues/343

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -244,4 +244,4 @@ build, run::
 
 The doc strings of each test case are designed to be digested by sphinx_. It is a good idea when writing new tests to make sure the doc strings are rendering as you expect them to. To make and serve the docs on your local machine::
 
-    ake docs-serve
+    make docs-serve

--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,27 @@ config file format should be made with this in mind.
 There is an example annotated config file in ``example_config.yaml`` in
 the root directory of the Camayoc repository.
 
+Configuration Template
+""""""""""""""""""""""
+
+The Jenkins automation jobs often use a template configuration file when
+running camaoyc. This template config has default values (such as
+``${jenkins_ssh_file}``) that are swapped out for values which Jenkins
+provides.  Additionally, ssh key files need to be set with the proper
+permissions.
+
+When working locally or in a dev environment, these steps can be automatically
+configured with a template config using the ``configure-camayoc.yaml`` playbook
+found in the ``camayoc/scripts/`` directory. To use the playbook, first open it
+and set the variables at the top accordingly (or overwrite them when calling
+the playbook using ``-e`` flags). Then, assuming the template configuration has
+been downloaded and defined correctly in the playbook, run the playbook::
+
+    cd scripts
+    ansible-palybook configure-camayoc.yaml
+
+
+
 Configuring py.test
 ^^^^^^^^^^^^^^^^^^^
 
@@ -223,4 +244,4 @@ build, run::
 
 The doc strings of each test case are designed to be digested by sphinx_. It is a good idea when writing new tests to make sure the doc strings are rendering as you expect them to. To make and serve the docs on your local machine::
 
-    make docs-serve
+    ake docs-serve

--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ the playbook using ``-e`` flags). Then, assuming the template configuration has
 been downloaded and defined correctly in the playbook, run the playbook::
 
     cd scripts
-    ansible-palybook configure-camayoc.yaml
+    sudo ansible-playbook configure-camayoc.yaml
 
 
 

--- a/scripts/configure-camayoc.yaml
+++ b/scripts/configure-camayoc.yaml
@@ -4,14 +4,14 @@
   hosts: localhost
   vars:
       config_template: "./config-template.yaml"
-      config_dir: "~/.config/camayoc/"
+      config_dir: "/home/user/.config/camayoc/"
       config_file: "config.yaml"
       server_ip: "127.0.0.1"
       container_ssh_file: "/sshkeys/id_rsa"
-      isolated_fs: "~/quipucords/server/volumes/sshkeys/"
-      sshkeyfile: "~/.ssh/id_rsa"
-      volume_sshkeyfile: "~/quipucords/server/volumes/sshkeys/id_rsa"
-      isolated_fs_user: "jenkins"
+      isolated_fs: "/home/user/quipucords/server/volumes/sshkeys/"
+      sshkeyfile: "/home/user/.ssh/id_rsa"
+      volume_sshkeyfile: "/home/user/quipucords/server/volumes/sshkeys/id_rsa"
+      isolated_fs_user: "user"
 
   tasks:
     - name: Ensure camayoc config dir exists

--- a/scripts/configure-camayoc.yaml
+++ b/scripts/configure-camayoc.yaml
@@ -34,9 +34,10 @@
         #        group: "{{ isolated_fs_user }}"
 
     - name: Copy sshkeyfile to container volume
-      copy:
-        src: "{{ sshkeyfile }}"
-        dest: "{{ volume_sshkeyfile }}"
+      shell: "sudo cp {{ sshkeyfile }} {{ volume_sshkeyfile }}"
+      #      copy:
+      #        src: "{{ sshkeyfile }}"
+      #        dest: "{{ volume_sshkeyfile }}"
 
     - name: Change sshkeys dir ownership
       shell: "sudo chown -R {{ isolated_fs_user }}:{{ isolated_fs_user }} {{ isolated_fs }}"

--- a/scripts/configure-camayoc.yaml
+++ b/scripts/configure-camayoc.yaml
@@ -43,10 +43,13 @@
         src: "{{ sshkeyfile }}"
         dest: "{{ volume_sshkeyfile }}"
 
+        #    - name: Change volume sshkeyfile permission
+        #      file:
+        #        path: "{{ volume_sshkeyfile }}"
+        #        mode: "0600"
+
     - name: Change volume sshkeyfile permission
-      file:
-        path: "{{ volume_sshkeyfile }}"
-        mode: "0600"
+      shell: "sudo chmod -R 0600 {{ volume_sshkeyfile }}"
 
     - name: Set container ssh location in config file
       replace:

--- a/scripts/configure-camayoc.yaml
+++ b/scripts/configure-camayoc.yaml
@@ -25,28 +25,14 @@
         regexp: '{jenkins_slave_ip}'
         replace: "{{ server_ip }}"
 
-        #    - name: Change sshkeys dir ownership
-        #      file:
-        #        path: "{{ isolated_fs }}"
-        #        state: directory
-        #        recurse: yes
-        #        owner: "{{ isolated_fs_user }}"
-        #        group: "{{ isolated_fs_user }}"
-
     - name: Copy sshkeyfile to container volume
-      copy:
-        src: "{{ sshkeyfile }}"
-        dest: "{{ volume_sshkeyfile }}"
-        unsafe_writes: yes
+      shell: "sudo cp {{ sshkeyfile }} {{ volume_sshkeyfile }}"
 
     - name: Change sshkeys dir ownership
       shell: "sudo chown -R {{ isolated_fs_user }}:{{ isolated_fs_user }} {{ isolated_fs }}"
 
-
-        #    - name: Change volume sshkeyfile permission
-        #      file:
-        #        path: "{{ volume_sshkeyfile }}"
-        #        mode: "0600"
+    - name: Change volume sshkeyfile permission
+      shell: "sudo chmod -R 0600 {{ volume_sshkeyfile }}"
 
     - name: Change volume sshkeyfile permission
       shell: "sudo chmod -R 0600 {{ volume_sshkeyfile }}"

--- a/scripts/configure-camayoc.yaml
+++ b/scripts/configure-camayoc.yaml
@@ -34,10 +34,10 @@
         #        group: "{{ isolated_fs_user }}"
 
     - name: Copy sshkeyfile to container volume
-      shell: "sudo cp {{ sshkeyfile }} {{ volume_sshkeyfile }}"
-      #      copy:
-      #        src: "{{ sshkeyfile }}"
-      #        dest: "{{ volume_sshkeyfile }}"
+      copy:
+        src: "{{ sshkeyfile }}"
+        dest: "{{ volume_sshkeyfile }}"
+        unsafe_writes: yes
 
     - name: Change sshkeys dir ownership
       shell: "sudo chown -R {{ isolated_fs_user }}:{{ isolated_fs_user }} {{ isolated_fs }}"

--- a/scripts/configure-camayoc.yaml
+++ b/scripts/configure-camayoc.yaml
@@ -29,6 +29,7 @@
       file:
         path: "{{ isolated_fs }}"
         state: directory
+        recurse: yes
         owner: "{{ isolated_fs_user }}"
         group: "{{ isolated_fs_user }}"
 

--- a/scripts/configure-camayoc.yaml
+++ b/scripts/configure-camayoc.yaml
@@ -33,15 +33,14 @@
         #        owner: "{{ isolated_fs_user }}"
         #        group: "{{ isolated_fs_user }}"
 
-
-    - name: Change sshkeys dir ownership
-      shell: "sudo chown -R {{ isolated_fs_user }}:{{ isolated_fs_user }} {{ isolated_fs }}"
-
-
     - name: Copy sshkeyfile to container volume
       copy:
         src: "{{ sshkeyfile }}"
         dest: "{{ volume_sshkeyfile }}"
+
+    - name: Change sshkeys dir ownership
+      shell: "sudo chown -R {{ isolated_fs_user }}:{{ isolated_fs_user }} {{ isolated_fs }}"
+
 
         #    - name: Change volume sshkeyfile permission
         #      file:

--- a/scripts/configure-camayoc.yaml
+++ b/scripts/configure-camayoc.yaml
@@ -1,0 +1,36 @@
+---
+
+- name: Setup and Configure Quipucords Components
+  hosts: localhost
+  vars:
+      config_template: "./config-template.yaml"
+      config_location: "~/.config/camayoc/config.yaml"
+      server_ip: "127.0.0.1"
+      container_ssh_file: "/sshkeys/id_rsa"
+      isolated_fs: "~/quipucords/server/volumes/sshkeys/"
+
+  tasks:
+    - name: Copy config template to config location
+      copy:
+        src: "{{ config_template }}"
+        dest: "{{ config_location }}"
+
+    - name: Replace server IPs in config file
+      replace:
+        path: "{{ config_location }}"
+        regexp: '{jenkins_slave_ip}'
+        replace: "{{ server_ip }}"
+
+    - name: Set container ssh location in config file
+      replace:
+        path: "{{ config_location }}"
+        regexp: '{jenkins_ssh_file}'
+        replace: "{{ container_ssh_file }}"
+
+    - name: Set user on ssh credentials
+
+    - name: Set isolated_fs_placeholder in config file
+      replace:
+        path: "{{ config_location }}"
+        regexp: '{isolated_fs_placeholder}'
+        replace: "{{ isolated_fs }}"

--- a/scripts/configure-camayoc.yaml
+++ b/scripts/configure-camayoc.yaml
@@ -8,7 +8,8 @@
       server_ip: "127.0.0.1"
       container_ssh_file: "/sshkeys/id_rsa"
       isolated_fs: "~/quipucords/server/volumes/sshkeys/"
-      sshkeyfile: "~/quipucords/server/volumes/sshkeys/id_rsa"
+      sshkeyfile: "~/.ssh/id_rsa"
+      volume_sshkeyfile: "~/quipucords/server/volumes/sshkeys/id_rsa"
       isolated_fs_user: "ryan"
 
   tasks:
@@ -31,9 +32,14 @@
         owner: "{{ isolated_fs_user }}"
         group: "{{ isolated_fs_user }}"
 
-    - name: Change sshkeyfile permission
+    - name: Copy sshkeyfile to container volume
+      copy:
+        src: "{{ sshkeyfile }}"
+        dest: "{{ volume_sshkeyfile }}"
+
+    - name: Change volume sshkeyfile permission
       file:
-        path: "{{ sshkeyfile }}"
+        path: "{{ volume_sshkeyfile }}"
         mode: "0600"
 
     - name: Set container ssh location in config file

--- a/scripts/configure-camayoc.yaml
+++ b/scripts/configure-camayoc.yaml
@@ -4,24 +4,29 @@
   hosts: localhost
   vars:
       config_template: "./config-template.yaml"
-      config_location: "~/.config/camayoc/config.yaml"
+      config_dir: "~/.config/camayoc/"
+      config_file: "config.yaml"
       server_ip: "127.0.0.1"
       container_ssh_file: "/sshkeys/id_rsa"
       isolated_fs: "~/quipucords/server/volumes/sshkeys/"
       sshkeyfile: "~/.ssh/id_rsa"
       volume_sshkeyfile: "~/quipucords/server/volumes/sshkeys/id_rsa"
-      isolated_fs_user: "ryan"
+      isolated_fs_user: "jenkins"
 
   tasks:
-    ## Need to Ensure/Make dir if does not exist
+    - name: Ensure camayoc config dir exists
+      file:
+        path: "{{ config_dir }}"
+        state: directory
+
     - name: Copy config template to config location
       copy:
         src: "{{ config_template }}"
-        dest: "{{ config_location }}"
+        dest: "{{ config_dir }}/{{ config_file }}"
 
     - name: Replace server IPs in config file
       replace:
-        path: "{{ config_location }}"
+        path: "{{ config_dir }}/{{ config_file }}"
         regexp: '{jenkins_slave_ip}'
         replace: "{{ server_ip }}"
 
@@ -39,12 +44,12 @@
 
     - name: Set container ssh location in config file
       replace:
-        path: "{{ config_location }}"
+        path: "{{ config_dir }}/{{ config_file }}"
         regexp: '{jenkins_ssh_file}'
         replace: "{{ container_ssh_file }}"
 
     - name: Set isolated_fs_placeholder in config file
       replace:
-        path: "{{ config_location }}"
+        path: "{{ config_dir }}/{{ config_file }}"
         regexp: '{isolated_fs_placeholder}'
         replace: "{{ isolated_fs }}"

--- a/scripts/configure-camayoc.yaml
+++ b/scripts/configure-camayoc.yaml
@@ -27,6 +27,7 @@
     - name: Change sshkeys dir ownership
       file:
         path: "{{ isolated_fs }}"
+        state: directory
         owner: "{{ isolated_fs_user }}"
         group: "{{ isolated_fs_user }}"
 

--- a/scripts/configure-camayoc.yaml
+++ b/scripts/configure-camayoc.yaml
@@ -25,13 +25,18 @@
         regexp: '{jenkins_slave_ip}'
         replace: "{{ server_ip }}"
 
+        #    - name: Change sshkeys dir ownership
+        #      file:
+        #        path: "{{ isolated_fs }}"
+        #        state: directory
+        #        recurse: yes
+        #        owner: "{{ isolated_fs_user }}"
+        #        group: "{{ isolated_fs_user }}"
+
+
     - name: Change sshkeys dir ownership
-      file:
-        path: "{{ isolated_fs }}"
-        state: directory
-        recurse: yes
-        owner: "{{ isolated_fs_user }}"
-        group: "{{ isolated_fs_user }}"
+      shell: "sudo chown -R {{ isolated_fs_user }}:{{ isolated_fs_user }} {{ isolated_fs }}"
+
 
     - name: Copy sshkeyfile to container volume
       copy:

--- a/scripts/configure-camayoc.yaml
+++ b/scripts/configure-camayoc.yaml
@@ -8,8 +8,11 @@
       server_ip: "127.0.0.1"
       container_ssh_file: "/sshkeys/id_rsa"
       isolated_fs: "~/quipucords/server/volumes/sshkeys/"
+      sshkeyfile: "~/quipucords/server/volumes/sshkeys/id_rsa"
+      isolated_fs_user: "ryan"
 
   tasks:
+    ## Need to Ensure/Make dir if does not exist
     - name: Copy config template to config location
       copy:
         src: "{{ config_template }}"
@@ -21,13 +24,22 @@
         regexp: '{jenkins_slave_ip}'
         replace: "{{ server_ip }}"
 
+    - name: Change sshkeys dir ownership
+      file:
+        path: "{{ isolated_fs }}"
+        owner: "{{ isolated_fs_user }}"
+        group: "{{ isolated_fs_user }}"
+
+    - name: Change sshkeyfile permission
+      file:
+        path: "{{ sshkeyfile }}"
+        mode: "0600"
+
     - name: Set container ssh location in config file
       replace:
         path: "{{ config_location }}"
         regexp: '{jenkins_ssh_file}'
         replace: "{{ container_ssh_file }}"
-
-    - name: Set user on ssh credentials
 
     - name: Set isolated_fs_placeholder in config file
       replace:


### PR DESCRIPTION
Now that Jenkins edits more of the config files for camayoc, it can be difficult to get everything running on a local machine for camayoc. This PR adds an ansible script that can automate much of the process of swapping out the values of the config file template Jenkins uses, as well has moving sshkey credentials around with the appropriate permissions. This PR also includes an added section to the README to reflect the changes.

Related to [CI Issue #164](https://github.com/quipucords/ci/issues/164)