### PR TITLE
Pinning jinja2 to version 3.0.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         "dev": [
             # For `make docs`
             "sphinx<1.8",
+            "jinja2==3.0.3",
             # For `make docs-serve`
             "sphinx-serve",
             # For `make lint`


### PR DESCRIPTION
Jinja2 3.1.0 deprecated contexts for Sphinx that we use and it's
causing failure in the GH workflow for Python 3.9.
See https://github.com/quipucords/camayoc/runs/6098467294