### PR TITLE
Update error message for the exclude_hosts option when testing sources with CLI

### DIFF
--- a/camayoc/tests/qpc/cli/test_sources.py
+++ b/camayoc/tests/qpc/cli/test_sources.py
@@ -765,8 +765,7 @@ def test_add_exclude_hosts_negative(
     )
     assert (
         qpc_source_add.expect(
-            "exclude_hosts: The exclude_hosts option "
-            + "is not valid for source of type {}.".format(source_type)
+            "exclude_hosts: The exclude_hosts option is not valid for this source."
         )
         == 0
     )


### PR DESCRIPTION
Pytest execution (snippet).

```
E               0: re.compile(b'exclude_hosts: The exclude_hosts option is not valid for source of type satellite.')

/Users/rmoura/Developer/camayoc/.venv/lib/python3.11/site-packages/pexpect/expect.py:122: EOF
=================================== short test summary info ====================================
FAILED camayoc/tests/qpc/cli/test_sources.py::test_add_exclude_hosts_negative[vcenter-192.168.0.42-192.168.0.43] - pexpect.exceptions.EOF: End Of File (EOF). Empty string style platform.
FAILED camayoc/tests/qpc/cli/test_sources.py::test_add_exclude_hosts_negative[satellite-192.168.0.42-192.168.0.43] - pexpect.exceptions.EOF: End Of File (EOF). Empty string style platform.
```

The qpc error message has changed for the exclude_hosts option.

```
$ qpc source add --name 54d0fac1-d178-4063-a5ec-f58ada0b2e56 --cred 948bf0dd-73ad-4190-b3d3-ff076da4da7b --hosts 192.168.0.42 --exclude-hosts 192.168.0.43 --type satellite
exclude_hosts: The exclude_hosts option is not valid for this source.
```

Related to #383.