### PR TITLE
Maintenance: pytest warnings and flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -9,17 +9,17 @@ repos:
     -   id: check-added-large-files
     -   id: debug-statements
 -   repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.3.0
+    rev: v3.9.0
     hooks:
     -   id: reorder-python-imports
--   repo: https://gitlab.com/pycqa/flake8.git
-    rev: 4.0.1
+-   repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
     hooks:
     -   id: flake8
         args: [--max-line-length, "100"]
         additional_dependencies: [flake8-docstrings]
 -   repo: https://github.com/ambv/black
-    rev: 22.6.0
+    rev: 22.10.0
     hooks:
     -   id: black
         args: [--safe, --quiet, --line-length, "100"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 filterwarnings = ignore::urllib3.exceptions.InsecureRequestWarning
+markers =
+    ssh_keyfile_path: mark test with SSH key file path mapped to /sshkeys/ on the server (deselect with '-m "not ssh_keyfile_path"')


### PR DESCRIPTION
* pytest: silence warnings regarding "pytest.mark.ssh_keyfile_path"
* pre-commit: get flake8 from github + update refs