### PR TITLE
[DISCOVERY-21] Update json deployment report fields

### DIFF
--- a/camayoc/tests/qpc/cli/test_reports.py
+++ b/camayoc/tests/qpc/cli/test_reports.py
@@ -105,6 +105,7 @@ JSON_DEPLOYMENTS_REPORT_FIELDS = DEPLOYMENTS_REPORT_FIELDS + (
     "cpu_core_per_socket",
     "id",
     "deployment_report",
+    "system_purpose",
 )
 """Deployments report expected fields for JSON output."""
 


### PR DESCRIPTION
Adapt tests for the changes introduced in quipucords/quipucords#2169

More context on [this comment](https://github.com/quipucords/quipucords/pull/2169#issuecomment-1175619760)

NOTE: because downstream doesn't return the same fact list merging this PR will cause the affected tests to break tests on downstream until these changes are released.