### PR TITLE
feat: add setting for qpc "package name"

### DIFF
--- a/camayoc/config.py
+++ b/camayoc/config.py
@@ -26,6 +26,7 @@ default_dynaconf_validators = [
     Validator("quipucords_server.password", default=""),
     Validator("quipucords_server.ssh_keyfile_path", default=""),
     Validator("quipucords_cli.executable", default="qpc"),
+    Validator("quipucords_cli.display_name", default="qpc"),
     Validator("openshift", default=[]),
     Validator("vcenter.hostname", default=""),
     Validator("vcenter.username", default=""),

--- a/camayoc/tests/qpc/cli/test_scans.py
+++ b/camayoc/tests/qpc/cli/test_scans.py
@@ -21,6 +21,7 @@ from .utils import scan_edit_and_check
 from .utils import scan_show_and_check
 from .utils import source_show
 from camayoc.utils import client_cmd
+from camayoc.utils import client_cmd_name
 from camayoc.utils import uuid4
 
 NEGATIVE_CASES = [1, -100, "redhat_packages", "ifconfig", {}, [], ["/foo/bar/"]]
@@ -123,7 +124,7 @@ def test_create_scan_with_disabled_products_negative(
             "sources": source_name,
             "disabled-optional-products": fail_cases,
         },
-        r"usage: {} scan add(.|[\r\n])*".format(client_cmd),
+        r"usage: {} scan add(.|[\r\n])*".format(client_cmd_name),
         exitstatus=2,
     )
 
@@ -367,7 +368,7 @@ def test_edit_scan_negative(isolated_filesystem, qpc_server_config, source):
     # Edit scan options
     scan_edit_and_check(
         {"name": scan_name, "sources": ""},
-        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd),
+        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd_name),
         exitstatus=2,
     )
 
@@ -381,7 +382,7 @@ def test_edit_scan_negative(isolated_filesystem, qpc_server_config, source):
     # Edit scan options
     scan_edit_and_check(
         {"name": scan_name, "sources": source_name, "max-concurrency": "abc"},
-        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd),
+        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd_name),
         exitstatus=2,
     )
 
@@ -392,7 +393,7 @@ def test_edit_scan_negative(isolated_filesystem, qpc_server_config, source):
             "sources": "",
             "disabled-optional-products": "not_a_real_product",
         },
-        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd),
+        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd_name),
         exitstatus=2,
     )
 
@@ -403,14 +404,14 @@ def test_edit_scan_negative(isolated_filesystem, qpc_server_config, source):
             "sources": "",
             "enabled-ext-product-search": "not_a_real_product",
         },
-        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd),
+        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd_name),
         exitstatus=2,
     )
 
     # Edit ext-product-search-dirs
     scan_edit_and_check(
         {"name": scan_name, "sources": "", "ext-product-search-dirs": "not-a-dir"},
-        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd),
+        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd_name),
         exitstatus=2,
     )
 

--- a/camayoc/tests/qpc/cli/test_sources.py
+++ b/camayoc/tests/qpc/cli/test_sources.py
@@ -28,6 +28,7 @@ from camayoc.tests.qpc.cli.utils import source_add_and_check
 from camayoc.tests.qpc.cli.utils import source_edit_and_check
 from camayoc.tests.qpc.cli.utils import source_show_and_check
 from camayoc.utils import client_cmd
+from camayoc.utils import client_cmd_name
 
 
 ISSUE_449_MARK = pytest.mark.xfail(
@@ -384,7 +385,7 @@ def test_add_with_ssl_cert_verify_negative(isolated_filesystem, qpc_server_confi
         expected_error = (
             "{} source add: error: argument --ssl-cert-verify: invalid "
             "choice: '{}' \\(choose from 'True', 'False', 'true', "
-            "'false'\\)".format(client_cmd, ssl_cert_verify)
+            "'false'\\)".format(client_cmd_name, ssl_cert_verify)
         )
         exitstatus = 2
     cred_add_and_check(
@@ -400,7 +401,7 @@ def test_add_with_ssl_cert_verify_negative(isolated_filesystem, qpc_server_confi
     qpc_source_add = pexpect.spawn(
         "{} source add --name {} --cred {} --hosts {} --port {} "
         "--ssl-cert-verify {} --type {}".format(
-            client_cmd, name, cred_name, hosts, port, ssl_cert_verify, source_type
+            client_cmd_name, name, cred_name, hosts, port, ssl_cert_verify, source_type
         )
     )
     assert qpc_source_add.expect(expected_error) == 0
@@ -486,7 +487,7 @@ def test_add_with_ssl_protocol_negative(isolated_filesystem, qpc_server_config, 
         expected_error = (
             "{} source add: error: argument --ssl-protocol: invalid choice: "
             "'{}' \\(choose from 'SSLv23', 'TLSv1', 'TLSv1_1', "
-            "'TLSv1_2'\\)".format(client_cmd, ssl_protocol)
+            "'TLSv1_2'\\)".format(client_cmd_name, ssl_protocol)
         )
         exitstatus = 2
     cred_add_and_check(
@@ -588,7 +589,7 @@ def test_add_with_disable_ssl_negative(isolated_filesystem, qpc_server_config, s
         expected_error = (
             "{} source add: error: argument --disable-ssl: invalid "
             "choice: '{}' \\(choose from 'True', 'False', 'true', "
-            "'false'\\)".format(client_cmd, disable_ssl)
+            "'false'\\)".format(client_cmd_name, disable_ssl)
         )
         exitstatus = 2
     cred_add_and_check(
@@ -1424,7 +1425,7 @@ def test_edit_ssl_cert_verify_negative(isolated_filesystem, qpc_server_config, s
         expected_error = (
             "{} source edit: error: argument --ssl-cert-verify: invalid "
             "choice: '{}' \\(choose from 'True', 'False', 'true', "
-            "'false'\\)".format(client_cmd, new_ssl_cert_verify)
+            "'false'\\)".format(client_cmd_name, new_ssl_cert_verify)
         )
         exitstatus = 2
         show_output_dict["options"] = {"ssl_cert_verify": ssl_cert_verify.lower()}
@@ -1568,7 +1569,7 @@ def test_edit_ssl_protocol_negative(isolated_filesystem, qpc_server_config, sour
         expected_error = (
             "{} source edit: error: argument --ssl-protocol: invalid "
             "choice: '{}' \\(choose from 'SSLv23', 'TLSv1', "
-            "'TLSv1_1', 'TLSv1_2'\\)".format(client_cmd, new_ssl_protocol)
+            "'TLSv1_1', 'TLSv1_2'\\)".format(client_cmd_name, new_ssl_protocol)
         )
         exitstatus = 2
         show_output_dict["options"] = {"ssl_protocol": ssl_protocol}
@@ -1710,7 +1711,7 @@ def test_edit_disable_ssl_negative(isolated_filesystem, qpc_server_config, sourc
         expected_error = (
             "{} source edit: error: argument --disable-ssl: invalid "
             "choice: '{}' \\(choose from 'True', 'False', 'true', "
-            "'false'\\)".format(client_cmd, new_disable_ssl)
+            "'false'\\)".format(client_cmd_name, new_disable_ssl)
         )
         exitstatus = 2
         show_output_dict["options"] = {"disable_ssl": disable_ssl.lower()}

--- a/camayoc/types/settings.py
+++ b/camayoc/types/settings.py
@@ -24,6 +24,7 @@ class QuipucordsServerOptions(BaseModel):
 
 class QuipucordsCLIOptions(BaseModel):
     executable: Optional[str] = "qpc"
+    display_name: Optional[str] = "qpc"
 
 
 class OpenShiftOptions(BaseModel):

--- a/camayoc/utils.py
+++ b/camayoc/utils.py
@@ -26,6 +26,11 @@ name_getter = operator.itemgetter("name")
 client_cmd = settings.quipucords_cli.executable
 """Client command to use during tests. Defaults to `qpc`."""
 
+client_cmd_name = settings.quipucords_cli.display_name
+"""Client name displayed on help texts. Defaults to `qpc`."""
+# this is useful when client_cmd is set to an absolute path, has extra arguments like -v
+# or even when we finally support running tests with proper dsc.
+
 
 def run_scans():
     """Check if scans should be run."""


### PR DESCRIPTION
cli executable might not be exactly what will appear on usage messages (for instance, if cli command is an absolute path and or an option is added to qpc - like `-v`).

For this reason I'm adding the extra setting.