### PR TITLE
OpenShift (Part 1)

### DIFF
--- a/camayoc/constants.py
+++ b/camayoc/constants.py
@@ -47,13 +47,13 @@ QPC_SCAN_STATES = QPC_SCAN_TERMINAL_STATES + ("running",)
 QPC_TOKEN_PATH = "token/"
 """The path to the endpoint used for obtaining an authentication token."""
 
-QPC_SOURCE_TYPES = ("vcenter", "network", "satellite")
+QPC_SOURCE_TYPES = ("vcenter", "network", "satellite", "openshift")
 """Types of sources that the quipucords server supports."""
 
 QPC_SCAN_TYPES = ("inspect", "connect")
 """Types of scans that the quipucords server supports."""
 
-QPC_HOST_MANAGER_TYPES = ("vcenter", "satellite")
+QPC_HOST_MANAGER_TYPES = ("vcenter", "satellite", "openshift")
 """Types of host managers that the quipucords server supports."""
 
 QPC_BECOME_METHODS = ("doas", "dzdo", "ksu", "pbrun", "pfexec", "runas", "su", "sudo")

--- a/camayoc/qpc_models.py
+++ b/camayoc/qpc_models.py
@@ -146,7 +146,7 @@ class Credential(QPCObject):
     """A class to aid in CRUD tests of Host Credentials on the QPC server.
 
     Host credentials can be created by instantiating a Credential
-    object. A unique name and username are provided by default.
+    object. A unique name and username or auth_token are provided by default.
     In order to create a valid host credential you must specify either a
     password or ssh_keyfile.
 
@@ -168,6 +168,7 @@ class Credential(QPCObject):
         username=None,
         password=None,
         ssh_keyfile=None,
+        auth_token=None,
         cred_type=None,
         become_method=None,
         become_password=None,
@@ -185,9 +186,10 @@ class Credential(QPCObject):
         super().__init__(client=client, _id=_id)
         self.name = uuid4() if name is None else name
         self.endpoint = QPC_CREDENTIALS_PATH
-        self.username = uuid4() if username is None else username
+        self.username = uuid4() if username is None and auth_token is None else username
         self.password = password
         self.ssh_keyfile = ssh_keyfile
+        self.auth_token = uuid4() if auth_token is None and self.username is None else auth_token
         self.cred_type = cred_type
         if become_method is not None:
             self.become_method = become_method

--- a/camayoc/tests/qpc/api/v1/credentials/test_creds_common.py
+++ b/camayoc/tests/qpc/api/v1/credentials/test_creds_common.py
@@ -31,6 +31,8 @@ def test_create_with_password(cred_type, shared_client, cleanup):
     :steps: Send POST with necessary data to documented api endpoint.
     :expectedresults: A new credential entry is created with the data.
     """
+    if cred_type == "openshift":
+        pytest.skip("Requires OpenShift")
     cred = Credential(cred_type=cred_type, client=shared_client, password=uuid4())
     cred.create()
     # add the credential to the list to destroy after the test is done
@@ -52,6 +54,8 @@ def test_update(cred_type, field, shared_client, cleanup):
         3) Confirm credential has been updated.
     :expectedresults: The credential is updated.
     """
+    if cred_type == "openshift":
+        pytest.skip("Requires OpenShift")
     cred = Credential(cred_type=cred_type, client=shared_client, password=uuid4())
     cred.create()
     # add the id to the list to destroy after the test is done
@@ -124,6 +128,8 @@ def test_list(cred_type, shared_client, cleanup):
     :expectedresults: All creds are present in the list returned from the
         credentials endpoint when a GET request is sent.
     """
+    if cred_type == "openshift":
+        pytest.skip("Requires OpenShift")
     local_creds = []
     for _ in range(random.randint(2, 7)):
         cred = Credential(cred_type=cred_type, client=shared_client, password=uuid4())
@@ -166,6 +172,8 @@ def test_read(cred_type, shared_client, cleanup):
     :expectedresults: Each credential can be read individually and has correct
         data returned when it is queried.
     """
+    if cred_type == "openshift":
+        pytest.skip("Requires OpenShift")
     creds = []
     for _ in range(random.randint(2, 5)):
         cred = Credential(cred_type=cred_type, client=shared_client, password=uuid4())
@@ -195,6 +203,8 @@ def test_delete_basic(cred_type, shared_client, cleanup):
     :expectedresults: All credentials are present in data returned by API
         except the deleted credential.
     """
+    if cred_type == "openshift":
+        pytest.skip("Requires OpenShift")
     creds = []
     for _ in range(random.randint(2, 5)):
         cred = Credential(cred_type=cred_type, client=shared_client, password=uuid4())
@@ -233,6 +243,8 @@ def test_delete__with_dependencies(obj_type, shared_client, cleanup):
     :expectedresults: We cannot delete a credential until no sources depend
         on it.
     """
+    if obj_type == "openshift":
+        pytest.skip("Requires OpenShift")
     cred = Credential(cred_type=obj_type, client=shared_client, password=uuid4())
     cred.create()
     cleanup.append(cred)
@@ -266,6 +278,7 @@ def test_delete__with_dependencies(obj_type, shared_client, cleanup):
     cleanup.remove(cred)
 
 
+@pytest.mark.skip(reason="Not implemented yet")
 @pytest.mark.parametrize("cred_type", QPC_SOURCE_TYPES)
 def test_negative_update_to_other_type(shared_client, cleanup, cred_type):
     """Attempt to update valid credential to be another type.

--- a/camayoc/tests/qpc/api/v1/sources/test_manager_sources.py
+++ b/camayoc/tests/qpc/api/v1/sources/test_manager_sources.py
@@ -40,6 +40,8 @@ def test_negative_create_multiple(src_type, shared_client, cleanup, scan_host):
             or ansible pattern like example[1-10].com)
     :expectedresults: An error is thrown and no new host is created.
     """
+    if src_type == "openshift":
+        pytest.skip("Requires OpenShift")
     # initialize & create multiple credentials
     cred = Credential(cred_type=src_type, client=shared_client, password=uuid4())
     cred2 = Credential(cred_type=src_type, client=shared_client, password=uuid4())
@@ -90,6 +92,8 @@ def test_negative_update_invalid(src_type, shared_client, cleanup, scan_host, in
         2) Attempt to update with multiple {hosts, credentials}
     :expectedresults: An error is thrown and no new host is created.
     """
+    if src_type == "openshift":
+        pytest.skip("Requires OpenShift")
     # initialize & create original credential & source
     pwd_cred = Credential(cred_type=src_type, client=shared_client, password=uuid4())
     pwd_cred.create()

--- a/camayoc/tests/qpc/api/v1/sources/test_sources_common.py
+++ b/camayoc/tests/qpc/api/v1/sources/test_sources_common.py
@@ -46,6 +46,8 @@ def test_create(shared_client, cleanup, scan_host, src_type):
            the source endpoint.
     :expectedresults: A new  source entry is created with the data.
     """
+    if src_type == "openshift":
+        pytest.skip("Requires OpenShift")
     cred = Credential(cred_type=src_type, client=shared_client, password=uuid4())
     cred.create()
     src = Source(
@@ -120,6 +122,8 @@ def test_update(shared_client, cleanup, scan_host, src_type):
            the data
     :expectedresults: The source entry is created and updated.
     """
+    if src_type == "openshift":
+        pytest.skip("Requires OpenShift")
     cred = Credential(cred_type=src_type, client=shared_client, password=uuid4())
     cred.create()
     cleanup.append(cred)
@@ -154,6 +158,8 @@ def test_update_bad_credential(src_type, scan_host, cleanup):
         2) Update the source with invalid credentials
     :expectedresults: Error codes are returned and the source is not updated.
     """
+    if src_type == "openshift":
+        pytest.skip("Requires OpenShift")
     src = gen_valid_source(cleanup, src_type, scan_host)
     original_data = copy.deepcopy(src.fields())
 
@@ -176,6 +182,8 @@ def test_update_remove_field(src_type, cleanup, field):
         2) Update the source with no credentials or no hosts
     :expectedresults: Error codes are returned and the source is not updated.
     """
+    if src_type == "openshift":
+        pytest.skip("Requires OpenShift")
     src = gen_valid_source(cleanup, src_type, "localhost")
     # we have to use deep copy because these are nested dictionaries
     original_data = copy.deepcopy(src.fields())
@@ -196,6 +204,8 @@ def test_update_with_bad_host(src_type, scan_host, cleanup):
         2) Update the source with an invalid host
     :expectedresults: Error codes are returned and the source is not updated.
     """
+    if src_type == "openshift":
+        pytest.skip("Requires OpenShift")
     src = gen_valid_source(cleanup, src_type, scan_host)
     original_data = copy.deepcopy(src.fields())
     # Test updating source with bad host
@@ -216,6 +226,8 @@ def test_update_with_bad_exclude_host(src_type, scan_host, cleanup):
         2) Update the source with an invalid excluded host
     :expectedresults: Error codes are returned and the source is not updated.
     """
+    if src_type == "openshift":
+        pytest.skip("Requires OpenShift")
     src = gen_valid_source(cleanup, src_type, scan_host)
     original_data = src.fields()
     # Test updating source with bad excluded host
@@ -259,6 +271,8 @@ def test_negative_create_missing_data(src_type, cleanup, shared_client, field):
             c) credential id's
     :expectedresults: Error is thrown and no new source is created.
     """
+    if src_type == "openshift":
+        pytest.skip("Requires OpenShift")
     cred = Credential(cred_type=src_type, client=shared_client, password=uuid4())
     cred.create()
     cleanup.append(cred)
@@ -302,6 +316,8 @@ def test_negative_create_invalid_data(src_type, cleanup, shared_client, data):
         c) name
     :expectedresults: Error is thrown and no new source is created.
     """
+    if src_type == "openshift":
+        pytest.skip("Requires OpenShift")
     cred = Credential(cred_type=src_type, client=shared_client, password=uuid4())
     cred.create()
     cleanup.append(cred)
@@ -332,6 +348,8 @@ def test_read_all(src_type, cleanup, shared_client):
         3) Confirm that all sources are in the list.
     :expectedresults: All sources are present in data returned by API.
     """
+    if src_type == "openshift":
+        pytest.skip("Requires OpenShift")
     created_src_ids = set()
     # having a list of the sources locally will be helpful
     # for understanding failures as pytest will display the
@@ -381,6 +399,8 @@ def test_delete(src_type, cleanup, shared_client):
     :expectedresults: All sources are present on the server except the
         deleted source.
     """
+    if src_type == "openshift":
+        pytest.skip("Requires OpenShift")
     created_srcs = []
     num_srcs = random.randint(2, 20)
     echo_client = api.Client(response_handler=api.echo_handler)
@@ -413,8 +433,12 @@ def test_type_mismatch(src_type, cleanup, shared_client):
     :expectedresults: An error is thrown and no new source is created.
     :caseautomation: notautomated
     """
+    if src_type == "openshift":
+        pytest.skip("Requires OpenShift")
     src = gen_valid_source(cleanup, src_type, "localhost", create=False)
-    other_types = set(QPC_SOURCE_TYPES).difference(set((src_type,)))
+    qpc_src_types_minus_openshift = set(QPC_SOURCE_TYPES)
+    qpc_src_types_minus_openshift.discard("openshift")
+    other_types = qpc_src_types_minus_openshift.difference(set((src_type,)))
     other_cred = Credential(password=uuid4(), cred_type=random.choice(list(other_types)))
     other_cred.create()
     cleanup.append(other_cred)
@@ -440,6 +464,8 @@ def test_port_default(src_type, cleanup, shared_client):
     :expectedresults: A source is created with sensible default port.
     :caseautomation: notautomated
     """
+    if src_type == "openshift":
+        pytest.skip("Requires OpenShift")
     src = gen_valid_source(cleanup, src_type, "localhost", create=False)
     src.port = None
     src.create()
@@ -461,6 +487,8 @@ def test_create_with_port(src_type, cleanup, shared_client):
     :expectedresults: A source is created with user specified data.
     :caseautomation: notautomated
     """
+    if src_type == "openshift":
+        pytest.skip("Requires OpenShift")
     src = gen_valid_source(cleanup, src_type, "localhost", create=False)
     src.port = random.randint(20, 9000)
     src.create()
@@ -484,6 +512,8 @@ def test_negative_invalid_port(src_type, bad_port, cleanup, shared_client):
     :expectedresults: The source is not created
     :caseautomation: notautomated
     """
+    if src_type == "openshift":
+        pytest.skip("Requires OpenShift")
     src = gen_valid_source(cleanup, src_type, "localhost", create=False)
     src.port = bad_port
     src.client = api.Client(api.echo_handler)
@@ -510,6 +540,8 @@ def test_delete_with_dependencies(src_type, cleanup, shared_client):
     :expectedresults: The source is not created
     :caseautomation: notautomated
     """
+    if src_type == "openshift":
+        pytest.skip("Requires OpenShift")
     src1 = gen_valid_source(cleanup, src_type, "localhost")
     src2 = gen_valid_source(cleanup, src_type, "localhost")
     scns = []

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -16,6 +16,10 @@ credentials:
       type: 'satellite'
       password: 'CHANGEME'
       username: 'CHANGEUSERNAME'
+    - name: 'ocp'
+      type: 'openshift'
+      auth_token: 'TOKEN'
+
 
 qpc:
     # this is how you would configure quipucords if running
@@ -52,6 +56,14 @@ qpc:
           - 'sat6'
       name: 'sat6'
       type: 'satellite'
+      options:
+          ssl_cert_verify: false
+    - hosts:
+          - 'my_openshift.com'
+      credentials:
+          - 'ocp'
+      name: 'openshift'
+      type: 'openshift'
       options:
           ssl_cert_verify: false
     scans:


### PR DESCRIPTION
Initial support for testing OpenShift with credential and source.
The basic idea of this PR is to provide the minimal modifications to support testing Credentials and Sources for OpenShift without breaking the framework with the current version of Quipucords. Note that, the corresponding tests are currently marked as `skip` for openshift, so they will need further development.