### PR TITLE
Fix test coverage for OCP Clusters and Nodes

### DIFF
--- a/camayoc/types/settings.py
+++ b/camayoc/types/settings.py
@@ -29,6 +29,7 @@ class QuipucordsCLIOptions(BaseModel):
 
 class OpenShiftOptions(BaseModel):
     hostname: str
+    port: int
     token: str
     skip_tls_verify: bool
 

--- a/camayoc/types/settings.py
+++ b/camayoc/types/settings.py
@@ -32,6 +32,9 @@ class OpenShiftOptions(BaseModel):
     port: int
     token: str
     skip_tls_verify: bool
+    cluster_id: str
+    version: str
+    nodes: list[str]
 
 
 class VCenterOptions(BaseModel):

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -32,6 +32,16 @@ openshift:
       port: 6443
       token: sha256~...
       skip_tls_verify: true
+      cluster_id: '00000000-1111-2222-3333-123456789abc'
+      version: '4.11.32'
+      nodes:
+          - 'master-0.example.com'
+          - 'master-1.example.com'
+          - 'master-2.example.com'
+          - 'worker-0.example.com'
+          - 'worker-1.example.com'
+          - 'worker-2.example.com'
+          - 'worker-3.example.com'
 
 # We host most of our test machines on a VCenter instance
 # and this section contains its URL and the credentials

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -28,7 +28,8 @@ quipucords_cli:
 
 # OpenShift (OCP) cluster
 openshift:
-    - hostname: api.example.com:6443
+    - hostname: api.example.com
+      port: 6443
       token: sha256~...
       skip_tls_verify: true
 


### PR DESCRIPTION
This fix completes the missing parameters for OpenShift inspection and validation. It will need further changes to adapt to the configuration style suggested in PR #389 . Relates to JIRA: DISCOVERY-281.