### PR TITLE
Converted the pytest.raises 'message' keyparams to pytest.fail calls

### DIFF
--- a/camayoc/tests/qpc/cli/test_reports.py
+++ b/camayoc/tests/qpc/cli/test_reports.py
@@ -454,34 +454,28 @@ def test_download_report(source_option, isolated_filesystem, qpc_server_config):
 
     # Test that fails on non-existant path
     missing_output_path = f"/no/such/number/{output_pkg})"
-    with pytest.raises(
-        AssertionError,
-        message="I expected to fail with an\
-    AssertionError due to a missing directory",
-    ) as no_dir_exception_info:
+    with pytest.raises(AssertionError) as no_dir_exception_info:
         report_download(
             {source_option: scan[source_option], "output-file": missing_output_path}
         )
-    expected_msg = "directory /no/such/number does not exist"
-    assert no_dir_exception_info.match(expected_msg), (
-        "Unexpected output from qpc report download! \n"
-        f'Expected to find "{expected_msg}" in output, actual output was: \
-        {str(no_dir_exception_info.value)}'
-    )
+        expected_msg = "directory /no/such/number does not exist"
+        assert no_dir_exception_info.match(expected_msg), (
+            "Unexpected output from qpc report download! \n"
+            f'Expected to find "{expected_msg}" in output, actual output was: \
+            {str(no_dir_exception_info.value)}'
+        )
+        pytest.fail("I expected to fail with an AssertionError due to a missing directory")
 
     # Test that non tar.gz files fail
     non_tar_file = f"{format(uuid4())}"
-    with pytest.raises(
-        AssertionError,
-        message="I expected to fail with an \
-    AssertionError due to a bad output value specified",
-    ) as tar_exception_info:
+    with pytest.raises(AssertionError) as tar_exception_info:
         report_download(
             {source_option: scan[source_option], "output-file": non_tar_file}
         )
-    expected_tar_error = "extension is required to be tar.gz"
-    assert tar_exception_info.match(expected_tar_error), (
-        "Unexpected output from qpc report download!\n"
-        f'Expected to find "{expected_tar_error}" in output, actual output \
-        was: {str(no_dir_exception_info.value)}'
-    )
+        expected_tar_error = "extension is required to be tar.gz"
+        assert tar_exception_info.match(expected_tar_error), (
+            "Unexpected output from qpc report download!\n"
+            f'Expected to find "{expected_tar_error}" in output, actual output \
+            was: {str(no_dir_exception_info.value)}'
+        )
+        pytest.fail("I expected to fail with an AssertionError due to a bad output value specified")


### PR DESCRIPTION
The `message` key parameter of `pytest.raises` [has been deprecated](https://docs.pytest.org/en/latest/deprecations.html#message-parameter-of-pytest-raises). This has caused some of the camayoc tests to fail recently.

This PR removes the `message` key parameter, and  adds the message as a `pytest.fail` message at the end of the `with pytest.raises` block, as suggested.

This fixes the tests failing due to this issue, and as such, closes issue #346.