### PR TITLE
Creates an Ansible Playbook for OpenShift project deployment

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -8,3 +8,4 @@ While still not a gospel, it allows to focus on things that would be easy to mis
 .. toctree::
 
     development/ui
+    development/openshift

--- a/docs/development/openshift.rst
+++ b/docs/development/openshift.rst
@@ -1,0 +1,17 @@
+OpenShift Tests
+===============
+
+.. caution::
+   Work in Progress! This documentation is a place for describing how to test Quipucords inspection of OpenShift clusters (OCP) with Camayoc.
+
+For running the Ansible Playbook to deploy a simple project to OpenShift, please make sure to have the OpenShift command-line interface (CLI) installed. Refer to the `oc <https://docs.openshift.com/container-platform/4.11/cli_reference/openshift_cli/getting-started-cli.html>`_ command for more information.
+
+Verify if you have the CLI installed:
+
+.. sourcecode:: shell
+
+   oc version
+   Client Version: 4.11.0-0.nightly-2022-05-18-171831
+   Kustomize Version: v4.5.4
+   Server Version: 4.10.43
+   Kubernetes Version: v1.23.12+8a6bfe4

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -64,6 +64,11 @@ qpc:
               - 'jbossamq-rhel-5-vc'
               - 'jbossamq-rhel-6-vc'
 
+# OpenShift (OCP) cluster
+openshift:
+    hostname: api.example.com:6443
+    token: sha256~...
+    skip_tls_verify: true
 
 # we host most of our test machines on a vcenter instance
 # and this section contains its URL and the credentials

--- a/scripts/openshift_deploy.yaml
+++ b/scripts/openshift_deploy.yaml
@@ -1,0 +1,25 @@
+---
+- name: Login and Provision OpenShift instance
+  hosts: localhost
+  vars:
+    config_dir: "/home/user/.config/camayoc/"
+    config_file: "config.yaml"
+    project: "discovery"
+    project_description: "Discovery project for the team."
+    project_display_name: "Discovery Project"
+    app_image: "registry.redhat.io/discovery/discovery-server-rhel8"
+
+  tasks:
+    - name: Retrieve variables dictionary
+      ansible.builtin.set_fact:
+        dict_vars: "{{ lookup('file', '{{config_dir}}/{{config_file}}')|from_yaml }}"
+    - name: Login to cluster using token
+      shell:
+        cmd: oc login --token "{{ dict_vars.openshift.token }}" --server "{{ dict_vars.openshift.hostname }}" --insecure-skip-tls-verify={{ dict_vars.openshift.skip_tls_verify }}
+    - name: Create new project
+      shell:
+        cmd: oc new-project "{{ project }}" --description="{{ project_description }}" --display-name="{{ project_display_name }}"
+    - name: Deploy new application
+      shell:
+        cmd: oc new-app --image "{{ app_image }}" -l name={{ project }}
+...


### PR DESCRIPTION
Creates an Ansible Playbook for provisioning an OpenShift (OCP) project for inspection.

Note: gave up using ocp modules for Ansible since most of them are deprecated. People are using community.k8s nowadays, but using shell with oc instead gave more freedom.

Co-authored-by: Ruda Moura <rmoura@redhat.com>