### PR TITLE
Update codecov to GitHub Action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,6 @@ jobs:
       - name: Install dependencies
         run: |
           make install-dev
-          pip install codecov
       - name: Validate docstrings
         run: |
           make validate-docstrings

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,10 +22,13 @@ jobs:
       - name: Install dependencies
         run: |
           make install-dev
-          pip install codecov
       - name: Run tests with coverage
         run: |
           make test-coverage
       - name: Code Coverage
-        run: |
-          codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          fail_ci_if_error: true
+          verbose: true

--- a/Makefile
+++ b/Makefile
@@ -70,9 +70,13 @@ test:
 	pytest $(PYTEST_OPTIONS) tests
 
 test-coverage:
-	pytest --verbose --cov-report term --cov=camayoc.cli \
-	--cov=camayoc.config --cov=camayoc.exceptions --cov=camayoc.utils \
-	--cov=camayoc.api tests
+	pytest --verbose --cov-report term --cov-report xml:coverage.xml \
+	--cov=camayoc.cli \
+	--cov=camayoc.config \
+	--cov=camayoc.exceptions \
+	--cov=camayoc.utils \
+	--cov=camayoc.api \
+	tests
 
 test-qpc-no-scans:
 	RUN_SCANS=False pytest $(PYTEST_OPTIONS) camayoc/tests/qpc


### PR DESCRIPTION
Update codecov to Github Action. See #392 and https://about.codecov.io/blog/message-regarding-the-pypi-package/ .

I needed to create new repository secret named `CODECOV_TOKEN`.

Personally I don't see much value in codecov and would be fine dropping it altogether, but that's another discussion - for now, let's focus on ensuring that CI passes.