### PR TITLE
Add data provider

### DIFF
--- a/camayoc/data_provider.py
+++ b/camayoc/data_provider.py
@@ -1,0 +1,145 @@
+import random
+from itertools import chain
+from itertools import cycle
+
+from littletable import Table
+
+from camayoc.config import settings
+from camayoc.exceptions import NoMatchingDataDefinitionException
+from camayoc.qpc_models import Credential
+from camayoc.qpc_models import Scan
+from camayoc.qpc_models import Source
+from camayoc.tests.qpc.utils import sort_and_delete
+from camayoc.utils import uuid4
+
+
+def replace_definition_name(definition, name=None):
+    if not name:
+        name = f"{definition.name}-{uuid4()}"
+    new_definition = definition.copy()
+    new_definition.name = name
+    return new_definition
+
+
+class ModelWorker:
+    def __init__(self, data_provider, definitions, model_class):
+        self._data_provider = data_provider
+        self._model_class = model_class
+        definition_table = Table()
+        definition_table.insert_many(definitions)
+        self._defined_models = definition_table
+        self._created_models = {}
+
+    def _select_definitions(self, match_criteria):
+        matching = self._defined_models.where(**match_criteria)
+        if not matching:
+            msg = (
+                "No data matching provided criteria. "
+                "Try changing 'match_criteria' or review Camayoc configuration."
+            )
+            raise NoMatchingDataDefinitionException(msg)
+        return list(matching)
+
+    def _create_model(self, model):
+        # FIXME: what should we do with possible HTTPError ?
+        model.create()
+        self._created_models[model.name] = model
+
+    def _create_dependencies(self, definition, new):
+        dependencies_ids = []
+        if issubclass(self._model_class, Credential):
+            return dependencies_ids
+
+        if issubclass(self._model_class, Source):
+            dependency_definitions = self._data_provider.credentials._select_definitions(
+                match_criteria={"name": Table.is_in(definition.credentials)}
+            )
+            for dependency_definition in dependency_definitions:
+                if new:
+                    dependency_definition = replace_definition_name(dependency_definition)
+                credential = self._data_provider.credentials._create_from_definition(
+                    definition=dependency_definition, new_dependencies=new, data_only=False
+                )
+                dependencies_ids.append(credential._id)
+            return dependencies_ids
+
+        if issubclass(self._model_class, Scan):
+            dependency_definitions = self._data_provider.sources._select_definitions(
+                match_criteria={"name": Table.is_in(definition.sources)}
+            )
+            for dependency_definition in dependency_definitions:
+                if new:
+                    dependency_definition = replace_definition_name(dependency_definition)
+                source = self._data_provider.sources._create_from_definition(
+                    definition=dependency_definition, new_dependencies=new, data_only=False
+                )
+                dependencies_ids.append(source._id)
+            return dependencies_ids
+
+    def _create_from_definition(self, definition, new_dependencies, data_only):
+        if existing_model := self._created_models.get(definition.name):
+            return existing_model
+
+        dependencies_ids = self._create_dependencies(definition, new=new_dependencies)
+        new_model = self._model_class.from_definition(definition, dependencies=dependencies_ids)
+
+        if not data_only:
+            self._create_model(new_model)
+
+        return new_model
+
+    def defined_many(self, match_criteria):
+        matching_definitions = self._select_definitions(match_criteria)
+        random.shuffle(matching_definitions)
+
+        for definition in matching_definitions:
+            model = self._create_from_definition(
+                definition=definition, new_dependencies=False, data_only=False
+            )
+            yield model
+
+    def defined_one(self, match_criteria):
+        defined_generator = self.defined_many(match_criteria)
+        return next(defined_generator)
+
+    def new_many(self, match_criteria, new_dependencies=True, data_only=True):
+        matching_definitions = self._select_definitions(match_criteria)
+        random.shuffle(matching_definitions)
+
+        for definition in cycle(matching_definitions):
+            definition = replace_definition_name(definition)
+            model = self._create_from_definition(
+                definition=definition, new_dependencies=new_dependencies, data_only=data_only
+            )
+            yield model
+
+    def new_one(self, match_criteria, new_dependencies=True, data_only=True):
+        new_generator = self.new_many(
+            match_criteria=match_criteria, new_dependencies=new_dependencies, data_only=data_only
+        )
+        return next(new_generator)
+
+
+class DataProvider:
+    def __init__(
+        self, credentials=settings.credentials, sources=settings.sources, scans=settings.scans
+    ):
+        self.credentials = ModelWorker(
+            data_provider=self, definitions=credentials, model_class=Credential
+        )
+        self.sources = ModelWorker(data_provider=self, definitions=sources, model_class=Source)
+        self.scans = ModelWorker(data_provider=self, definitions=scans, model_class=Scan)
+        self._stores = ("credentials", "sources", "scans")
+
+    def mark_for_cleanup(self, obj):
+        obj_name = f"manually-added-{obj.name}"
+        for store in self._stores:
+            worker = getattr(self, store)
+            if isinstance(obj, worker._model_class):
+                worker._created_models[obj_name] = obj
+
+    def cleanup(self):
+        trash = chain.from_iterable(
+            (getattr(self, store)._created_models.values() for store in self._stores)
+        )
+        sort_and_delete(trash)

--- a/camayoc/exceptions.py
+++ b/camayoc/exceptions.py
@@ -85,6 +85,12 @@ class APIResultsEmpty(DataProviderException):
     """
 
 
+class NoMatchingDataDefinitionException(DataProviderException):
+    """Requested match_criteria do not match anything in DataProvider
+    instance configuration.
+    """
+
+
 class FilteredAPIResultsEmpty(DataProviderException):
     """There are no objects in API request response results matching
     provided criteria.

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ install_requires =
     attrs
     dynaconf
     factory_boy
+    littletable
     pexpect
     playwright
     plumbum

--- a/tests/test_data_provider.py
+++ b/tests/test_data_provider.py
@@ -1,0 +1,178 @@
+from unittest import mock
+
+import pytest
+
+from camayoc.data_provider import DataProvider
+from camayoc.exceptions import NoMatchingDataDefinitionException
+from camayoc.types.settings import ScanOptions
+from camayoc.types.settings import SourceOptions
+from camayoc.types.settings import SSHNetworkCredentialOptions
+from camayoc.types.settings import VCenterCredentialOptions
+
+
+CREDENTIALS = [
+    SSHNetworkCredentialOptions(
+        **{
+            "name": "network",
+            "type": "network",
+            "username": "root",
+            "sshkeyfile": "~/.ssh/id_rsa",
+        }
+    ),
+    VCenterCredentialOptions(
+        **{
+            "name": "vcenter",
+            "type": "vcenter",
+            "password": "example1",
+            "username": "username1",
+        }
+    ),
+]
+SOURCES = [
+    SourceOptions(
+        **{
+            "name": "mynetwork",
+            "hosts": ["myfavnetwork.com"],
+            "credentials": ["network"],
+            "type": "network",
+        }
+    ),
+    SourceOptions(
+        **{
+            "name": "vcenter",
+            "hosts": ["my_vcenter.com"],
+            "credentials": ["vcenter"],
+            "type": "vcenter",
+            "options": {"ssl_cert_verify": False},
+        }
+    ),
+]
+SCANS = [
+    ScanOptions(
+        **{
+            "name": "networkscan",
+            "sources": ["mynetwork"],
+        }
+    ),
+    ScanOptions(
+        **{
+            "name": "VCenterOnly",
+            "sources": ["vcenter"],
+        }
+    ),
+]
+
+
+def test_defined_one():
+    dp = DataProvider(credentials=CREDENTIALS, sources=SOURCES, scans=SCANS)
+    with mock.patch("camayoc.api.Client"):
+        with mock.patch.object(dp.credentials._model_class, "create") as mock_create:
+            cred = dp.credentials.defined_one({"type": "network"})
+            mock_create.assert_called_once()
+    assert cred.name == "network"
+    assert cred.username == "root"
+    assert cred.ssh_keyfile == "~/.ssh/id_rsa"
+
+
+def test_defined_reuse():
+    dp = DataProvider(credentials=CREDENTIALS, sources=SOURCES, scans=SCANS)
+    with mock.patch("camayoc.api.Client"):
+        with mock.patch.object(dp.credentials._model_class, "create") as mock_create:
+            cred1 = dp.credentials.defined_one({"type": "network"})
+            cred2 = dp.credentials.defined_one({"type": "network"})
+            mock_create.assert_called_once()
+    assert cred1.name == "network"
+    assert cred1.username == "root"
+    assert cred1.ssh_keyfile == "~/.ssh/id_rsa"
+    assert cred1.equivalent(cred2)
+
+
+def test_new_one():
+    dp = DataProvider(credentials=CREDENTIALS, sources=SOURCES, scans=SCANS)
+    with mock.patch("camayoc.api.Client"):
+        with mock.patch.object(dp.credentials._model_class, "create") as mock_create:
+            cred = dp.credentials.new_one({"type": "network"}, data_only=False)
+            mock_create.assert_called_once()
+    assert cred.name != "network"
+    assert cred.username == "root"
+    assert cred.ssh_keyfile == "~/.ssh/id_rsa"
+
+
+def test_new_one_data_only():
+    dp = DataProvider(credentials=CREDENTIALS, sources=SOURCES, scans=SCANS)
+    with mock.patch("camayoc.api.Client"):
+        with mock.patch.object(dp.credentials._model_class, "create") as mock_create:
+            cred = dp.credentials.new_one({"type": "network"}, data_only=True)
+            mock_create.assert_not_called()
+    assert cred.name != "network"
+    assert cred.username == "root"
+    assert cred.ssh_keyfile == "~/.ssh/id_rsa"
+
+
+def test_new_with_dependencies():
+    dp = DataProvider(credentials=CREDENTIALS, sources=SOURCES, scans=SCANS)
+    with mock.patch("camayoc.api.Client"):
+        with mock.patch.object(dp.credentials._model_class, "create") as mock_cred_create:
+            with mock.patch.object(dp.sources._model_class, "create") as mock_source_create:
+                source1 = dp.sources.new_one(
+                    {"type": "network"}, new_dependencies=True, data_only=False
+                )
+                source2 = dp.sources.new_one(
+                    {"type": "network"}, new_dependencies=True, data_only=False
+                )
+                assert mock_cred_create.call_count == 2
+                assert mock_source_create.call_count == 2
+    assert len(dp.credentials._created_models) == 2
+    assert source1.name != "mynetwork"
+    assert source1.name.startswith("mynetwork")
+    assert source2.name.startswith("mynetwork")
+
+
+def test_new_without_dependencies():
+    dp = DataProvider(credentials=CREDENTIALS, sources=SOURCES, scans=SCANS)
+    with mock.patch("camayoc.api.Client"):
+        with mock.patch.object(dp.credentials._model_class, "create") as mock_cred_create:
+            with mock.patch.object(dp.sources._model_class, "create") as mock_source_create:
+                source1 = dp.sources.new_one(
+                    {"type": "network"}, new_dependencies=False, data_only=False
+                )
+                source2 = dp.sources.new_one(
+                    {"type": "network"}, new_dependencies=False, data_only=False
+                )
+                mock_cred_create.assert_called_once()
+                assert mock_source_create.call_count == 2
+    assert len(dp.credentials._created_models) == 1
+    assert source1.name != "mynetwork"
+    assert source1.name.startswith("mynetwork")
+    assert source2.name.startswith("mynetwork")
+
+
+def test_new_no_match():
+    dp = DataProvider(credentials=CREDENTIALS, sources=SOURCES, scans=SCANS)
+    with pytest.raises(NoMatchingDataDefinitionException):
+        dp.credentials.new_one({"nosuchkey": "nosuchvalue"})
+
+
+def test_automatic_cleanup():
+    dp = DataProvider(credentials=CREDENTIALS, sources=SOURCES, scans=SCANS)
+    with mock.patch("camayoc.api.Client"):
+        with mock.patch.object(dp.credentials._model_class, "delete") as mock_delete:
+            dp.credentials.new_one({"type": "network"}, data_only=False)
+            mock_delete.return_value = mock.Mock
+            mock_delete.return_value.status_code = mock.PropertyMock(return_value=200)
+            dp.cleanup()
+            mock_delete.assert_called()
+
+
+def test_mark_for_cleanup():
+    dp = DataProvider(credentials=CREDENTIALS, sources=SOURCES, scans=SCANS)
+    with mock.patch("camayoc.api.Client"):
+        with mock.patch.object(dp.credentials._model_class, "delete") as mock_delete:
+            cred = dp.credentials.new_one({"type": "network"}, data_only=True)
+            mock_delete.return_value = mock.Mock
+            mock_delete.return_value.status_code = mock.PropertyMock(return_value=200)
+            dp.cleanup()
+            mock_delete.assert_not_called()
+            dp.mark_for_cleanup(cred)
+            dp.cleanup()
+            mock_delete.assert_called()


### PR DESCRIPTION
This is a **proposal** of new data providing facility. It's far from complete, but it _may_ work for certain cases and I feel it's complete _enough_ to enable discussion about something tangible.

This is fundamental framework work that - once completed - will enable us to tackle DISCOVERY-293. As it turned out, it will also enable to mostly tackle DISCOVERY-284. In other words, with this done, we will be set up to run **all** API and CLI tests in CI.

Commit 2f62d0f0e42684dd5acb04442b8798640015f9d1 is for illustrative purposes only. I will remove it before opening PR for merge.

The basic assumption is that most of the time, tests want data that is valid, and that can be safely removed afterwards. Sometimes tests want only data (i.e. negative object creation tests), sometimes they want created data (i.e. negative object update tests). Sometimes they want shared dependencies (to save time needed to create them), sometimes they want completely new chain of dependencies (to ensure independence from other tests).

Another important point is that data should be created lazily, only when actually needed. This is large problem with current setup - scans are run automatically when running any test, because _some_ tests _might_ need scan data - even if we deselected them all in current pytest session.

The data provider is meant as a helper for most common use cases, not mandatory solution for all your data needs. You can still create and maintain QPCModels manually, as you did in the past. (Although I do feel that data provider should be the only one responsible for data cleanup, no matter if objects were created manually or not.)

Open questions:

* Should dependencies be created through the same interface as object under test itself? Let's say you are running CLI test for scans. With current implementation, you ask data provider for valid data of scan, but source and credential of this potential scan are going to be created through HTTP API anyway.
* Using [littletable](https://pypi.org/project/littletable/) for object querying. Alternative projects with similar goals are [asq](https://asq.readthedocs.io/en/latest/) and [PyFunctional](https://github.com/EntilZha/PyFunctional). I picked littletable because it seems to be the most active right now. But whatever we pick, I'm not super happy that it is becoming the core API camayoc is depending on. On the other hand, I am picking something _precisely_ because I don't want to invent my own iterable querying API.