### PR TITLE
Fix Camayoc checks

### DIFF
--- a/scripts/gen_config.py
+++ b/scripts/gen_config.py
@@ -53,7 +53,7 @@ def get_config():
     try:
         cfg = config.get_config()
     except ConfigFileNotFoundError:
-        cfg = yaml.load(BASE_CONFIG)
+        cfg = yaml.load(BASE_CONFIG, Loader=yaml.FullLoader)
 
     return cfg, os.path.join(os.getcwd(), "config.yaml")
 

--- a/scripts/power_control.py
+++ b/scripts/power_control.py
@@ -43,7 +43,7 @@ def get_config():
     try:
         cfg = config.get_config()
     except ConfigFileNotFoundError:
-        cfg = yaml.load(BASE_CONFIG)
+        cfg = yaml.load(BASE_CONFIG, Loader=yaml.FullLoader)
 
     return cfg
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -75,8 +75,8 @@ class APIClientTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Create a parsed configuraton dictionary."""
-        cls.config = yaml.load(CAMAYOC_CONFIG)
-        cls.invalid_config = yaml.load(INVALID_HOST_CONFIG)
+        cls.config = yaml.load(CAMAYOC_CONFIG, Loader=yaml.FullLoader)
+        cls.invalid_config = yaml.load(INVALID_HOST_CONFIG, Loader=yaml.FullLoader)
 
     def test_create_with_config(self):
         """If a hostname is specified in the config file, we use it."""
@@ -215,8 +215,8 @@ class CredentialTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Create a parsed configuraton dictionary."""
-        cls.config = yaml.load(CAMAYOC_CONFIG)
-        cls.invalid_config = yaml.load(INVALID_HOST_CONFIG)
+        cls.config = yaml.load(CAMAYOC_CONFIG, Loader=yaml.FullLoader)
+        cls.invalid_config = yaml.load(INVALID_HOST_CONFIG, Loader=yaml.FullLoader)
 
     def test_equivalent(self):
         """If a hostname is specified in the config file, we use it."""
@@ -241,8 +241,8 @@ class SourceTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Create a parsed configuraton dictionary."""
-        cls.config = yaml.load(CAMAYOC_CONFIG)
-        cls.invalid_config = yaml.load(INVALID_HOST_CONFIG)
+        cls.config = yaml.load(CAMAYOC_CONFIG, Loader=yaml.FullLoader)
+        cls.invalid_config = yaml.load(INVALID_HOST_CONFIG, Loader=yaml.FullLoader)
 
     def test_equivalent_network(self):
         """If a hostname is specified in the config file, we use it."""
@@ -287,7 +287,7 @@ class ScanTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Create a parsed configuraton dictionary."""
-        cls.config = yaml.load(CAMAYOC_CONFIG)
+        cls.config = yaml.load(CAMAYOC_CONFIG, Loader=yaml.FullLoader)
 
     def test_equivalent(self):
         """If a hostname is specified in the config file, we use it."""
@@ -306,7 +306,7 @@ class ScanJobTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Create a parsed configuraton dictionary."""
-        cls.config = yaml.load(CAMAYOC_CONFIG)
+        cls.config = yaml.load(CAMAYOC_CONFIG, Loader=yaml.FullLoader)
 
     def test_create(self):
         """If a hostname is specified in the config file, we use it."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -48,7 +48,7 @@ class GetConfigTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Create a parsed configuraton dictionary."""
-        cls.config = yaml.load(CAMAYOC_CONFIG)
+        cls.config = yaml.load(CAMAYOC_CONFIG, Loader=yaml.FullLoader)
 
     def test_cache_full(self):
         """No config is read from disk if the cache is populated."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -48,7 +48,7 @@ def test_get_qpc_url_no_hostname():
 def test_isolated_filesystem():
     """Test default ``camayoc.utils.isolated_filesystem``."""
     with utils.isolated_filesystem() as path:
-        assert path.startswith('/tmp/'), "Make sure default isolated_filesystem "\
+        assert path.startswith('/tmp/') or path.startswith('/var/folders/'), "Make sure default isolated_filesystem "\
             "creates the temp dir at '/tmp/'."
 
 


### PR DESCRIPTION
Testing Camayoc was failing due yaml.load() required positional
argument: 'Loader'.

Fix check for temporary directory when running on Mac /var/folders/