### PR TITLE
Proper end to end tests utilizing Playwright

### DIFF
--- a/camayoc/tests/qpc/ui/test_endtoend.py
+++ b/camayoc/tests/qpc/ui/test_endtoend.py
@@ -1,4 +1,4 @@
-"""Tests for handling credentials in the UI.
+"""Web user interface end-to-end tests.
 
 :caseautomation: automated
 :casecomponent: ui
@@ -8,88 +8,118 @@
 :testtype: functional
 :upstream: yes
 """
+import shutil
+import tarfile
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from camayoc.qpc_models import Credential
+from camayoc.qpc_models import Scan
+from camayoc.qpc_models import Source
+from camayoc.tests.qpc.utils import calculate_sha256sums
+from camayoc.tests.qpc.utils import get_expected_sha256sums
 from camayoc.ui import Client
 from camayoc.ui import data_factories
 from camayoc.ui.data_factories import AddCredentialDTOFactory
 from camayoc.ui.data_factories import AddSourceDTOFactory
+from camayoc.ui.data_factories import SSHNetworkCredentialFormDTOFactory
 from camayoc.ui.data_factories import TriggerScanDTOFactory
 from camayoc.ui.enums import CredentialTypes
 from camayoc.ui.enums import MainMenuPages
+from camayoc.ui.enums import NetworkCredentialBecomeMethods
 from camayoc.ui.enums import SourceTypes
 
 
-def test_demo_endtoend(ui_client: Client):
-    """Demonstrate new UI framework capabilities in scope of creating data
+def credential_source_pairs():
+    credential_form = SSHNetworkCredentialFormDTOFactory(
+        username="cloud-user",
+        ssh_key_file="/sshkeys/id_rsa",
+        passphrase="",
+        become_method=NetworkCredentialBecomeMethods.SUDO,
+        become_user="root",
+        become_password="",
+    )
+    credential = AddCredentialDTOFactory(
+        credential_type=CredentialTypes.NETWORK,
+        credential_form_dto=credential_form,
+    )
+    source = AddSourceDTOFactory(
+        select_source_type__source_type=SourceTypes.NETWORK_RANGE,
+        source_form__addresses=["10.0.151.20", "10.0.149.227"],
+        source_form__credentials=[credential.credential_form_dto.credential_name],
+    )
+    yield pytest.param(credential, source, id="network")
 
-    :id: 18977f91-700d-4358-975e-f68c0a1c1907
-    :description: This demonstrates how you can use DTOs and
-        fluent page object pattern to model user journey through
-        the system - login, create credential, create source
-        associated with this credential and trigger the scan.
-        Scan will not succeed.
+    credential = AddCredentialDTOFactory(credential_type=CredentialTypes.SATELLITE)
+    source = AddSourceDTOFactory(
+        select_source_type__source_type=SourceTypes.SATELLITE,
+        source_form__credentials=[credential.credential_form_dto.credential_name],
+    )
+    yield pytest.param(credential, source, id="satellite")
+
+    credential = AddCredentialDTOFactory(credential_type=CredentialTypes.VCENTER)
+    source = AddSourceDTOFactory(
+        select_source_type__source_type=SourceTypes.VCENTER_SERVER,
+        source_form__credentials=[credential.credential_form_dto.credential_name],
+    )
+    yield pytest.param(credential, source, id="vcenter")
+
+
+@pytest.mark.parametrize("credential,source", credential_source_pairs())
+def test_end_to_end(cleanup, ui_client: Client, credential, source):
+    """End-to-end test using web user interface.
+
+    :id: f187fbd0-021c-4563-9691-61e54eb272bf
+    :description: This is end-to-end user journey through web user interface.
     :steps:
         1) Log into the UI.
         2) Go to Credentials page, open Credentials modal and fill in the form.
         3) Go to Sources page, open Sources wizard and fill in all the forms.
         4) Trigger scan for newly created source.
-    :expectedresults: Credential and Source are created
+        5) Wait for scan to complete.
+        6) Download scan report.
+        7) Log out.
+    :expectedresults: Credential and Source are created. Scan is completed.
+        Report is downloaded. User is logged out.
     """
-    import random
-
-    matching_types = [
-        (CredentialTypes.NETWORK, SourceTypes.NETWORK_RANGE),
-        (CredentialTypes.SATELLITE, SourceTypes.SATELLITE),
-        (CredentialTypes.VCENTER, SourceTypes.VCENTER_SERVER),
-    ]
-    credential_type, source_type = random.choice(matching_types)
-    # FIXME: above should be somewhere else
-
-    credential_data = AddCredentialDTOFactory(credential_type=credential_type)
-    source_data = AddSourceDTOFactory(
-        select_source_type__source_type=source_type,
-        source_form__credentials=[credential_data.credential_form_dto.credential_name],
-    )
     trigger_scan_data = TriggerScanDTOFactory(
-        source_name=source_data.source_form.source_name,
+        source_name=source.source_form.source_name,
+        scan_form__jboss_eap=None,
+        scan_form__fuse=None,
+        scan_form__jboss_web_server=None,
+        scan_form__decision_manager=None,
     )
-
+    cleanup.append(Credential(name=credential.credential_form_dto.credential_name))
+    cleanup.append(Scan(name=trigger_scan_data.scan_form.scan_name))
+    cleanup.append(Source(name=source.source_form.source_name))
     (
         ui_client.begin()
         .login(data_factories.LoginFormDTOFactory())
         .navigate_to(MainMenuPages.CREDENTIALS)
-        .add_credential(credential_data)
+        .add_credential(credential)
         .navigate_to(MainMenuPages.SOURCES)
-        .add_source(source_data)
+        .add_source(source)
         .trigger_scan(trigger_scan_data)
         .navigate_to(MainMenuPages.SCANS)
+        .download_scan(trigger_scan_data.scan_form.scan_name)
+        .logout()
     )
 
-
-def test_demo_download(ui_client: Client):
-    """Demonstrate new UI framework capabilities in scope of downloading data
-
-    :id: c5db7b18-64c8-4646-aed7-febc1261a9d9
-    :description: This demonstrates how you can download the file
-        and use it later in the test.
-    :steps:
-        1) Log into the UI.
-        2) Go to Scans page and download report of specific scan.
-        3) Do something with downloaded file.
-    :expectedresults: File is downloaded
-    """
-    scan_name = "6c0584fd-d092-46a8-afe8-0603663cbcd1"
-
-    (
-        ui_client.begin()
-        .login(data_factories.LoginFormDTOFactory())
-        .navigate_to(MainMenuPages.SCANS)
-        .download_scan(scan_name)
-    )
     downloaded_report = ui_client.downloaded_files[-1]
-    assert "playwright" in downloaded_report.path().as_posix()
-    # downloaded_report.path() - Path() object pointing to file on local fs
-    # downloaded_report.suggested_filename - str representing how server wants file to be named
-    # the workflow from now could be:
-    # 1. copy file to some directory we have control over
-    # 2. use `tarfile` to unpack files
-    # 3. use `json` and `csv` to read unpacked files and assert their content
+    report_directory = Path(tempfile.mkdtemp(prefix="camayoc"))
+    report_file = report_directory / downloaded_report.suggested_filename
+    shutil.copy(downloaded_report.path(), report_file)
+    tarfile.open(report_file).extractall(report_directory)
+    actual_shasums = calculate_sha256sums(report_directory)
+    expected_shasums = get_expected_sha256sums(report_directory)
+
+    for filename, expected_shasum in expected_shasums.items():
+        actual_shasum = actual_shasums.get(filename)
+        assert actual_shasum == expected_shasum
+
+    for file in report_directory.rglob("*"):
+        if not file.is_file():
+            continue
+        assert file.stat().st_size > 0

--- a/camayoc/tests/qpc/ui/test_playwright_demo.py
+++ b/camayoc/tests/qpc/ui/test_playwright_demo.py
@@ -1,0 +1,112 @@
+"""Tests that demonstrate capabilities of Playwright-based UI framework.
+
+:caseautomation: automated
+:casecomponent: ui
+:caseimportance: medium
+:caselevel: integration
+:requirement: Sonar
+:testtype: functional
+:upstream: yes
+"""
+import shutil
+import tarfile
+import tempfile
+from pathlib import Path
+
+from camayoc.tests.qpc.utils import calculate_sha256sums
+from camayoc.tests.qpc.utils import get_expected_sha256sums
+from camayoc.ui import Client
+from camayoc.ui import data_factories
+from camayoc.ui.data_factories import AddCredentialDTOFactory
+from camayoc.ui.data_factories import AddSourceDTOFactory
+from camayoc.ui.data_factories import TriggerScanDTOFactory
+from camayoc.ui.enums import CredentialTypes
+from camayoc.ui.enums import MainMenuPages
+from camayoc.ui.enums import SourceTypes
+
+
+def test_demo_endtoend(ui_client: Client):
+    """Demonstrate new UI framework capabilities in scope of creating data
+
+    :id: 18977f91-700d-4358-975e-f68c0a1c1907
+    :description: This demonstrates how you can use DTOs and
+        fluent page object pattern to model user journey through
+        the system - login, create credential, create source
+        associated with this credential and trigger the scan.
+        Scan will not succeed.
+    :steps:
+        1) Log into the UI.
+        2) Go to Credentials page, open Credentials modal and fill in the form.
+        3) Go to Sources page, open Sources wizard and fill in all the forms.
+        4) Trigger scan for newly created source.
+    :expectedresults: Credential and Source are created
+    """
+    import random
+
+    matching_types = [
+        (CredentialTypes.NETWORK, SourceTypes.NETWORK_RANGE),
+        (CredentialTypes.SATELLITE, SourceTypes.SATELLITE),
+        (CredentialTypes.VCENTER, SourceTypes.VCENTER_SERVER),
+    ]
+    credential_type, source_type = random.choice(matching_types)
+    # FIXME: above should be somewhere else
+
+    credential_data = AddCredentialDTOFactory(credential_type=credential_type)
+    source_data = AddSourceDTOFactory(
+        select_source_type__source_type=source_type,
+        source_form__credentials=[credential_data.credential_form_dto.credential_name],
+    )
+    trigger_scan_data = TriggerScanDTOFactory(
+        source_name=source_data.source_form.source_name,
+    )
+
+    (
+        ui_client.begin()
+        .login(data_factories.LoginFormDTOFactory())
+        .navigate_to(MainMenuPages.CREDENTIALS)
+        .add_credential(credential_data)
+        .navigate_to(MainMenuPages.SOURCES)
+        .add_source(source_data)
+        .trigger_scan(trigger_scan_data)
+        .navigate_to(MainMenuPages.SCANS)
+    )
+
+
+def test_demo_download(ui_client: Client):
+    """Demonstrate new UI framework capabilities in scope of downloading data
+
+    :id: c5db7b18-64c8-4646-aed7-febc1261a9d9
+    :description: This demonstrates how you can download the file
+        and use it later in the test.
+    :steps:
+        1) Log into the UI.
+        2) Go to Scans page and download report of specific scan.
+        3) Do something with downloaded file.
+    :expectedresults: File is downloaded
+    """
+    scan_name = "6c0584fd-d092-46a8-afe8-0603663cbcd1"
+
+    (
+        ui_client.begin()
+        .login(data_factories.LoginFormDTOFactory())
+        .navigate_to(MainMenuPages.SCANS)
+        .download_scan(scan_name)
+    )
+    downloaded_report = ui_client.downloaded_files[-1]
+    assert "playwright" in downloaded_report.path().as_posix()
+
+    report_directory = Path(tempfile.mkdtemp(prefix="camayoc"))
+    report_file = report_directory / downloaded_report.suggested_filename
+    shutil.copy(downloaded_report.path(), report_file)
+    tarfile.open(report_file).extractall(report_directory)
+    actual_shasums = calculate_sha256sums(report_directory)
+    expected_shasums = get_expected_sha256sums(report_directory)
+
+    for filename, expected_shasum in expected_shasums.items():
+        actual_shasum = actual_shasums.get(filename)
+        assert actual_shasum == expected_shasum
+
+    for file in report_directory.rglob("*"):
+        if not file.is_file():
+            continue
+        assert file.stat().st_size > 0

--- a/camayoc/tests/qpc/utils.py
+++ b/camayoc/tests/qpc/utils.py
@@ -1,4 +1,7 @@
 """Utility functions for quipucords server tests."""
+import hashlib
+from pathlib import Path
+
 import pytest
 
 from camayoc import api
@@ -75,6 +78,22 @@ def assert_source_create_fails(source, source_type=""):
     source.client = orig_client
 
 
+def calculate_sha256sums(directory):
+    """Calculate SHA256 sum of all files in directory."""
+    directory = Path(directory)
+    shasums = {}
+    for file in directory.rglob("*"):
+        if not file.is_file():
+            continue
+        key = str(file.relative_to(directory))
+        shasum = hashlib.sha256()
+        with open(file, "rb") as fh:
+            while block := fh.read(4096):
+                shasum.update(block)
+        shasums[key] = shasum.hexdigest()
+    return shasums
+
+
 def gen_valid_source(cleanup, src_type, hosts, create=True, exclude_hosts=None):
     """Create valid source."""
     cred = Credential(cred_type=src_type, password=uuid4())
@@ -89,6 +108,44 @@ def gen_valid_source(cleanup, src_type, hosts, create=True, exclude_hosts=None):
         cleanup.append(source)
         assert_matches_server(source)
     return source
+
+
+def get_expected_sha256sums(directory):
+    """Find SHA256SUM files in directory and parse them.
+
+    SHA256SUM file names are transformed to be relative to directory arg,
+    so output of this function should be strict subset of output of
+    `calculate_sha256sums` ran on the same directory.
+    """
+    directory = Path(directory)
+    parsed_shasums = {}
+    for file in directory.rglob("*"):
+        if file.name != "SHA256SUM":
+            continue
+
+        with open(file) as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                expected_sum, filename = line.split(maxsplit=1)
+                if not filename:
+                    continue
+                key = str(file.relative_to(directory).with_name(filename))
+                parsed_shasums[key] = expected_sum
+
+    return parsed_shasums
+
+
+def get_object_id(obj):
+    """Get id of object whose name is known."""
+    if obj._id:
+        return obj._id
+
+    available_objs = obj.list(params={"search_by_name": obj.name}).json()
+    for received_obj in available_objs.get("results", []):
+        if received_obj.get("name") == obj.name:
+            return received_obj.get("id")
 
 
 def sort_and_delete(trash):
@@ -115,7 +172,11 @@ def sort_and_delete(trash):
             # Override client to use a fresh one. It may have been a while
             # since the object was created and its token may be invalid.
             obj.client = client
+            # Get object id based on the name.
+            # This allows us to clean up objects created from UI and CLI.
+            if not obj._id and obj.name:
+                obj._id = get_object_id(obj)
             # Only assert that we do not hit an internal server error, in case
-            # for some reason the object was allready cleaned up by the test
+            # for some reason the object was already cleaned up by the test
             response = obj.delete()
             assert response.status_code < 500, response.content

--- a/camayoc/ui/models/components/logged_in.py
+++ b/camayoc/ui/models/components/logged_in.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from camayoc.ui.enums import Pages
 from camayoc.ui.types import UIPage
 
 if TYPE_CHECKING:
@@ -16,4 +17,4 @@ class LoggedIn(UIPage):
         self._driver.click(app_user_dropdown)
         self._driver.click(logout_link)
 
-        return self._new_page("Login")
+        return self._new_page(Pages.LOGIN)

--- a/camayoc/ui/models/mixins.py
+++ b/camayoc/ui/models/mixins.py
@@ -1,8 +1,9 @@
 from .components.items_list import ItemsList
+from .components.logged_in import LoggedIn
 from .components.toasts import ToastNotifications
 from .components.vertical_navigation import VerticalNavigation
 from .pages.abstract_page import AbstractPage
 
 
-class MainPageMixin(ToastNotifications, VerticalNavigation, ItemsList, AbstractPage):
+class MainPageMixin(ToastNotifications, LoggedIn, VerticalNavigation, ItemsList, AbstractPage):
     pass

--- a/camayoc/ui/models/pages/scans.py
+++ b/camayoc/ui/models/pages/scans.py
@@ -10,8 +10,10 @@ from camayoc.ui.decorators import creates_toast
 class ScanListElem(AbstractListItem):
     def download_scan(self) -> Download:
         scan_locator = "div.list-view-pf-actions button[title=Download]"
+        # timeout argument below is in milliseconds; this is how long
+        # script will wait for download button to appear
         with self.locator.page.expect_download() as download_info:
-            self.locator.locator(scan_locator).click()
+            self.locator.locator(scan_locator).click(timeout=30_000)
         download = download_info.value
         download.path()  # blocks the script while file is downloaded
         return download

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -16,7 +16,7 @@ clean-api-docs:
 	@rm -rf api/*
 
 gen-api-docs: clean-api-docs
-	@sphinx-apidoc -efMT -o api ../camayoc '../*/ui/data*' '../*/ui/test_endtoend*'
+	@sphinx-apidoc -efMT -o api ../camayoc '../*/ui/data*' '../*/ui/test_endtoend*' '../*/ui/test_playwright_demo*'
 	@sphinx-apidoc -efMT -o api ../tests
 	@../scripts/gen_api_docs.sh
 


### PR DESCRIPTION
This PR includes / builds upon #365 . Story is similar to #369 - I can include this in #365 , or we can close #365 and continue discussion here, or I can rebase this once #365 is merged.

This is parallel to #369 and one should nicely rebase on top of another. I didn't include one in another to indicate that this is largely independent work.


This introduces proper end-to-end UI tests. For each source type (Network, Satellite and vCenter), it executes following path:

1. Login
2. Create credential
3. Create source
4. Trigger scan
5. Download report
6. Logout
7. Run assertions on report


Created data is later removed using API, so we should be able to run test repeatedly without leaving too much rubbish behind.

Input data for forms may be specified inside function. I have done this for Network source and credential, based on data available on OpenStack instance. I did not find reference values for Satellite and vCenter, so these were left out. When running tests, use `-k network` to only run test that should pass.

Report assertions are relatively weak - I only check that file can be extracted, that all files inside have non-zero size and that their SHA256 sums match what is specified in report file. We probably *should* focus more on reports content, but (1) reports are the same no matter the interface, and we already have some reports tests in CLI and API; (2) report helpers I have found are not easy to use, and at this point I am not in position to fully refactor them.