### PR TITLE
Skipping flaky tests for now

### DIFF
--- a/camayoc/tests/qpc/api/v1/scanjobs/test_pause_cancel_restart.py
+++ b/camayoc/tests/qpc/api/v1/scanjobs/test_pause_cancel_restart.py
@@ -20,6 +20,7 @@ from camayoc.qpc_models import ScanJob
 from camayoc.tests.qpc.utils import mark_runs_scans
 
 
+@pytest.mark.skip(reason="Test is flaky. Skipping until Quipucords Issue #2040 resoloved")
 @mark_runs_scans
 @pytest.mark.parametrize("source_type", QPC_SOURCE_TYPES)
 def test_pause_cancel(shared_client, cleanup, source_type):
@@ -49,6 +50,7 @@ def test_pause_cancel(shared_client, cleanup, source_type):
     util.wait_until_state(job, state="canceled", timeout=60)
 
 
+@pytest.mark.skip(reason="Test is flaky. Skipping until Quipucords Issue #2040 resoloved")
 @mark_runs_scans
 @pytest.mark.parametrize("source_type", QPC_SOURCE_TYPES)
 def test_restart(shared_client, cleanup, source_type):

--- a/camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py
+++ b/camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py
@@ -28,6 +28,7 @@ from camayoc.tests.qpc.api.v1.conftest import get_scan_result, scan_list
 from camayoc.tests.qpc.utils import mark_runs_scans
 
 
+@pytest.mark.skip(reason="Test is flaky. Skipping until Quipucords Issue #2040 resoloved")
 @mark_runs_scans
 @pytest.mark.parametrize("scan_info", scan_list(), ids=utils.name_getter)
 def test_scan_complete(scan_info):


### PR DESCRIPTION
We still had some tests randomly failing and passing depending on the run. They seem to fail due to complications related to known pause/restart issues. So, for the time being they will be skipped until working again.