### PR TITLE
Skip more tests with hardcoded /sshkeys/ path

### DIFF
--- a/camayoc/tests/qpc/api/v1/sources/test_network_sources.py
+++ b/camayoc/tests/qpc/api/v1/sources/test_network_sources.py
@@ -27,6 +27,7 @@ CREATE_DATA = ["localhost", "127.0.0.1", "example.com"]
 HOST_FORMAT_DATA = [["192.0.2.[0:255]", "192.0.3.0/24"]]
 RESULTING_HOST_FORMAT_DATA = ["192.0.2.[0:255]", "192.0.3.[0:255]"]
 MIXED_DATA = CREATE_DATA + HOST_FORMAT_DATA
+SKIP_REASON_LOCAL_SSHKEYS = "Expects the same hardcoded /sshkeys/ locally and at the server"
 
 
 @pytest.mark.parametrize("scan_host", HOST_FORMAT_DATA)
@@ -59,6 +60,7 @@ def test_create_multiple_hosts(shared_client, cleanup, scan_host):
     assert_matches_server(src)
 
 
+@pytest.mark.skip(reason=SKIP_REASON_LOCAL_SSHKEYS)
 @pytest.mark.ssh_keyfile_path
 @pytest.mark.parametrize("scan_host", CREATE_DATA)
 def test_create_multiple_creds(shared_client, cleanup, scan_host, isolated_filesystem):
@@ -100,6 +102,7 @@ def test_create_multiple_creds(shared_client, cleanup, scan_host, isolated_files
     assert_matches_server(src)
 
 
+@pytest.mark.skip(reason=SKIP_REASON_LOCAL_SSHKEYS)
 @pytest.mark.ssh_keyfile_path
 @pytest.mark.parametrize("scan_host", MIXED_DATA)
 def test_create_multiple_creds_and_sources(
@@ -151,6 +154,7 @@ def test_create_multiple_creds_and_sources(
     assert_matches_server(src)
 
 
+@pytest.mark.skip(reason=SKIP_REASON_LOCAL_SSHKEYS)
 @pytest.mark.ssh_keyfile_path
 @pytest.mark.parametrize("scan_host", CREATE_DATA)
 def test_negative_update_invalid(

--- a/camayoc/tests/qpc/cli/test_credentials.py
+++ b/camayoc/tests/qpc/cli/test_credentials.py
@@ -33,6 +33,9 @@ from camayoc.tests.qpc.cli.utils import (
 )
 
 
+SKIP_REASON_LOCAL_SSHKEYS = "Expects the same hardcoded /sshkeys/ locally and at the server"
+
+
 def generate_show_output(data):
     """Generate a regex pattern with the data for a qpc cred show output."""
     cred_type = data.get("cred_type", "network")
@@ -124,6 +127,7 @@ def test_add_with_username_password_become_password(
     )
 
 
+@pytest.mark.skip(reason=SKIP_REASON_LOCAL_SSHKEYS)
 @pytest.mark.ssh_keyfile_path
 def test_add_with_username_sshkeyfile(isolated_filesystem, qpc_server_config):
     """Add an auth with username and sshkeyfile.
@@ -156,6 +160,7 @@ def test_add_with_username_sshkeyfile(isolated_filesystem, qpc_server_config):
     )
 
 
+@pytest.mark.skip(reason=SKIP_REASON_LOCAL_SSHKEYS)
 @pytest.mark.ssh_keyfile_path
 def test_add_with_username_sshkeyfile_become_password(
     isolated_filesystem, qpc_server_config
@@ -252,6 +257,7 @@ def test_edit_username(isolated_filesystem, qpc_server_config, source_type):
     )
 
 
+@pytest.mark.skip(reason=SKIP_REASON_LOCAL_SSHKEYS)
 @pytest.mark.ssh_keyfile_path
 def test_edit_username_negative(isolated_filesystem, qpc_server_config):
     """Edit the username of a not created auth entry.
@@ -335,6 +341,7 @@ def test_edit_password(isolated_filesystem, qpc_server_config, source_type):
     )
 
 
+@pytest.mark.skip(reason=SKIP_REASON_LOCAL_SSHKEYS)
 @pytest.mark.ssh_keyfile_path
 def test_edit_password_negative(isolated_filesystem, qpc_server_config):
     """Edit the password of a not created auth entry.
@@ -363,6 +370,7 @@ def test_edit_password_negative(isolated_filesystem, qpc_server_config):
     assert qpc_cred_edit.exitstatus != 0
 
 
+@pytest.mark.skip(reason=SKIP_REASON_LOCAL_SSHKEYS)
 @pytest.mark.ssh_keyfile_path
 def test_edit_sshkeyfile(isolated_filesystem, qpc_server_config):
     """Edit an auth's sshkeyfile.
@@ -417,6 +425,7 @@ def test_edit_sshkeyfile(isolated_filesystem, qpc_server_config):
     )
 
 
+@pytest.mark.skip(reason=SKIP_REASON_LOCAL_SSHKEYS)
 @pytest.mark.ssh_keyfile_path
 def test_edit_sshkeyfile_negative(isolated_filesystem, qpc_server_config):
     """Edit the sshkeyfile of a not created auth entry.
@@ -453,6 +462,7 @@ def test_edit_sshkeyfile_negative(isolated_filesystem, qpc_server_config):
     assert qpc_cred_edit.exitstatus != 0
 
 
+@pytest.mark.skip(reason=SKIP_REASON_LOCAL_SSHKEYS)
 @pytest.mark.ssh_keyfile_path
 def test_edit_become_password(isolated_filesystem, qpc_server_config):
     """Edit an auth's become password.
@@ -516,6 +526,7 @@ def test_edit_become_password(isolated_filesystem, qpc_server_config):
     )
 
 
+@pytest.mark.skip(reason=SKIP_REASON_LOCAL_SSHKEYS)
 @pytest.mark.ssh_keyfile_path
 def test_edit_become_password_negative(isolated_filesystem, qpc_server_config):
     """Edit the become password of a not created auth entry.
@@ -573,6 +584,7 @@ def test_edit_no_credentials(isolated_filesystem, qpc_server_config):
     assert qpc_cred_edit.exitstatus != 0
 
 
+@pytest.mark.skip(reason=SKIP_REASON_LOCAL_SSHKEYS)
 @pytest.mark.ssh_keyfile_path
 def test_clear(isolated_filesystem, qpc_server_config):
     """Clear an auth.
@@ -613,6 +625,7 @@ def test_clear(isolated_filesystem, qpc_server_config):
     qpc_cred_show.close()
 
 
+@pytest.mark.skip(reason=SKIP_REASON_LOCAL_SSHKEYS)
 @pytest.mark.ssh_keyfile_path
 def test_clear_with_source(isolated_filesystem, qpc_server_config):
     """Attempt to clear a credential being used by a source.
@@ -725,6 +738,7 @@ def test_clear_negative(isolated_filesystem, qpc_server_config):
     assert qpc_cred_clear.exitstatus == 1
 
 
+@pytest.mark.skip(reason=SKIP_REASON_LOCAL_SSHKEYS)
 @pytest.mark.ssh_keyfile_path
 def test_clear_all(isolated_filesystem, qpc_server_config):
     """Clear all auth entries.


### PR DESCRIPTION
Skip tests with the same hardcoded `/sshkeys/` path locally and at the server.