### PR TITLE
Creates playbook for provisioning ocp instance

### DIFF
--- a/example_config.yaml
+++ b/example_config.yaml
@@ -119,3 +119,6 @@ inventory:
               version: '7.0.2'
           openjdk:
               version: '1.8'
+ocp:
+  token: "ha256~PA0VKgOhCJ3EIs-lYPK5iW88qLl6T1pZXYMqF_gzoRg"
+  server: "https://api.ci-ln-z2kjytb-76ef8.origin-ci-int-aws.dev.rhcloud.com:6443"

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -120,5 +120,7 @@ inventory:
           openjdk:
               version: '1.8'
 ocp:
-  token: "ha256~PA0VKgOhCJ3EIs-lYPK5iW88qLl6T1pZXYMqF_gzoRg"
+  token: "token-example"
   server: "https://api.ci-ln-z2kjytb-76ef8.origin-ci-int-aws.dev.rhcloud.com:6443"
+  hosts: "api.ci-ln-z2kjytb-76ef8.origin-ci-int-aws.dev.rhcloud.com"
+  image: "registry.redhat.io/discovery/discovery-server-rhel8"

--- a/scripts/provision_ocp_instance.yaml
+++ b/scripts/provision_ocp_instance.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Login and Provision OCP instance
+- name: Login and Provision OpenShift instance
   hosts: localhost
   vars:
       config_dir: "/home/user/.config/camayoc/"
@@ -17,4 +17,4 @@
       cmd: oc new-project discovery --description="discovery" --display-name="discovery"
   - name: Deploy new application
     shell:
-      cmd: oc new-app --image registry.redhat.io/discovery/discovery-server-rhel8 -l name=discovery
+      cmd: oc new-app --image "{{ dict_vars.ocp.image }}" -l name=discovery

--- a/scripts/provision_ocp_instance.yaml
+++ b/scripts/provision_ocp_instance.yaml
@@ -1,0 +1,20 @@
+---
+- name: Login and Provision OCP instance
+  hosts: localhost
+  vars:
+      config_dir: "/home/user/.config/camayoc/"
+      config_file: "config.yaml"
+
+  tasks:
+  - name: Retrieve variables dictionary
+    ansible.builtin.set_fact:
+      dict_vars : "{{ lookup('file', '{{config_dir}}{{config_file}}')|from_yaml }}"
+  - name: Login to cluster using kubeadmin
+    shell:
+      cmd: oc login --token "{{ dict_vars.ocp.token }}" --server "{{ dict_vars.ocp.server }}" --insecure-skip-tls-verify=true
+  - name: Create new project
+    shell:
+      cmd: oc new-project discovery --description="discovery" --display-name="discovery"
+  - name: Deploy new application
+    shell:
+      cmd: oc new-app --image registry.redhat.io/discovery/discovery-server-rhel8 -l name=discovery


### PR DESCRIPTION
After careful consideration I've come to the conclusion that the Camayoc is the right place for this playbook/test. If I place this on Camayoc I can take advantage of the already obligatory config.yaml to place my config variables such as token and server info instead of prompting the user for them. Camayoc does already most of the cli tasks I would need to do, so placing it here would also avoid code duplication. 
Observations:

1.  I gave up using ocp modules for Ansible since most of them are deprecated. People are using community.k8s nowadays, but using shell instead gave me more freedom.
2. To run this playbook successfully the user must have the oc installed in his computer. I didn't find where I should add this observation. Could you help me with this @ruda ?
3. I discarded the Molecule tests for this. This playbook usually runs in around 2 seconds. Tests were taking almost 3 minutes to complete. 

I will follow this PR with another that adds a test which will verify the details report for the existence of the discovery app I deployed. After we remodel ocp we can improve the test. 