### PR TITLE
DISCOVERY-86: fix test failing due to TIMEOUT

### DIFF
--- a/camayoc/tests/qpc/cli/test_sources.py
+++ b/camayoc/tests/qpc/cli/test_sources.py
@@ -1943,7 +1943,10 @@ def test_clear_all(isolated_filesystem, qpc_server_config, source_type):
         [(CONNECTION_PASSWORD_INPUT, utils.uuid4())],
     )
 
-    qpc_source_clear = pexpect.spawn("{} source clear --all".format(client_cmd))
+    qpc_source_clear = pexpect.spawn(
+        "{} source clear --all".format(client_cmd),
+        timeout=120,
+    )
     assert qpc_source_clear.expect(pexpect.EOF) == 0
     qpc_source_clear.close()
     assert qpc_source_clear.exitstatus >= 0


### PR DESCRIPTION
`camayoc/tests/qpc/cli/test_sources.py::test_clear_all` fails when running the whole test suite.

The problem is in dependency between tests. When running a whole suite, there's a bunch of sources created by other tests. To ensure they do not interfere with this test, it first calls `qpc source clear --all`. However, clearing all sources can take some time, and pexpect can raise timeout exception before the command finishes.

On my machine:

```
$ RUN_SCANS=False pytest -v -s camayoc/tests/qpc/cli/test_sources.py -k test_add
========================================================== 2 failed, 67 passed, 68 deselected in 327.57s (0:05:27) ===========================================================
$ time qpc source clear --all
All sources were removed.

real	0m33.806s
user	0m4.242s
sys	0m0.160s
```

`pexpect` timeout is 30 seconds by default. And I think it has even more sources to clear during standard run.

With this PR, we raise `pexpect` timeout to give qpc time it needs. I guessed 2 minutes should be enough, but we may tweak that later. We can also disable timeouts completely, but that might result in blocking the suite completely, if there's a bug that prevents qpc from ever finishing.