### PR TITLE
Fix CLI tests with verbosity implicit

### DIFF
--- a/camayoc/tests/qpc/api/v1/sources/test_sources_common.py
+++ b/camayoc/tests/qpc/api/v1/sources/test_sources_common.py
@@ -28,7 +28,7 @@ from camayoc.utils import uuid4
 
 CREATE_DATA = ["localhost", "127.0.0.1", "example.com"]
 DEFAULT_PORT = {"network": 22, "vcenter": 443, "satellite": 443}
-INCOMPATIBLE_SRC_TYPES = {"vcenter", "satellite"}
+INCOMPATIBLE_SRC_TYPES = ("vcenter", "satellite")
 
 
 @pytest.mark.parametrize("src_type", QPC_SOURCE_TYPES)

--- a/camayoc/tests/qpc/cli/utils.py
+++ b/camayoc/tests/qpc/cli/utils.py
@@ -353,7 +353,7 @@ def scan_add_and_check(options, status_message_regex=None, exitstatus=0):
     if not status_message_regex:
         status_message_regex = r'Scan "{}" was added.'.format(options["name"])
     result = scan_add(options, exitstatus)
-    match = re.match(status_message_regex, result)
+    match = re.search(status_message_regex, result)
     assert match is not None
 
 


### PR DESCRIPTION
With the changes proposed here, all CLI tests will pass as long the setting for executable is set to `qpc -v`.

Also requires changes proposed on quipucords/qpc#230 and quipucords/quipucords#2331

NOTE: we should choose between this, #394 or #398