### PR TITLE
Set Ibutsu component automatically based on test location

### DIFF
--- a/camayoc/tests/conftest.py
+++ b/camayoc/tests/conftest.py
@@ -2,13 +2,50 @@
 """Pytest customizations and fixtures for the quipucords tests."""
 import os
 import ssl
+from pathlib import Path
 
 import pytest
 from pyVim.connect import Disconnect
 from pyVim.connect import SmartConnect
 
+try:
+    from pytest_ibutsu.pytest_plugin import ibutsu_plugin_key
+    from pytest_ibutsu.pytest_plugin import ibutsu_result_key
+except ImportError:
+    ibutsu_plugin_key = None
+
 from camayoc import utils
 from camayoc.config import get_config
+
+
+def _ibutsu_enabled(config: pytest.Config) -> bool:
+    if not ibutsu_plugin_key:
+        return False
+    ibutsu = config.stash.get(ibutsu_plugin_key, None)
+    if ibutsu is None:
+        return False
+    return ibutsu.enabled
+
+
+def _fill_ibutsu_result(item: pytest.Item):
+    ibutsu_result = item.stash[ibutsu_result_key]
+    component = ibutsu_result.metadata.get("component", None)
+    if not component:
+        testpath, _, _ = item.location
+        testpath = Path(testpath).relative_to("camayoc/tests/qpc/")
+        component = testpath.parts[0]
+    ibutsu_result.component = component
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_collection_modifyitems(
+    session: pytest.Session, items: list[pytest.Item], config: pytest.Config
+) -> None:
+    ibutsu_enabled = _ibutsu_enabled(config)
+    if not ibutsu_enabled:
+        return
+    for item in items:
+        _fill_ibutsu_result(item)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
We would like Ibutsu dashboard to show rows for CLI, API and UI. To do that, we need to set `component` field in result object.

However, that field can't be set using command line. So we have to use custom pytest hook.

If pytest-ibutsu is not installed, none of this will be executed.


Side note: Jenkins calls pytest with 
```
--ibutsu-data discovery=${DISCOVERY_RELEASE} camayoc=1.0.0 dsc=${DISCOVERY_RELEASE} jenkins_job_number="${BUILD_NUMBER}"
```

`camayoc` field _could_ be set up using hook from this PR, but we would need to solve [Single-sourcing the package version](https://packaging.python.org/en/latest/guides/single-sourcing-package-version/) first.