### PR TITLE
fix: DROP ALL CHECKS FOR NOW 'optional' MESSAGES

### DIFF
--- a/camayoc/tests/qpc/cli/test_credentials.py
+++ b/camayoc/tests/qpc/cli/test_credentials.py
@@ -226,7 +226,6 @@ def test_edit_username(isolated_filesystem, qpc_server_config, source_type):
         "{} cred edit --name={} --username={}".format(client_cmd, name, new_username)
     )
     qpc_cred_edit.logfile = BytesIO()
-    assert qpc_cred_edit.expect('Credential "{}" was updated'.format(name)) == 0
     assert qpc_cred_edit.expect(pexpect.EOF) == 0
     qpc_cred_edit.close()
     assert qpc_cred_edit.exitstatus == 0
@@ -303,7 +302,6 @@ def test_edit_password(isolated_filesystem, qpc_server_config, source_type):
     qpc_cred_edit = pexpect.spawn("{} cred edit --name={} --password".format(client_cmd, name))
     assert qpc_cred_edit.expect(CONNECTION_PASSWORD_INPUT) == 0
     qpc_cred_edit.sendline(new_password)
-    assert qpc_cred_edit.expect('Credential "{}" was updated'.format(name)) == 0
     assert qpc_cred_edit.expect(pexpect.EOF) == 0
     qpc_cred_edit.close()
     assert qpc_cred_edit.exitstatus == 0
@@ -386,7 +384,6 @@ def test_edit_sshkeyfile(isolated_filesystem, qpc_server_config):
         )
     )
     qpc_cred_edit.logfile = BytesIO()
-    assert qpc_cred_edit.expect('Credential "{}" was updated'.format(name)) == 0
     assert qpc_cred_edit.expect(pexpect.EOF) == 0
     qpc_cred_edit.close()
     assert qpc_cred_edit.exitstatus == 0
@@ -480,7 +477,6 @@ def test_edit_become_password(isolated_filesystem, qpc_server_config):
     )
     assert qpc_cred_edit.expect(BECOME_PASSWORD_INPUT) == 0
     qpc_cred_edit.sendline(new_become_password)
-    assert qpc_cred_edit.expect('Credential "{}" was updated'.format(name)) == 0
     assert qpc_cred_edit.expect(pexpect.EOF) == 0
     qpc_cred_edit.close()
     assert qpc_cred_edit.exitstatus == 0
@@ -572,7 +568,6 @@ def test_clear(isolated_filesystem, qpc_server_config):
     )
 
     qpc_cred_clear = pexpect.spawn("{} cred clear --name={}".format(client_cmd, name))
-    assert qpc_cred_clear.expect('Credential "{}" was removed'.format(name)) == 0
     assert qpc_cred_clear.expect(pexpect.EOF) == 0
     qpc_cred_clear.close()
     assert qpc_cred_clear.exitstatus == 0
@@ -652,13 +647,11 @@ def test_clear_with_source(isolated_filesystem, qpc_server_config):
     qpc_cred_clear.close()
     # delete the source using credential
     qpc_source_clear = pexpect.spawn("{} source clear --name={}".format(client_cmd, source_name))
-    assert qpc_source_clear.expect('Source "{}" was removed'.format(source_name)) == 0
     assert qpc_source_clear.expect(pexpect.EOF) == 0
     qpc_source_clear.close()
     assert qpc_source_clear.exitstatus == 0
     # successfully remove credential
     qpc_cred_clear = pexpect.spawn("{} cred clear --name={}".format(client_cmd, cred_name))
-    assert qpc_cred_clear.expect('Credential "{}" was removed'.format(cred_name)) == 0
     assert qpc_cred_clear.expect(pexpect.EOF) == 0
     qpc_cred_clear.close()
     assert qpc_cred_clear.exitstatus == 0
@@ -713,7 +706,6 @@ def test_clear_all(isolated_filesystem, qpc_server_config):
     output, exitstatus = pexpect.run(
         "{} cred clear --all".format(client_cmd), encoding="utf-8", withexitstatus=True
     )
-    assert "All credentials were removed." in output
     assert exitstatus == 0
 
     output, exitstatus = pexpect.run(

--- a/camayoc/tests/qpc/cli/test_reports.py
+++ b/camayoc/tests/qpc/cli/test_reports.py
@@ -338,15 +338,13 @@ def test_deployments_report(source_option, output_format, isolated_filesystem, q
     """
     scan = random.choice(_SCANS)
     output_path = "{}.{}".format(uuid4(), output_format)
-    output = report_deployments(
+    report_deployments(
         {
             source_option: scan[source_option],
             output_format: None,
             "output-file": output_path,
         }
     )
-
-    assert "Report written successfully." in output
 
     with open(output_path) as f:
         if output_format == "json":
@@ -381,15 +379,13 @@ def test_detail_report(source_option, output_format, isolated_filesystem, qpc_se
     """
     scan = random.choice(_SCANS)
     output_path = "{}.{}".format(uuid4(), output_format)
-    output = report_detail(
+    report_detail(
         {
             "output-file": output_path,
             output_format: None,
             source_option: scan[source_option],
         }
     )
-
-    assert "Report written successfully." in output
 
     with open(output_path) as f:
         if output_format == "json":
@@ -452,10 +448,9 @@ def test_merge_report(merge_by, isolated_filesystem, qpc_server_config):
 
     wait_for_report_merge(job_id)
     report_id = report_merge_status({"job": job_id})["report_id"]
-
+    assert report_id
     output_path = "{}.json".format(uuid4())
     output = report_deployments({"report": report_id, "json": None, "output-file": output_path})
-    assert "Report written successfully." in output
 
     with open(output_path) as f:
         report = json.load(f)
@@ -481,13 +476,8 @@ def test_download_report(source_option, isolated_filesystem, qpc_server_config):
     scan = random.choice(_SCANS)
     output_path = f"{uuid4()}"
     output_pkg = f"{output_path}.tar.gz"
-    output = report_download({source_option: scan[source_option], "output-file": output_pkg})
+    report_download({source_option: scan[source_option], "output-file": output_pkg})
     # Test that package downloaded
-    assert "successfully written to" in output, (
-        "Unexpected output from qpc report download! \n"
-        'Expected to find "successfully written to" in output.'
-        f"Actual output: {output}"
-    )
     assert os.path.isfile(output_pkg), (
         "Unexpected output from qpc report download!\n"
         f"Download package not found at expected location: {output_pkg}"

--- a/camayoc/tests/qpc/cli/test_scans.py
+++ b/camayoc/tests/qpc/cli/test_scans.py
@@ -10,13 +10,13 @@
 :upstream: yes
 """
 import json
-import re
 
 import pytest
 
 from .utils import config_sources
 from .utils import scan_add_and_check
 from .utils import scan_clear
+from .utils import scan_edit
 from .utils import scan_edit_and_check
 from .utils import scan_show_and_check
 from .utils import source_show
@@ -213,15 +213,14 @@ def test_edit_scan(isolated_filesystem, qpc_server_config, source):
     scan_show_and_check(scan_name, expected_result)
 
     # Edit scan options
-    scan_edit_and_check(
+    scan_edit(
         {
             "name": scan_name,
             "max-concurrency": 25,
             "disabled-optional-products": "jboss_eap",
             "enabled-ext-product-search": "jboss_fuse",
             "ext-product-search-dirs": "/foo/bar/",
-        },
-        r'Scan "{}" was updated.'.format(scan_name),
+        }
     )
 
     expected_result = {
@@ -301,14 +300,13 @@ def test_edit_scan_with_options(isolated_filesystem, qpc_server_config, source):
     scan_show_and_check(scan_name, expected_result)
 
     # Edit scan options
-    scan_edit_and_check(
+    scan_edit(
         {
             "name": scan_name,
             "max-concurrency": 25,
             "disabled-optional-products": "",
             "enabled-ext-product-search": "",
-        },
-        r'Scan "{}" was updated.'.format(scan_name),
+        }
     )
 
     expected_result = {
@@ -445,9 +443,7 @@ def test_clear(isolated_filesystem, qpc_server_config, source):
     scan_show_and_check(scan_name, expected_result)
 
     # Remove scan
-    result = scan_clear({"name": scan_name})
-    match = re.match(r'Scan "{}" was removed.'.format(scan_name), result)
-    assert match is not None
+    scan_clear({"name": scan_name})
 
 
 def test_clear_all(isolated_filesystem, qpc_server_config, scan_type):
@@ -479,6 +475,4 @@ def test_clear_all(isolated_filesystem, qpc_server_config, scan_type):
     scan_show_and_check(scan_name, expected_result)
 
     # Remove scan
-    result = scan_clear({"all": None})
-    match = re.match(r"All scans were removed.", result)
-    assert match is not None
+    scan_clear({"all": None})

--- a/camayoc/tests/qpc/cli/test_scans.py
+++ b/camayoc/tests/qpc/cli/test_scans.py
@@ -20,7 +20,6 @@ from .utils import scan_clear
 from .utils import scan_edit_and_check
 from .utils import scan_show_and_check
 from .utils import source_show
-from camayoc.utils import client_cmd
 from camayoc.utils import client_cmd_name
 from camayoc.utils import uuid4
 
@@ -151,7 +150,7 @@ def test_create_scan_with_extended_products_negative(
             "sources": source_name,
             "enabled-ext-product-search": fail_cases,
         },
-        r"usage: {} scan add(.|[\r\n])*".format(client_cmd),
+        r"usage: {} scan add(.|[\r\n])*".format(client_cmd_name),
         exitstatus=2,
     )
 

--- a/camayoc/tests/qpc/cli/test_sources.py
+++ b/camayoc/tests/qpc/cli/test_sources.py
@@ -141,7 +141,6 @@ def test_add_with_cred_hosts(isolated_filesystem, qpc_server_config, hosts, sour
             client_cmd, name, cred_name, hosts, source_type
         )
     )
-    assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
     assert qpc_source_add.exitstatus == 0
@@ -195,7 +194,6 @@ def test_add_with_cred_hosts_file(isolated_filesystem, qpc_server_config, hosts,
             client_cmd, name, cred_name, "hosts_file", source_type
         )
     )
-    assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
     assert qpc_source_add.exitstatus == 0
@@ -244,7 +242,6 @@ def test_add_with_port(isolated_filesystem, qpc_server_config, source_type):
         "{} source add --name {} --cred {} --hosts {} --port {} "
         "--type {}".format(client_cmd, name, cred_name, hosts, port, source_type)
     )
-    assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
     assert qpc_source_add.exitstatus == 0
@@ -337,7 +334,6 @@ def test_add_with_ssl_cert_verify(
         "{} source add --name {} --cred {} --hosts {} --ssl-cert-verify {} "
         "--type {}".format(client_cmd, name, cred_name, hosts, ssl_cert_verify, source_type)
     )
-    assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
     assert qpc_source_add.exitstatus == 0
@@ -440,7 +436,6 @@ def test_add_with_ssl_protocol(isolated_filesystem, qpc_server_config, source_ty
         "{} source add --name {} --cred {} --hosts {} --ssl-protocol {} "
         "--type {}".format(client_cmd, name, cred_name, hosts, ssl_protocol, source_type)
     )
-    assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
     assert qpc_source_add.exitstatus == 0
@@ -542,7 +537,6 @@ def test_add_with_disable_ssl(isolated_filesystem, qpc_server_config, source_typ
         "{} source add --name {} --cred {} --hosts {} --disable-ssl {} "
         "--type {}".format(client_cmd, name, cred_name, hosts, disable_ssl, source_type)
     )
-    assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
     assert qpc_source_add.exitstatus == 0
@@ -647,7 +641,6 @@ def test_add_with_exclude_hosts(
             client_cmd, name, cred_name, hosts, exclude_hosts, source_type
         )
     )
-    assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
     assert qpc_source_add.exitstatus == 0
@@ -706,7 +699,6 @@ def test_add_with_cred_hosts_exclude_file(
             client_cmd, name, cred_name, hosts, "exclude_hosts_file", source_type
         )
     )
-    assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
     assert qpc_source_add.exitstatus == 0
@@ -801,7 +793,6 @@ def test_edit_cred(isolated_filesystem, qpc_server_config, source_type):
             client_cmd, name, cred_name, hosts, source_type
         )
     )
-    assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
     assert qpc_source_add.exitstatus == 0
@@ -822,7 +813,6 @@ def test_edit_cred(isolated_filesystem, qpc_server_config, source_type):
     qpc_source_edit = pexpect.spawn(
         "{} source edit --name {} --cred {}".format(client_cmd, name, new_cred_name)
     )
-    assert qpc_source_edit.expect('Source "{}" was updated'.format(name)) == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
     qpc_source_edit.close()
     assert qpc_source_edit.exitstatus == 0
@@ -868,7 +858,6 @@ def test_edit_cred_negative(isolated_filesystem, qpc_server_config, source_type)
             client_cmd, name, cred_name, hosts, source_type
         )
     )
-    assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
     assert qpc_source_add.exitstatus == 0
@@ -911,7 +900,6 @@ def test_edit_hosts(isolated_filesystem, qpc_server_config, new_hosts, source_ty
             client_cmd, name, cred_name, hosts, source_type
         )
     )
-    assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
     assert qpc_source_add.exitstatus == 0
@@ -932,7 +920,6 @@ def test_edit_hosts(isolated_filesystem, qpc_server_config, new_hosts, source_ty
     qpc_source_edit = pexpect.spawn(
         "{} source edit --name {} --hosts {}".format(client_cmd, name, new_hosts)
     )
-    assert qpc_source_edit.expect('Source "{}" was updated'.format(name)) == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
     qpc_source_edit.close()
     assert qpc_source_edit.exitstatus == 0
@@ -981,7 +968,6 @@ def test_edit_hosts_file(isolated_filesystem, qpc_server_config, new_hosts, sour
         )
     )
     qpc_source_add.logfile = BytesIO()
-    assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
     assert qpc_source_add.exitstatus == 0
@@ -1006,7 +992,6 @@ def test_edit_hosts_file(isolated_filesystem, qpc_server_config, new_hosts, sour
         "{} source edit --name {} --hosts {}".format(client_cmd, name, "hosts_file")
     )
     qpc_source_edit.logfile = BytesIO()
-    assert qpc_source_edit.expect('Source "{}" was updated'.format(name)) == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
     qpc_source_edit.close()
     assert qpc_source_edit.exitstatus == 0
@@ -1057,7 +1042,6 @@ def test_edit_hosts_negative(isolated_filesystem, qpc_server_config, new_hosts, 
             client_cmd, name, cred_name, hosts, source_type
         )
     )
-    assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
     assert qpc_source_add.exitstatus == 0
@@ -1225,7 +1209,6 @@ def test_edit_port(isolated_filesystem, qpc_server_config, source_type):
             client_cmd, name, cred_name, hosts, port, source_type
         )
     )
-    assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
     assert qpc_source_add.exitstatus == 0
@@ -1246,7 +1229,6 @@ def test_edit_port(isolated_filesystem, qpc_server_config, source_type):
     qpc_source_edit = pexpect.spawn(
         "{} source edit --name {} --port {}".format(client_cmd, name, new_port)
     )
-    assert qpc_source_edit.expect('Source "{}" was updated'.format(name)) == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
     qpc_source_edit.close()
     assert qpc_source_edit.exitstatus == 0
@@ -1296,7 +1278,6 @@ def test_edit_port_negative(isolated_filesystem, qpc_server_config, source_type)
             client_cmd, name, cred_name, hosts, port, source_type
         )
     )
-    assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
     assert qpc_source_add.exitstatus == 0
@@ -1340,7 +1321,6 @@ def test_edit_ssl_cert_verify(isolated_filesystem, qpc_server_config, source_typ
         "{} source add --name {} --cred {} --hosts {} --ssl-cert-verify {} "
         "--type {}".format(client_cmd, name, cred_name, hosts, ssl_cert_verify, source_type)
     )
-    assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
     assert qpc_source_add.exitstatus == 0
@@ -1364,7 +1344,6 @@ def test_edit_ssl_cert_verify(isolated_filesystem, qpc_server_config, source_typ
             client_cmd, name, new_ssl_cert_verify
         )
     )
-    assert qpc_source_edit.expect('Source "{}" was updated'.format(name)) == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
     qpc_source_edit.close()
     assert qpc_source_edit.exitstatus == 0
@@ -1486,7 +1465,6 @@ def test_edit_ssl_protocol(isolated_filesystem, qpc_server_config, source_type):
         "{} source add --name {} --cred {} --hosts {} --ssl-protocol {} "
         "--type {}".format(client_cmd, name, cred_name, hosts, ssl_protocol, source_type)
     )
-    assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
     assert qpc_source_add.exitstatus == 0
@@ -1508,7 +1486,6 @@ def test_edit_ssl_protocol(isolated_filesystem, qpc_server_config, source_type):
     qpc_source_edit = pexpect.spawn(
         "{} source edit --name {} --ssl-protocol {}".format(client_cmd, name, new_ssl_protocol)
     )
-    assert qpc_source_edit.expect('Source "{}" was updated'.format(name)) == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
     qpc_source_edit.close()
     assert qpc_source_edit.exitstatus == 0
@@ -1628,7 +1605,6 @@ def test_edit_disable_ssl(isolated_filesystem, qpc_server_config, source_type):
         "{} source add --name {} --cred {} --hosts {} --disable-ssl {} "
         "--type {}".format(client_cmd, name, cred_name, hosts, disable_ssl, source_type)
     )
-    assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
     assert qpc_source_add.exitstatus == 0
@@ -1650,7 +1626,6 @@ def test_edit_disable_ssl(isolated_filesystem, qpc_server_config, source_type):
     qpc_source_edit = pexpect.spawn(
         "{} source edit --name {} --disable-ssl {}".format(client_cmd, name, new_disable_ssl)
     )
-    assert qpc_source_edit.expect('Source "{}" was updated'.format(name)) == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
     qpc_source_edit.close()
     assert qpc_source_edit.exitstatus == 0
@@ -1769,7 +1744,6 @@ def test_clear(isolated_filesystem, qpc_server_config, source_type):
             client_cmd, name, cred_name, hosts, source_type
         )
     )
-    assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
     assert qpc_source_add.exitstatus == 0
@@ -1788,7 +1762,6 @@ def test_clear(isolated_filesystem, qpc_server_config, source_type):
     )
 
     qpc_source_clear = pexpect.spawn("{} source clear --name={}".format(client_cmd, name))
-    assert qpc_source_clear.expect('Source "{}" was removed'.format(name)) == 0
     assert qpc_source_clear.expect(pexpect.EOF) == 0
     qpc_source_clear.close()
     assert qpc_source_clear.exitstatus == 0
@@ -1839,7 +1812,6 @@ def test_clear_with_scans(isolated_filesystem, qpc_server_config, source_type):
             client_cmd, name, cred_name, hosts, source_type
         )
     )
-    assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
     assert qpc_source_add.exitstatus == 0
@@ -1875,12 +1847,10 @@ def test_clear_with_scans(isolated_filesystem, qpc_server_config, source_type):
     ).encode("utf-8")
 
     qpc_scan_clear = pexpect.spawn("{} scan clear --name={}".format(client_cmd, scan_name))
-
-    assert qpc_scan_clear.expect('Scan "{}" was removed'.format(scan_name)) == 0
+    assert qpc_scan_clear.expect(pexpect.EOF) == 0
 
     qpc_source_clear = pexpect.spawn("{} source clear --name={}".format(client_cmd, name))
 
-    assert qpc_source_clear.expect('Source "{}" was removed'.format(name)) == 0
     assert qpc_source_clear.expect(pexpect.EOF) == 0
     qpc_source_clear.close()
     assert qpc_source_clear.exitstatus == 0
@@ -1968,7 +1938,6 @@ def test_clear_all(isolated_filesystem, qpc_server_config, source_type):
                 client_cmd, name, cred_name, hosts, source_type
             )
         )
-        assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
         assert qpc_source_add.expect(pexpect.EOF) == 0
         qpc_source_add.close()
         assert qpc_source_add.exitstatus == 0
@@ -1990,13 +1959,11 @@ def test_clear_all(isolated_filesystem, qpc_server_config, source_type):
     assert sorted(sources, key=name) == sorted(output, key=name)
 
     qpc_source_clear = pexpect.spawn("{} source clear --all".format(client_cmd))
-    assert qpc_source_clear.expect("All sources were removed") == 0
     assert qpc_source_clear.expect(pexpect.EOF) == 0
     qpc_source_clear.close()
     assert qpc_source_clear.exitstatus == 0
 
     qpc_source_list = pexpect.spawn("{} source list".format(client_cmd))
-    assert qpc_source_list.expect("No sources exist yet.") == 0
     assert qpc_source_list.expect(pexpect.EOF) == 0
     qpc_source_list.close()
     assert qpc_source_list.exitstatus == 0

--- a/camayoc/tests/qpc/cli/utils.py
+++ b/camayoc/tests/qpc/cli/utils.py
@@ -177,8 +177,6 @@ def cred_add_and_check(options, inputs=None, exitstatus=0):
     for prompt, value in inputs:
         assert qpc_cred_add.expect(prompt) == 0
         qpc_cred_add.sendline(value)
-    if "name" in options:
-        assert qpc_cred_add.expect('Credential "{}" was added'.format(options["name"])) == 0
     assert qpc_cred_add.expect(pexpect.EOF) == 0
     qpc_cred_add.close()
     assert qpc_cred_add.exitstatus == exitstatus
@@ -278,7 +276,6 @@ def source_add_and_check(options, inputs=None, exitstatus=0):
     for prompt, value in inputs:
         assert qpc_source_add.expect(prompt) == 0
         qpc_source_add.sendline(value)
-    assert qpc_source_add.expect('Source "{}" was added'.format(options["name"])) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
     assert qpc_source_add.exitstatus == exitstatus
@@ -313,7 +310,6 @@ def source_edit_and_check(options, inputs=None, exitstatus=0):
     for prompt, value in inputs:
         assert qpc_source_edit.expect(prompt) == 0
         qpc_source_edit.sendline(value)
-    assert qpc_source_edit.expect('Source "{}" was updated'.format(options["name"])) == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
     qpc_source_edit.close()
     assert qpc_source_edit.exitstatus == exitstatus
@@ -352,9 +348,7 @@ def scan_add_and_check(options, status_message_regex=None, exitstatus=0):
     assert options.get("name") is not None
     if not status_message_regex:
         status_message_regex = r'Scan "{}" was added.'.format(options["name"])
-    result = scan_add(options, exitstatus)
-    match = re.match(status_message_regex, result)
-    assert match is not None
+    scan_add(options, exitstatus)
 
 
 def scan_edit_and_check(options, status_message_regex, exitstatus=0):
@@ -369,7 +363,7 @@ def scan_edit_and_check(options, status_message_regex, exitstatus=0):
 
     result = scan_edit(options, exitstatus)
     match = re.match(status_message_regex, result)
-    assert match is not None
+    assert match is not None, result
 
 
 def scan_show_and_check(scan_name, expected_result=None):


### PR DESCRIPTION
With the changes proposed here, all CLI tests will pass.

Also requires changes proposed on quipucords/qpc#230 and quipucords/quipucords#2331

NOTE: we should choose between this, #394 or #397 