### PR TITLE
Update error messages received during source creation

### DIFF
--- a/camayoc/tests/qpc/utils.py
+++ b/camayoc/tests/qpc/utils.py
@@ -62,15 +62,9 @@ def assert_source_create_fails(source, source_type=""):
     create_response = source.create()
     assert create_response.status_code == 400
     expected_errors = [
-        {"hosts": ["Source of type vcenter must have a single hosts."]},
-        {"credentials": ["Source of type vcenter must have a single credential."]},
-        {"hosts": ["Source of type satellite must have a single hosts."]},
-        {"credentials": ["Source of type satellite must have a single credential."]},
-        {
-            "exclude_hosts": [
-                "The exclude_hosts option is not valid for source of type " + source_type + "."
-            ]
-        },
+        {"hosts": ["This source must have a single host."]},
+        {"credentials": ["This source must have a single credential."]},
+        {"exclude_hosts": ["The exclude_hosts option is not valid for this source."]},
     ]
     response = create_response.json()
     assert response in expected_errors


### PR DESCRIPTION
Error messages received when trying to create source changed, causing tests to fail.

I update all messages in one go, as 2 of them are checked in one test, and another in next one. But since all are next to each other, I think it's cleaner this way.

```
$ RUN_SCANS=False pytest -v -s 'camayoc/tests/qpc/api/v1/sources/test_manager_sources.py::test_negative_create_multiple' 'camayoc/tests/qpc/api/v1/sources/test_sources_common.py::test_create_exclude_hosts_negative'
camayoc/tests/qpc/api/v1/sources/test_manager_sources.py::test_negative_create_multiple[vcenter-scan_host0] PASSED
camayoc/tests/qpc/api/v1/sources/test_manager_sources.py::test_negative_create_multiple[vcenter-scan_host1] PASSED
camayoc/tests/qpc/api/v1/sources/test_manager_sources.py::test_negative_create_multiple[satellite-scan_host0] PASSED
camayoc/tests/qpc/api/v1/sources/test_manager_sources.py::test_negative_create_multiple[satellite-scan_host1] PASSED
camayoc/tests/qpc/api/v1/sources/test_sources_common.py::test_create_exclude_hosts_negative[satellite-localhost] PASSED
camayoc/tests/qpc/api/v1/sources/test_sources_common.py::test_create_exclude_hosts_negative[satellite-127.0.0.1] PASSED
camayoc/tests/qpc/api/v1/sources/test_sources_common.py::test_create_exclude_hosts_negative[satellite-example.com] PASSED
camayoc/tests/qpc/api/v1/sources/test_sources_common.py::test_create_exclude_hosts_negative[vcenter-localhost] PASSED
camayoc/tests/qpc/api/v1/sources/test_sources_common.py::test_create_exclude_hosts_negative[vcenter-127.0.0.1] PASSED
camayoc/tests/qpc/api/v1/sources/test_sources_common.py::test_create_exclude_hosts_negative[vcenter-example.com] PASSED

============================================================================ 10 passed in 46.25s =============================================================================
```