### PR TITLE
flake8 moved from GitLab to Github

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,8 +12,8 @@ repos:
     rev: v3.3.0
     hooks:
     -   id: reorder-python-imports
--   repo: https://gitlab.com/pycqa/flake8.git
-    rev: 4.0.1
+-   repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
     hooks:
     -   id: flake8
         args: [--max-line-length, "100"]


### PR DESCRIPTION
CI is currently broken because it tries to pull flake8 hook from GitLab - but it has moved to Github a long time ago. Gitlab was kept as outdated mirror for about a year, before disappearing in November last year.

Also, while we are at it, update flake8 to newer version.