### PR TITLE
DISCOVERY-281 - Add test coverage for OCP Clusters and Nodes

### DIFF
--- a/camayoc/constants.py
+++ b/camayoc/constants.py
@@ -5,6 +5,9 @@ from camayoc import utils
 MASKED_PASSWORD_OUTPUT = r"\*{8}"
 """Regex that matches password on outputs."""
 
+TOKEN_INPUT = "Provide a token for authentication.\r\nToken:"
+"""Connection token input prompt."""
+
 BECOME_PASSWORD_INPUT = (
     "Provide a privilege escalation password to be used when running a "
     "network scan.\r\nPassword:"

--- a/camayoc/tests/qpc/cli/test_openshift.py
+++ b/camayoc/tests/qpc/cli/test_openshift.py
@@ -1,0 +1,127 @@
+"""Tests for OpenShift sources.
+
+:caseautomation: automated
+:casecomponent: cli
+:caseimportance: high
+:caselevel: integration
+:requirement: OCP
+:testtype: functional
+:upstream: yes
+"""
+import json
+import pathlib
+import re
+import tarfile
+
+import pytest
+
+from camayoc import utils
+from camayoc.constants import TOKEN_INPUT
+from camayoc.tests.qpc.cli.utils import config_openshift
+from camayoc.tests.qpc.cli.utils import cred_add_and_check
+from camayoc.tests.qpc.cli.utils import report_download
+from camayoc.tests.qpc.cli.utils import scan_add_and_check
+from camayoc.tests.qpc.cli.utils import scan_job
+from camayoc.tests.qpc.cli.utils import scan_start
+from camayoc.tests.qpc.cli.utils import source_add_and_check
+from camayoc.tests.qpc.cli.utils import wait_for_scan
+
+
+def retrieve_report(scan_name, scan_job_id):
+    output_file = f"report-{scan_name}.tar.gz"
+    report_download({"scan-job": scan_job_id, "output-file": output_file})
+    details = deployments = None
+    with tarfile.open(output_file) as pkg:
+        for member in pkg.getmembers():
+            if member.name.endswith("details.json"):
+                data = pkg.extractfile(member).read()
+                details = json.loads(data)
+            if member.name.endswith("deployments.json"):
+                data = pkg.extractfile(member).read()
+                deployments = json.loads(data)
+    pathlib.Path.unlink(output_file)
+    return details, deployments
+
+
+def validate_openshift_report(cluster, details, deployments):
+    assert details["sources"]
+    assert deployments["system_fingerprints"]
+    cluster_version = cluster["version"]
+    cluster_id = cluster["cluster_id"]
+    cluster_nodes = cluster["nodes"]
+    total_clusters = 0
+    seen_nodes = []
+    facts = details["sources"][0]["facts"]
+    for fact in facts:
+        if "node" in fact:
+            assert fact["node"]["kind"] == "node"
+            seen_nodes.append(fact["node"]["name"])
+        if "cluster" in fact:
+            assert fact["cluster"]["uuid"] == cluster_id
+            assert fact["cluster"]["version"] == cluster_version
+            total_clusters += 1
+        if "projects" in fact:
+            assert len(fact["projects"]) > 0
+        if "workloads" in fact:
+            assert len(fact["workloads"]) > 0
+    assert total_clusters == 1, "Only one system fact should have a 'cluster' key"
+    assert set(cluster_nodes) == set(seen_nodes), "The number of expected nodes diverged"
+    #
+    # Fingerprints
+    #
+    seen_nodes = []
+    facts = deployments["system_fingerprints"]
+    for fact in facts:
+        assert fact["name"] in cluster_nodes
+        assert fact["cpu_count"] > 0
+        assert fact["architecture"] in ("x86_64",)
+        seen_nodes.append(fact["name"])
+    assert set(cluster_nodes) == set(seen_nodes), "The number of expected nodes diverged"
+
+
+@pytest.mark.parametrize(
+    "cluster", config_openshift(), ids=(x["hostname"] for x in config_openshift())
+)
+def test_openshift_clusters(cluster, qpc_server_config):
+    """Perform OpenShift inspection and validate results.
+
+    :id: b7719be5-5473-424f-895d-022ea9ae55d5
+    :description: Perform OpenShift inspection and validate cluster and nodes
+        results.
+    :steps:
+        1. Add source with credential for a cluster
+        2. Perform a scan
+        3. Collect the report
+    :expectedresults: The facts already knew about the cluster and nodes
+        have expected values in deployment and details reports.
+    """
+    cred_name = utils.uuid4()
+    cred_add_and_check(
+        {"name": cred_name, "token": None, "type": "openshift"},
+        [(TOKEN_INPUT, cluster["token"])],
+    )
+    source_name = utils.uuid4()
+    hostname = cluster["hostname"]
+    port = cluster.get("port", 6443)
+    ssl_cert_verify = not cluster["skip_tls_verify"]
+    source_add_and_check(
+        {
+            "name": source_name,
+            "cred": [cred_name],
+            "hosts": [hostname],
+            "port": port,
+            "ssl-cert-verify": ssl_cert_verify,
+            "type": "openshift",
+        }
+    )
+    scan_name = utils.uuid4()
+    scan_add_and_check({"name": scan_name, "sources": source_name})
+    output = scan_start({"name": scan_name})
+    match_scan_id = re.match(r'Scan "(\d+)" started.', output)
+    assert match_scan_id is not None
+    scan_job_id = match_scan_id.group(1)
+    wait_for_scan(scan_job_id, timeout=1200)
+    result = scan_job({"id": scan_job_id})
+    assert result["status"] == "completed"
+    details, deployments = retrieve_report(scan_name, scan_job_id)
+    validate_openshift_report(cluster, details, deployments)

--- a/camayoc/tests/qpc/cli/utils.py
+++ b/camayoc/tests/qpc/cli/utils.py
@@ -65,6 +65,15 @@ def config_sources():
     return [source for source in config_sources if source["name"] in scan_sources]
 
 
+def config_openshift():
+    """Return all OpenShift sources available on configuration file for CLI scans."""
+    try:
+        cfg = get_config().get("openshift", [])
+    except ConfigFileNotFoundError:
+        cfg = []
+    return cfg
+
+
 def config_scans():
     """Return all CLI scans available on the configuration file."""
     try:


### PR DESCRIPTION
Fix: DISCOVERY-281.

An OpenShift cluster is one or more instances belonging to a single product installation.  An instance is a host or VM running in the cloud. Each cluster will have a unique name called the `cluster_id`.

The objective of this test is to verify if Quipucords is performing OpenShift (OCP) inspection and collecting correct facts at the level of clusters and nodes.

Camayoc config.yaml for openshift with cluster and nodes.
```yaml
openshift:
  - hostname: api.sharedocp4upi412ovn.example.com
    port: 6443
    token: 'sha256~...'
    skip_tls_verify: true
    cluster_id: '97c44acf-e8f1-46eb-b6a5-6ed78ecf2659'
    version: '4.12.5'
    nodes: 6
    hosts:
      - 'master-0.sharedocp4upi412ovn.example.com'
      - 'master-1.sharedocp4upi412ovn.example.com'
      - 'master-2.sharedocp4upi412ovn.example.com'
      - 'worker-0.sharedocp4upi412ovn.example.com'
      - 'worker-1.sharedocp4upi412ovn.example.com'
      - 'worker-2.sharedocp4upi412ovn.example.com'
```

Open to discussion:
* What is the best place for the openshift configuration?
* Should split this in credential and source parts?
* Cluster provisioning and how to skip this test.
* How to handle token expiration?