### PR TITLE
Skip tests with hardcoded /sshkeys/ path

### DIFF
--- a/camayoc/tests/qpc/api/v1/credentials/test_network_creds.py
+++ b/camayoc/tests/qpc/api/v1/credentials/test_network_creds.py
@@ -24,6 +24,10 @@ from camayoc.tests.qpc.utils import assert_matches_server
 from camayoc.utils import uuid4
 
 
+SKIP_REASON_LOCAL_SSHKEYS = "Expects the same hardcoded /sshkeys/ locally and at the server"
+
+
+@pytest.mark.skip(reason=SKIP_REASON_LOCAL_SSHKEYS)
 @pytest.mark.ssh_keyfile_path
 def test_update_password_to_sshkeyfile(shared_client, cleanup, isolated_filesystem):
     """Create a network credential using password and switch it to use sshkey.
@@ -54,6 +58,7 @@ def test_update_password_to_sshkeyfile(shared_client, cleanup, isolated_filesyst
     assert_matches_server(cred)
 
 
+@pytest.mark.skip(reason=SKIP_REASON_LOCAL_SSHKEYS)
 @pytest.mark.ssh_keyfile_path
 def test_update_sshkey_to_password(shared_client, cleanup, isolated_filesystem):
     """Create a network credential using password and switch it to use sshkey.
@@ -85,6 +90,7 @@ def test_update_sshkey_to_password(shared_client, cleanup, isolated_filesystem):
     assert_matches_server(cred)
 
 
+@pytest.mark.skip(reason=SKIP_REASON_LOCAL_SSHKEYS)
 @pytest.mark.ssh_keyfile_path
 def test_negative_update_to_invalid(shared_client, cleanup, isolated_filesystem):
     """Attempt to update valid credential with invalid data.
@@ -135,6 +141,7 @@ def test_negative_update_to_invalid(shared_client, cleanup, isolated_filesystem)
     assert_matches_server(cred)
 
 
+@pytest.mark.skip(reason=SKIP_REASON_LOCAL_SSHKEYS)
 @pytest.mark.ssh_keyfile_path
 def test_create_with_sshkey(shared_client, cleanup, isolated_filesystem):
     """Create a network credential with username and sshkey.


### PR DESCRIPTION
Skip tests with hardcoded /sshkeys/ path locally and at the server.
We will figure out how to handle these tests later.

```
================================= test session starts ==================================
platform darwin -- Python 3.10.2, pytest-7.0.1, pluggy-1.0.0 -- /Users/rmoura/.virtualenvs/camayoc/bin/python3
cachedir: .pytest_cache
rootdir: /Users/rmoura/Developer/camayoc, configfile: pytest.ini
plugins: cov-3.0.0
collected 574 items / 559 deselected / 15 selected                                     

camayoc/tests/qpc/api/v1/credentials/test_network_creds.py::test_update_password_to_sshkeyfile SKIPPED [  6%]
camayoc/tests/qpc/api/v1/credentials/test_network_creds.py::test_update_sshkey_to_password SKIPPED [ 13%]
camayoc/tests/qpc/api/v1/credentials/test_network_creds.py::test_negative_update_to_invalid SKIPPED [ 20%]
camayoc/tests/qpc/api/v1/credentials/test_network_creds.py::test_create_with_sshkey SKIPPED [ 26%]
camayoc/tests/qpc/api/v1/credentials/test_network_creds.py::test_negative_create_key_and_pass PASSED [ 33%]
camayoc/tests/qpc/api/v1/credentials/test_network_creds.py::test_create_become_method[doas] PASSED [ 40%]
camayoc/tests/qpc/api/v1/credentials/test_network_creds.py::test_create_become_method[dzdo] PASSED [ 46%]
camayoc/tests/qpc/api/v1/credentials/test_network_creds.py::test_create_become_method[ksu] PASSED [ 53%]
camayoc/tests/qpc/api/v1/credentials/test_network_creds.py::test_create_become_method[pbrun] PASSED [ 60%]
camayoc/tests/qpc/api/v1/credentials/test_network_creds.py::test_create_become_method[pfexec] PASSED [ 66%]
camayoc/tests/qpc/api/v1/credentials/test_network_creds.py::test_create_become_method[runas] PASSED [ 73%]
camayoc/tests/qpc/api/v1/credentials/test_network_creds.py::test_create_become_method[su] PASSED [ 80%]
camayoc/tests/qpc/api/v1/credentials/test_network_creds.py::test_create_become_method[sudo] PASSED [ 86%]
camayoc/tests/qpc/api/v1/credentials/test_network_creds.py::test_negative_invalid_become_method[not-a-method] PASSED [ 93%]
camayoc/tests/qpc/api/v1/credentials/test_network_creds.py::test_negative_invalid_become_method[86] PASSED [100%]

=================================== warnings summary ===================================
camayoc/tests/qpc/api/v1/credentials/test_network_creds.py:28
  /Users/rmoura/Developer/camayoc/camayoc/tests/qpc/api/v1/credentials/test_network_creds.py:28: PytestUnknownMarkWarning: Unknown pytest.mark.ssh_keyfile_path - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.ssh_keyfile_path

...

camayoc/tests/qpc/cli/test_scanjobs.py:42
  /Users/rmoura/Developer/camayoc/camayoc/tests/qpc/cli/test_scanjobs.py:42: PytestUnknownMarkWarning: Unknown pytest.mark.troubleshoot - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.troubleshoot

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============= 11 passed, 4 skipped, 559 deselected, 20 warnings in 31.77s ==============
```