### PR TITLE
Set timeout to 1800s for qpc.cli.test_scanjobs.test_scanjob

### DIFF
--- a/camayoc/tests/qpc/cli/test_scanjobs.py
+++ b/camayoc/tests/qpc/cli/test_scanjobs.py
@@ -55,7 +55,7 @@ def test_scanjob(isolated_filesystem, qpc_server_config, scan):
     match = re.match(r'Scan "(\d+)" started.', result)
     assert match is not None
     scan_job_id = match.group(1)
-    wait_for_scan(scan_job_id)
+    wait_for_scan(scan_job_id, timeout=1800)
     result = scan_job({"id": scan_job_id})
     assert result["status"] == "completed"
     report_id = result["report_id"]


### PR DESCRIPTION
Increase wait_for_scan() time to 30 minutes (1800 seconds),
to avoid to have the test_scanjob timed out in longer scan executions.