### PR TITLE
DISCOVERY-313: set command template with verbosity to capture output

### DIFF
--- a/camayoc/tests/qpc/cli/test_credentials.py
+++ b/camayoc/tests/qpc/cli/test_credentials.py
@@ -223,7 +223,7 @@ def test_edit_username(isolated_filesystem, qpc_server_config, source_type):
     )
 
     qpc_cred_edit = pexpect.spawn(
-        "{} cred edit --name={} --username={}".format(client_cmd, name, new_username)
+        "{} -v cred edit --name={} --username={}".format(client_cmd, name, new_username)
     )
     qpc_cred_edit.logfile = BytesIO()
     assert qpc_cred_edit.expect('Credential "{}" was updated'.format(name)) == 0
@@ -262,7 +262,7 @@ def test_edit_username_negative(isolated_filesystem, qpc_server_config):
     name = utils.uuid4()
     username = utils.uuid4()
     qpc_cred_edit = pexpect.spawn(
-        "{} cred edit --name={} --username={}".format(client_cmd, name, username)
+        "{} -v cred edit --name={} --username={}".format(client_cmd, name, username)
     )
     qpc_cred_edit.logfile = BytesIO()
     assert qpc_cred_edit.expect('Credential "{}" does not exist'.format(name)) == 0
@@ -300,7 +300,7 @@ def test_edit_password(isolated_filesystem, qpc_server_config, source_type):
         ),
     )
 
-    qpc_cred_edit = pexpect.spawn("{} cred edit --name={} --password".format(client_cmd, name))
+    qpc_cred_edit = pexpect.spawn("{} -v cred edit --name={} --password".format(client_cmd, name))
     assert qpc_cred_edit.expect(CONNECTION_PASSWORD_INPUT) == 0
     qpc_cred_edit.sendline(new_password)
     assert qpc_cred_edit.expect('Credential "{}" was updated'.format(name)) == 0
@@ -338,7 +338,7 @@ def test_edit_password_negative(isolated_filesystem, qpc_server_config):
     )
 
     name = utils.uuid4()
-    qpc_cred_edit = pexpect.spawn("{} cred edit --name={} --password".format(client_cmd, name))
+    qpc_cred_edit = pexpect.spawn("{} -v cred edit --name={} --password".format(client_cmd, name))
     assert qpc_cred_edit.expect('Credential "{}" does not exist'.format(name)) == 0
     assert qpc_cred_edit.expect(pexpect.EOF) == 0
     qpc_cred_edit.close()
@@ -381,7 +381,7 @@ def test_edit_sshkeyfile(isolated_filesystem, qpc_server_config):
     )
 
     qpc_cred_edit = pexpect.spawn(
-        "{} cred edit --name={} --sshkeyfile {}".format(
+        "{} -v cred edit --name={} --sshkeyfile {}".format(
             client_cmd, name, f"/sshkeys/{tmp_dir}/{new_sshkeyfile_name}"
         )
     )
@@ -428,7 +428,7 @@ def test_edit_sshkeyfile_negative(isolated_filesystem, qpc_server_config):
     sshkeyfile = Path(sshkeyfile_name)
     sshkeyfile.touch()
     qpc_cred_edit = pexpect.spawn(
-        "{} cred edit --name={} --sshkeyfile {}".format(
+        "{} -v cred edit --name={} --sshkeyfile {}".format(
             client_cmd, name, f"/sshkeys/{tmp_dir}/{sshkeyfile_name}"
         )
     )
@@ -476,7 +476,7 @@ def test_edit_become_password(isolated_filesystem, qpc_server_config):
     )
 
     qpc_cred_edit = pexpect.spawn(
-        "{} cred edit --name={} --become-password".format(client_cmd, name)
+        "{} -v cred edit --name={} --become-password".format(client_cmd, name)
     )
     assert qpc_cred_edit.expect(BECOME_PASSWORD_INPUT) == 0
     qpc_cred_edit.sendline(new_become_password)
@@ -515,7 +515,7 @@ def test_edit_become_password_negative(isolated_filesystem, qpc_server_config):
 
     name = utils.uuid4()
     qpc_cred_edit = pexpect.spawn(
-        "{} cred edit --name={} --become-password".format(client_cmd, name)
+        "{} -v cred edit --name={} --become-password".format(client_cmd, name)
     )
     assert qpc_cred_edit.expect('Credential "{}" does not exist'.format(name)) == 0
     assert qpc_cred_edit.expect(pexpect.EOF) == 0
@@ -535,7 +535,7 @@ def test_edit_no_credentials(isolated_filesystem, qpc_server_config):
     """
     name = utils.uuid4()
 
-    qpc_cred_edit = pexpect.spawn("{} cred edit --name={} --password".format(client_cmd, name))
+    qpc_cred_edit = pexpect.spawn("{} -v cred edit --name={} --password".format(client_cmd, name))
     qpc_cred_edit.logfile = BytesIO()
     assert qpc_cred_edit.expect('Credential "{}" does not exist'.format(name)) == 0
     assert qpc_cred_edit.expect(pexpect.EOF) == 0
@@ -571,13 +571,13 @@ def test_clear(isolated_filesystem, qpc_server_config):
         ),
     )
 
-    qpc_cred_clear = pexpect.spawn("{} cred clear --name={}".format(client_cmd, name))
+    qpc_cred_clear = pexpect.spawn("{} -v cred clear --name={}".format(client_cmd, name))
     assert qpc_cred_clear.expect('Credential "{}" was removed'.format(name)) == 0
     assert qpc_cred_clear.expect(pexpect.EOF) == 0
     qpc_cred_clear.close()
     assert qpc_cred_clear.exitstatus == 0
 
-    qpc_cred_show = pexpect.spawn("{} cred show --name={}".format(client_cmd, name))
+    qpc_cred_show = pexpect.spawn("{} -v cred show --name={}".format(client_cmd, name))
     assert qpc_cred_show.expect('Credential "{}" does not exist'.format(name)) == 0
     assert qpc_cred_show.expect(pexpect.EOF) == 0
     qpc_cred_show.close()
@@ -635,7 +635,7 @@ def test_clear_with_source(isolated_filesystem, qpc_server_config):
     output = source_show({"name": source_name})
     output = json.loads(output)
     # try to delete credential
-    qpc_cred_clear = pexpect.spawn("{} cred clear --name={}".format(client_cmd, cred_name))
+    qpc_cred_clear = pexpect.spawn("{} -v cred clear --name={}".format(client_cmd, cred_name))
     qpc_cred_clear.logfile = BytesIO()
     assert qpc_cred_clear.expect(pexpect.EOF) == 0
     assert (
@@ -651,19 +651,19 @@ def test_clear_with_source(isolated_filesystem, qpc_server_config):
     assert qpc_cred_clear.exitstatus == 1
     qpc_cred_clear.close()
     # delete the source using credential
-    qpc_source_clear = pexpect.spawn("{} source clear --name={}".format(client_cmd, source_name))
+    qpc_source_clear = pexpect.spawn("{} -v source clear --name={}".format(client_cmd, source_name))
     assert qpc_source_clear.expect('Source "{}" was removed'.format(source_name)) == 0
     assert qpc_source_clear.expect(pexpect.EOF) == 0
     qpc_source_clear.close()
     assert qpc_source_clear.exitstatus == 0
     # successfully remove credential
-    qpc_cred_clear = pexpect.spawn("{} cred clear --name={}".format(client_cmd, cred_name))
+    qpc_cred_clear = pexpect.spawn("{} -v cred clear --name={}".format(client_cmd, cred_name))
     assert qpc_cred_clear.expect('Credential "{}" was removed'.format(cred_name)) == 0
     assert qpc_cred_clear.expect(pexpect.EOF) == 0
     qpc_cred_clear.close()
     assert qpc_cred_clear.exitstatus == 0
     # try showing cred
-    qpc_cred_show = pexpect.spawn("{} cred show --name={}".format(client_cmd, cred_name))
+    qpc_cred_show = pexpect.spawn("{} -v cred show --name={}".format(client_cmd, cred_name))
     assert qpc_cred_show.expect('Credential "{}" does not exist'.format(cred_name)) == 0
     assert qpc_cred_show.expect(pexpect.EOF) == 0
     qpc_cred_show.close()
@@ -680,7 +680,7 @@ def test_clear_negative(isolated_filesystem, qpc_server_config):
         be removed.
     """
     name = utils.uuid4()
-    qpc_cred_clear = pexpect.spawn("{} cred clear --name={}".format(client_cmd, name))
+    qpc_cred_clear = pexpect.spawn("{} -v cred clear --name={}".format(client_cmd, name))
     qpc_cred_clear.logfile = BytesIO()
     assert qpc_cred_clear.expect(pexpect.EOF) == 0
     assert qpc_cred_clear.logfile.getvalue().strip().decode(
@@ -711,13 +711,13 @@ def test_clear_all(isolated_filesystem, qpc_server_config):
         cred_add_and_check(options, inputs)
 
     output, exitstatus = pexpect.run(
-        "{} cred clear --all".format(client_cmd), encoding="utf-8", withexitstatus=True
+        "{} -v cred clear --all".format(client_cmd), encoding="utf-8", withexitstatus=True
     )
     assert "All credentials were removed." in output
     assert exitstatus == 0
 
     output, exitstatus = pexpect.run(
-        "{} cred list".format(client_cmd), encoding="utf8", withexitstatus=True
+        "{} -v cred list".format(client_cmd), encoding="utf8", withexitstatus=True
     )
     assert "No credentials exist yet." in output
     assert exitstatus == 0

--- a/camayoc/tests/qpc/cli/test_sources.py
+++ b/camayoc/tests/qpc/cli/test_sources.py
@@ -137,7 +137,7 @@ def test_add_with_cred_hosts(isolated_filesystem, qpc_server_config, hosts, sour
     )
 
     qpc_source_add = pexpect.spawn(
-        "{} source add --name {} --cred {} --hosts {} --type {}".format(
+        "{} -v source add --name {} --cred {} --hosts {} --type {}".format(
             client_cmd, name, cred_name, hosts, source_type
         )
     )
@@ -191,7 +191,7 @@ def test_add_with_cred_hosts_file(isolated_filesystem, qpc_server_config, hosts,
         handler.write(hosts.replace(" ", "\n") + "\n")
 
     qpc_source_add = pexpect.spawn(
-        "{} source add --name {} --cred {} --hosts {} --type {}".format(
+        "{} -v source add --name {} --cred {} --hosts {} --type {}".format(
             client_cmd, name, cred_name, "hosts_file", source_type
         )
     )
@@ -241,7 +241,7 @@ def test_add_with_port(isolated_filesystem, qpc_server_config, source_type):
     )
 
     qpc_source_add = pexpect.spawn(
-        "{} source add --name {} --cred {} --hosts {} --port {} "
+        "{} -v source add --name {} --cred {} --hosts {} --port {} "
         "--type {}".format(client_cmd, name, cred_name, hosts, port, source_type)
     )
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
@@ -289,7 +289,7 @@ def test_add_with_port_negative(isolated_filesystem, qpc_server_config, source_t
     )
 
     qpc_source_add = pexpect.spawn(
-        "{} source add --name {} --cred {} --hosts {} --port {} --type {}".format(
+        "{} -v source add --name {} --cred {} --hosts {} --port {} --type {}".format(
             client_cmd, name, cred_name, hosts, port, source_type
         )
     )
@@ -334,7 +334,7 @@ def test_add_with_ssl_cert_verify(
     )
 
     qpc_source_add = pexpect.spawn(
-        "{} source add --name {} --cred {} --hosts {} --ssl-cert-verify {} "
+        "{} -v source add --name {} --cred {} --hosts {} --ssl-cert-verify {} "
         "--type {}".format(client_cmd, name, cred_name, hosts, ssl_cert_verify, source_type)
     )
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
@@ -437,7 +437,7 @@ def test_add_with_ssl_protocol(isolated_filesystem, qpc_server_config, source_ty
     )
 
     qpc_source_add = pexpect.spawn(
-        "{} source add --name {} --cred {} --hosts {} --ssl-protocol {} "
+        "{} -v source add --name {} --cred {} --hosts {} --ssl-protocol {} "
         "--type {}".format(client_cmd, name, cred_name, hosts, ssl_protocol, source_type)
     )
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
@@ -501,7 +501,7 @@ def test_add_with_ssl_protocol_negative(isolated_filesystem, qpc_server_config, 
     )
 
     qpc_source_add = pexpect.spawn(
-        "{} source add --name {} --cred {} --hosts {} --port {} "
+        "{} -v source add --name {} --cred {} --hosts {} --port {} "
         "--ssl-protocol {} --type {}".format(
             client_cmd, name, cred_name, hosts, port, ssl_protocol, source_type
         )
@@ -539,7 +539,7 @@ def test_add_with_disable_ssl(isolated_filesystem, qpc_server_config, source_typ
     )
 
     qpc_source_add = pexpect.spawn(
-        "{} source add --name {} --cred {} --hosts {} --disable-ssl {} "
+        "{} -v source add --name {} --cred {} --hosts {} --disable-ssl {} "
         "--type {}".format(client_cmd, name, cred_name, hosts, disable_ssl, source_type)
     )
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
@@ -603,7 +603,7 @@ def test_add_with_disable_ssl_negative(isolated_filesystem, qpc_server_config, s
     )
 
     qpc_source_add = pexpect.spawn(
-        "{} source add --name {} --cred {} --hosts {} --port {} "
+        "{} -v source add --name {} --cred {} --hosts {} --port {} "
         "--disable-ssl {} --type {}".format(
             client_cmd, name, cred_name, hosts, port, disable_ssl, source_type
         )
@@ -642,7 +642,7 @@ def test_add_with_exclude_hosts(
     )
 
     qpc_source_add = pexpect.spawn(
-        """{} source add --name {} --cred {} --hosts {} --exclude-hosts {}
+        """{} -v source add --name {} --cred {} --hosts {} --exclude-hosts {}
         --type {}""".format(
             client_cmd, name, cred_name, hosts, exclude_hosts, source_type
         )
@@ -701,7 +701,7 @@ def test_add_with_cred_hosts_exclude_file(
         handler.write(exclude_hosts.replace(" ", "\n") + "\n")
 
     qpc_source_add = pexpect.spawn(
-        """{} source add --name {} --cred {} --hosts {} --exclude-hosts={}
+        """{} -v source add --name {} --cred {} --hosts {} --exclude-hosts={}
         --type {}""".format(
             client_cmd, name, cred_name, hosts, "exclude_hosts_file", source_type
         )
@@ -759,7 +759,7 @@ def test_add_exclude_hosts_negative(
     )
 
     qpc_source_add = pexpect.spawn(
-        """{} source add --name {} --cred {} --hosts {} --exclude-hosts {}
+        """{} -v source add --name {} --cred {} --hosts {} --exclude-hosts {}
         --type {}""".format(
             client_cmd, name, cred_name, hosts, exclude_hosts, source_type
         )
@@ -797,7 +797,7 @@ def test_edit_cred(isolated_filesystem, qpc_server_config, source_type):
         )
 
     qpc_source_add = pexpect.spawn(
-        "{} source add --name {} --cred {} --hosts {} --type {}".format(
+        "{} -v source add --name {} --cred {} --hosts {} --type {}".format(
             client_cmd, name, cred_name, hosts, source_type
         )
     )
@@ -820,7 +820,7 @@ def test_edit_cred(isolated_filesystem, qpc_server_config, source_type):
     )
 
     qpc_source_edit = pexpect.spawn(
-        "{} source edit --name {} --cred {}".format(client_cmd, name, new_cred_name)
+        "{} -v source edit --name {} --cred {}".format(client_cmd, name, new_cred_name)
     )
     assert qpc_source_edit.expect('Source "{}" was updated'.format(name)) == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
@@ -864,7 +864,7 @@ def test_edit_cred_negative(isolated_filesystem, qpc_server_config, source_type)
     )
 
     qpc_source_add = pexpect.spawn(
-        "{} source add --name {} --cred {} --hosts {} --type {}".format(
+        "{} -v source add --name {} --cred {} --hosts {} --type {}".format(
             client_cmd, name, cred_name, hosts, source_type
         )
     )
@@ -874,7 +874,7 @@ def test_edit_cred_negative(isolated_filesystem, qpc_server_config, source_type)
     assert qpc_source_add.exitstatus == 0
 
     qpc_source_edit = pexpect.spawn(
-        "{} source edit --name {} --cred {}".format(client_cmd, invalid_name, utils.uuid4())
+        "{} -v source edit --name {} --cred {}".format(client_cmd, invalid_name, utils.uuid4())
     )
     qpc_source_edit.logfile = BytesIO()
     assert qpc_source_edit.expect('Source "{}" does not exist.'.format(invalid_name)) == 0
@@ -907,7 +907,7 @@ def test_edit_hosts(isolated_filesystem, qpc_server_config, new_hosts, source_ty
     )
 
     qpc_source_add = pexpect.spawn(
-        "{} source add --name {} --cred {} --hosts {} --type {}".format(
+        "{} -v source add --name {} --cred {} --hosts {} --type {}".format(
             client_cmd, name, cred_name, hosts, source_type
         )
     )
@@ -930,7 +930,7 @@ def test_edit_hosts(isolated_filesystem, qpc_server_config, new_hosts, source_ty
     )
 
     qpc_source_edit = pexpect.spawn(
-        "{} source edit --name {} --hosts {}".format(client_cmd, name, new_hosts)
+        "{} -v source edit --name {} --hosts {}".format(client_cmd, name, new_hosts)
     )
     assert qpc_source_edit.expect('Source "{}" was updated'.format(name)) == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
@@ -976,7 +976,7 @@ def test_edit_hosts_file(isolated_filesystem, qpc_server_config, new_hosts, sour
     )
 
     qpc_source_add = pexpect.spawn(
-        "{} source add --name {} --cred {} --hosts {} --type {}".format(
+        "{} -v source add --name {} --cred {} --hosts {} --type {}".format(
             client_cmd, name, cred_name, hosts, source_type
         )
     )
@@ -1003,7 +1003,7 @@ def test_edit_hosts_file(isolated_filesystem, qpc_server_config, new_hosts, sour
         handler.write(new_hosts.replace(" ", "\n") + "\n")
 
     qpc_source_edit = pexpect.spawn(
-        "{} source edit --name {} --hosts {}".format(client_cmd, name, "hosts_file")
+        "{} -v source edit --name {} --hosts {}".format(client_cmd, name, "hosts_file")
     )
     qpc_source_edit.logfile = BytesIO()
     assert qpc_source_edit.expect('Source "{}" was updated'.format(name)) == 0
@@ -1053,7 +1053,7 @@ def test_edit_hosts_negative(isolated_filesystem, qpc_server_config, new_hosts, 
     )
 
     qpc_source_add = pexpect.spawn(
-        "{} source add --name {} --cred {} --hosts {} --type {}".format(
+        "{} -v source add --name {} --cred {} --hosts {} --type {}".format(
             client_cmd, name, cred_name, hosts, source_type
         )
     )
@@ -1063,7 +1063,7 @@ def test_edit_hosts_negative(isolated_filesystem, qpc_server_config, new_hosts, 
     assert qpc_source_add.exitstatus == 0
 
     qpc_source_edit = pexpect.spawn(
-        "{} source edit --name {} --hosts {}".format(client_cmd, name, new_hosts)
+        "{} -v source edit --name {} --hosts {}".format(client_cmd, name, new_hosts)
     )
     qpc_source_edit.logfile = BytesIO()
     assert qpc_source_edit.expect("hosts: This source must have a single host.") == 0
@@ -1221,7 +1221,7 @@ def test_edit_port(isolated_filesystem, qpc_server_config, source_type):
     )
 
     qpc_source_add = pexpect.spawn(
-        "{} source add --name {} --cred {} --hosts {} --port {} --type {}".format(
+        "{} -v source add --name {} --cred {} --hosts {} --port {} --type {}".format(
             client_cmd, name, cred_name, hosts, port, source_type
         )
     )
@@ -1244,7 +1244,7 @@ def test_edit_port(isolated_filesystem, qpc_server_config, source_type):
     )
 
     qpc_source_edit = pexpect.spawn(
-        "{} source edit --name {} --port {}".format(client_cmd, name, new_port)
+        "{} -v source edit --name {} --port {}".format(client_cmd, name, new_port)
     )
     assert qpc_source_edit.expect('Source "{}" was updated'.format(name)) == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
@@ -1292,7 +1292,7 @@ def test_edit_port_negative(isolated_filesystem, qpc_server_config, source_type)
     )
 
     qpc_source_add = pexpect.spawn(
-        "{} source add --name {} --cred {} --hosts {} --port {} --type {}".format(
+        "{} -v source add --name {} --cred {} --hosts {} --port {} --type {}".format(
             client_cmd, name, cred_name, hosts, port, source_type
         )
     )
@@ -1302,7 +1302,7 @@ def test_edit_port_negative(isolated_filesystem, qpc_server_config, source_type)
     assert qpc_source_add.exitstatus == 0
 
     qpc_source_edit = pexpect.spawn(
-        "{} source edit --name {} --port {}".format(client_cmd, invalid_name, new_port)
+        "{} -v source edit --name {} --port {}".format(client_cmd, invalid_name, new_port)
     )
     qpc_source_edit.logfile = BytesIO()
     assert qpc_source_edit.expect('Source "{}" does not exist.'.format(invalid_name)) == 0
@@ -1337,7 +1337,7 @@ def test_edit_ssl_cert_verify(isolated_filesystem, qpc_server_config, source_typ
     )
 
     qpc_source_add = pexpect.spawn(
-        "{} source add --name {} --cred {} --hosts {} --ssl-cert-verify {} "
+        "{} -v source add --name {} --cred {} --hosts {} --ssl-cert-verify {} "
         "--type {}".format(client_cmd, name, cred_name, hosts, ssl_cert_verify, source_type)
     )
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
@@ -1360,7 +1360,7 @@ def test_edit_ssl_cert_verify(isolated_filesystem, qpc_server_config, source_typ
     )
 
     qpc_source_edit = pexpect.spawn(
-        "{} source edit --name {} --ssl-cert-verify {}".format(
+        "{} -v source edit --name {} --ssl-cert-verify {}".format(
             client_cmd, name, new_ssl_cert_verify
         )
     )
@@ -1407,7 +1407,7 @@ def test_edit_ssl_cert_verify_negative(isolated_filesystem, qpc_server_config, s
         "source_type": source_type,
     }
     if source_type == "network":
-        add_command = "{} source add --name {} --cred {} --hosts {} --port {} --type {}".format(
+        add_command = "{} -v source add --name {} --cred {} --hosts {} --port {} --type {}".format(
             client_cmd, name, cred_name, hosts, port, source_type
         )
         new_ssl_cert_verify = random.choice(QPC_BOOLEAN_VALUES)
@@ -1416,7 +1416,7 @@ def test_edit_ssl_cert_verify_negative(isolated_filesystem, qpc_server_config, s
     else:
         ssl_cert_verify = random.choice(QPC_BOOLEAN_VALUES)
         add_command = (
-            "{} source add --name {} --cred {} --hosts {} --port {} "
+            "{} -v source add --name {} --cred {} --hosts {} --port {} "
             "--ssl-cert-verify {} --type {}".format(
                 client_cmd, name, cred_name, hosts, port, ssl_cert_verify, source_type
             )
@@ -1483,7 +1483,7 @@ def test_edit_ssl_protocol(isolated_filesystem, qpc_server_config, source_type):
     )
 
     qpc_source_add = pexpect.spawn(
-        "{} source add --name {} --cred {} --hosts {} --ssl-protocol {} "
+        "{} -v source add --name {} --cred {} --hosts {} --ssl-protocol {} "
         "--type {}".format(client_cmd, name, cred_name, hosts, ssl_protocol, source_type)
     )
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
@@ -1506,7 +1506,7 @@ def test_edit_ssl_protocol(isolated_filesystem, qpc_server_config, source_type):
     )
 
     qpc_source_edit = pexpect.spawn(
-        "{} source edit --name {} --ssl-protocol {}".format(client_cmd, name, new_ssl_protocol)
+        "{} -v source edit --name {} --ssl-protocol {}".format(client_cmd, name, new_ssl_protocol)
     )
     assert qpc_source_edit.expect('Source "{}" was updated'.format(name)) == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
@@ -1551,7 +1551,7 @@ def test_edit_ssl_protocol_negative(isolated_filesystem, qpc_server_config, sour
         "source_type": source_type,
     }
     if source_type == "network":
-        add_command = "{} source add --name {} --cred {} --hosts {} --port {} --type {}".format(
+        add_command = "{} -v source add --name {} --cred {} --hosts {} --port {} --type {}".format(
             client_cmd, name, cred_name, hosts, port, source_type
         )
         new_ssl_protocol = random.choice(QPC_SSL_PROTOCOL_VALUES)
@@ -1560,7 +1560,7 @@ def test_edit_ssl_protocol_negative(isolated_filesystem, qpc_server_config, sour
     else:
         ssl_protocol = random.choice(QPC_SSL_PROTOCOL_VALUES)
         add_command = (
-            "{} source add --name {} --cred {} --hosts {} --port {} "
+            "{} -v source add --name {} --cred {} --hosts {} --port {} "
             "--ssl-protocol {} --type {}".format(
                 client_cmd, name, cred_name, hosts, port, ssl_protocol, source_type
             )
@@ -1589,7 +1589,7 @@ def test_edit_ssl_protocol_negative(isolated_filesystem, qpc_server_config, sour
     assert qpc_source_add.exitstatus == 0
 
     qpc_source_edit = pexpect.spawn(
-        "{} source edit --name {} --ssl-protocol {}".format(client_cmd, name, new_ssl_protocol)
+        "{} -v source edit --name {} --ssl-protocol {}".format(client_cmd, name, new_ssl_protocol)
     )
     assert qpc_source_edit.expect(expected_error) == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
@@ -1625,7 +1625,7 @@ def test_edit_disable_ssl(isolated_filesystem, qpc_server_config, source_type):
     )
 
     qpc_source_add = pexpect.spawn(
-        "{} source add --name {} --cred {} --hosts {} --disable-ssl {} "
+        "{} -v source add --name {} --cred {} --hosts {} --disable-ssl {} "
         "--type {}".format(client_cmd, name, cred_name, hosts, disable_ssl, source_type)
     )
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
@@ -1648,7 +1648,7 @@ def test_edit_disable_ssl(isolated_filesystem, qpc_server_config, source_type):
     )
 
     qpc_source_edit = pexpect.spawn(
-        "{} source edit --name {} --disable-ssl {}".format(client_cmd, name, new_disable_ssl)
+        "{} -v source edit --name {} --disable-ssl {}".format(client_cmd, name, new_disable_ssl)
     )
     assert qpc_source_edit.expect('Source "{}" was updated'.format(name)) == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
@@ -1693,7 +1693,7 @@ def test_edit_disable_ssl_negative(isolated_filesystem, qpc_server_config, sourc
         "source_type": source_type,
     }
     if source_type == "network":
-        add_command = "{} source add --name {} --cred {} --hosts {} --port {} --type {}".format(
+        add_command = "{} -v source add --name {} --cred {} --hosts {} --port {} --type {}".format(
             client_cmd, name, cred_name, hosts, port, source_type
         )
         new_disable_ssl = random.choice(QPC_BOOLEAN_VALUES)
@@ -1702,7 +1702,7 @@ def test_edit_disable_ssl_negative(isolated_filesystem, qpc_server_config, sourc
     else:
         disable_ssl = random.choice(QPC_BOOLEAN_VALUES)
         add_command = (
-            "{} source add --name {} --cred {} --hosts {} --port {} "
+            "{} -v source add --name {} --cred {} --hosts {} --port {} "
             "--disable-ssl {} --type {}".format(
                 client_cmd, name, cred_name, hosts, port, disable_ssl, source_type
             )
@@ -1731,7 +1731,7 @@ def test_edit_disable_ssl_negative(isolated_filesystem, qpc_server_config, sourc
     assert qpc_source_add.exitstatus == 0
 
     qpc_source_edit = pexpect.spawn(
-        "{} source edit --name {} --disable-ssl {}".format(client_cmd, name, new_disable_ssl)
+        "{} -v source edit --name {} --disable-ssl {}".format(client_cmd, name, new_disable_ssl)
     )
     assert qpc_source_edit.expect(expected_error) == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
@@ -1765,7 +1765,7 @@ def test_clear(isolated_filesystem, qpc_server_config, source_type):
     )
 
     qpc_source_add = pexpect.spawn(
-        "{} source add --name {} --cred {} --hosts {} --type {}".format(
+        "{} -v source add --name {} --cred {} --hosts {} --type {}".format(
             client_cmd, name, cred_name, hosts, source_type
         )
     )
@@ -1787,19 +1787,19 @@ def test_clear(isolated_filesystem, qpc_server_config, source_type):
         ),
     )
 
-    qpc_source_clear = pexpect.spawn("{} source clear --name={}".format(client_cmd, name))
+    qpc_source_clear = pexpect.spawn("{} -v source clear --name={}".format(client_cmd, name))
     assert qpc_source_clear.expect('Source "{}" was removed'.format(name)) == 0
     assert qpc_source_clear.expect(pexpect.EOF) == 0
     qpc_source_clear.close()
     assert qpc_source_clear.exitstatus == 0
 
-    qpc_source_clear = pexpect.spawn("{} source clear --name={}".format(client_cmd, name))
+    qpc_source_clear = pexpect.spawn("{} -v source clear --name={}".format(client_cmd, name))
     assert qpc_source_clear.expect('Source "{}" was not found.'.format(name)) == 0
     assert qpc_source_clear.expect(pexpect.EOF) == 0
     qpc_source_clear.close()
     assert qpc_source_clear.exitstatus == 1
 
-    qpc_source_show = pexpect.spawn("{} source show --name={}".format(client_cmd, name))
+    qpc_source_show = pexpect.spawn("{} -v source show --name={}".format(client_cmd, name))
     assert qpc_source_show.expect('Source "{}" does not exist.'.format(name)) == 0
     assert qpc_source_show.expect(pexpect.EOF) == 0
     qpc_source_show.close()
@@ -1835,7 +1835,7 @@ def test_clear_with_scans(isolated_filesystem, qpc_server_config, source_type):
     )
 
     qpc_source_add = pexpect.spawn(
-        "{} source add --name {} --cred {} --hosts {} --type {}".format(
+        "{} -v source add --name {} --cred {} --hosts {} --type {}".format(
             client_cmd, name, cred_name, hosts, source_type
         )
     )
@@ -1863,7 +1863,7 @@ def test_clear_with_scans(isolated_filesystem, qpc_server_config, source_type):
     scan_show_result = scan_show({"name": scan_name})
     scan_show_result = json.loads(scan_show_result)
 
-    qpc_source_clear = pexpect.spawn("{} source clear --name={}".format(client_cmd, name))
+    qpc_source_clear = pexpect.spawn("{} -v source clear --name={}".format(client_cmd, name))
 
     qpc_source_clear.logfile = BytesIO()
     assert qpc_source_clear.expect(pexpect.EOF) == 0
@@ -1874,24 +1874,24 @@ def test_clear_with_scans(isolated_filesystem, qpc_server_config, source_type):
         'Failed to remove source "%s".' % (scan_show_result["id"], scan_name, name)
     ).encode("utf-8")
 
-    qpc_scan_clear = pexpect.spawn("{} scan clear --name={}".format(client_cmd, scan_name))
+    qpc_scan_clear = pexpect.spawn("{} -v scan clear --name={}".format(client_cmd, scan_name))
 
     assert qpc_scan_clear.expect('Scan "{}" was removed'.format(scan_name)) == 0
 
-    qpc_source_clear = pexpect.spawn("{} source clear --name={}".format(client_cmd, name))
+    qpc_source_clear = pexpect.spawn("{} -v source clear --name={}".format(client_cmd, name))
 
     assert qpc_source_clear.expect('Source "{}" was removed'.format(name)) == 0
     assert qpc_source_clear.expect(pexpect.EOF) == 0
     qpc_source_clear.close()
     assert qpc_source_clear.exitstatus == 0
 
-    qpc_source_clear = pexpect.spawn("{} source clear --name={}".format(client_cmd, name))
+    qpc_source_clear = pexpect.spawn("{} -v source clear --name={}".format(client_cmd, name))
     assert qpc_source_clear.expect('Source "{}" was not found.'.format(name)) == 0
     assert qpc_source_clear.expect(pexpect.EOF) == 0
     qpc_source_clear.close()
     assert qpc_source_clear.exitstatus == 1
 
-    qpc_source_show = pexpect.spawn("{} source show --name={}".format(client_cmd, name))
+    qpc_source_show = pexpect.spawn("{} -v source show --name={}".format(client_cmd, name))
     assert qpc_source_show.expect('Source "{}" does not exist.'.format(name)) == 0
     assert qpc_source_show.expect(pexpect.EOF) == 0
     qpc_source_show.close()
@@ -1908,7 +1908,7 @@ def test_clear_negative(isolated_filesystem, qpc_server_config):
         can't be removed.
     """
     name = utils.uuid4()
-    qpc_source_clear = pexpect.spawn("{} source clear --name={}".format(client_cmd, name))
+    qpc_source_clear = pexpect.spawn("{} -v source clear --name={}".format(client_cmd, name))
     qpc_source_clear.logfile = BytesIO()
     assert qpc_source_clear.expect(pexpect.EOF) == 0
     assert qpc_source_clear.logfile.getvalue().strip() == 'Source "{}" was not found.'.format(
@@ -1964,7 +1964,7 @@ def test_clear_all(isolated_filesystem, qpc_server_config, source_type):
             source["options"] = {"ssl_cert_verify": True}
         sources.append(source)
         qpc_source_add = pexpect.spawn(
-            "{} source add --name {} --cred {} --hosts {} --type {}".format(
+            "{} -v source add --name {} --cred {} --hosts {} --type {}".format(
                 client_cmd, name, cred_name, hosts, source_type
             )
         )
@@ -1989,13 +1989,13 @@ def test_clear_all(isolated_filesystem, qpc_server_config, source_type):
     name = operator.itemgetter("name")
     assert sorted(sources, key=name) == sorted(output, key=name)
 
-    qpc_source_clear = pexpect.spawn("{} source clear --all".format(client_cmd))
+    qpc_source_clear = pexpect.spawn("{} -v source clear --all".format(client_cmd))
     assert qpc_source_clear.expect("All sources were removed") == 0
     assert qpc_source_clear.expect(pexpect.EOF) == 0
     qpc_source_clear.close()
     assert qpc_source_clear.exitstatus == 0
 
-    qpc_source_list = pexpect.spawn("{} source list".format(client_cmd))
+    qpc_source_list = pexpect.spawn("{} -v source list".format(client_cmd))
     assert qpc_source_list.expect("No sources exist yet.") == 0
     assert qpc_source_list.expect(pexpect.EOF) == 0
     qpc_source_list.close()

--- a/camayoc/tests/qpc/cli/utils.py
+++ b/camayoc/tests/qpc/cli/utils.py
@@ -174,7 +174,7 @@ def cred_add_and_check(options, inputs=None, exitstatus=0):
     """
     if "type" not in options:
         options["type"] = "network"
-    command = "{} cred add".format(client_cmd)
+    command = "{} -v cred add".format(client_cmd)
     for key, value in options.items():
         if value is None:
             command += " --{}".format(key)
@@ -205,7 +205,7 @@ def cred_show_and_check(options, output, exitstatus=0):
         network and \d+ respectively.
     :param exitstatus: Expected exit status code.
     """
-    command = "{} cred show".format(client_cmd)
+    command = "{} -v cred show".format(client_cmd)
     for key, value in options.items():
         if value is None:
             command += " --{}".format(key)
@@ -218,16 +218,16 @@ def cred_show_and_check(options, output, exitstatus=0):
     assert qpc_cred_show.exitstatus == exitstatus
 
 
-report_detail = functools.partial(cli_command, "{} report details".format(client_cmd))
+report_detail = functools.partial(cli_command, "{} -v report details".format(client_cmd))
 """Run ``qpc report detail`` with ``options`` and return output."""
 
-report_merge = functools.partial(cli_command, "{} report merge".format(client_cmd))
+report_merge = functools.partial(cli_command, "{} -v report merge".format(client_cmd))
 """Run ``qpc report merge`` with ``options`` and return output."""
 
 
 def report_merge_status(options=None, exitstatus=0):
     """Run ``qpc report merge-status`` with ``options`` and return output."""
-    output = cli_command("{} report merge-status".format(client_cmd), options, exitstatus)
+    output = cli_command("{} -v report merge-status".format(client_cmd), options, exitstatus)
     match = re.match(
         r"Report merge job (?P<id>\d+) is (?P<status>\w+)(.*id: " r'"(?P<report_id>\d+)")?',
         output,
@@ -236,10 +236,10 @@ def report_merge_status(options=None, exitstatus=0):
     return match.groupdict()
 
 
-report_deployments = functools.partial(cli_command, "{} report deployments".format(client_cmd))
+report_deployments = functools.partial(cli_command, "{} -v report deployments".format(client_cmd))
 """Run ``qpc report deployments`` with ``options`` and return output."""
 
-report_download = functools.partial(cli_command, "{} report download".format(client_cmd))
+report_download = functools.partial(cli_command, "{} -v report download".format(client_cmd))
 """Run ``qpc report download`` with ``options`` and return output."""
 
 
@@ -275,7 +275,7 @@ def source_add_and_check(options, inputs=None, exitstatus=0):
         options["exclude-hosts"] = " ".join(options["exclude-hosts"])
     if "type" not in options:
         options["type"] = "network"
-    command = "{} source add".format(client_cmd)
+    command = "{} -v source add".format(client_cmd)
     for key, value in options.items():
         if value is None:
             command += " --{}".format(key)
@@ -310,7 +310,7 @@ def source_edit_and_check(options, inputs=None, exitstatus=0):
         options["hosts"] = " ".join(options["hosts"])
     if "exclude-hosts" in options:
         options["exclude-hosts"] = " ".join(options["exclude-hosts"])
-    command = "{} source edit".format(client_cmd)
+    command = "{} -v source edit".format(client_cmd)
     for key, value in options.items():
         if value is None:
             command += " --{}".format(key)
@@ -337,7 +337,7 @@ def source_show_and_check(options, output, exitstatus=0):
         output. Make sure to escape any regular expression especial character.
     :param exitstatus: Expected exit status code.
     """
-    command = "{} source show".format(client_cmd)
+    command = "{} -v source show".format(client_cmd)
     for key, value in options.items():
         if value is None:
             command += " --{}".format(key)
@@ -397,28 +397,28 @@ def scan_show_and_check(scan_name, expected_result=None):
         assert expected_result == scan_show_result
 
 
-scan_cancel = functools.partial(cli_command, "{} scan cancel".format(client_cmd))
+scan_cancel = functools.partial(cli_command, "{} -v scan cancel".format(client_cmd))
 """Run ``qpc scan cancel`` command with ``options`` returning its output."""
 
-scan_pause = functools.partial(cli_command, "{} scan pause".format(client_cmd))
+scan_pause = functools.partial(cli_command, "{} -v scan pause".format(client_cmd))
 """Run ``qpc scan pause`` command with ``options`` returning its output."""
 
-scan_restart = functools.partial(cli_command, "{} scan restart".format(client_cmd))
+scan_restart = functools.partial(cli_command, "{} -v scan restart".format(client_cmd))
 """Run ``qpc scan restart`` command with ``options`` returning its output."""
 
-scan_add = functools.partial(cli_command, "{} scan add".format(client_cmd))
+scan_add = functools.partial(cli_command, "{} -v scan add".format(client_cmd))
 """Run ``qpc scan add`` command with ``options`` returning its output."""
 
-scan_clear = functools.partial(cli_command, "{} scan clear".format(client_cmd))
+scan_clear = functools.partial(cli_command, "{} -v scan clear".format(client_cmd))
 """Run ``qpc scan clear`` returning its output."""
 
-scan_edit = functools.partial(cli_command, "{} scan edit".format(client_cmd))
+scan_edit = functools.partial(cli_command, "{} -v scan edit".format(client_cmd))
 """Run ``qpc scan edit`` command with ``options`` returning its output."""
 
-scan_show = functools.partial(cli_command, "{} scan show".format(client_cmd))
+scan_show = functools.partial(cli_command, "{} -v scan show".format(client_cmd))
 """Run ``qpc scan show`` command with ``options`` returning its output."""
 
-scan_start = functools.partial(cli_command, "{} scan start".format(client_cmd))
+scan_start = functools.partial(cli_command, "{} -v scan start".format(client_cmd))
 """Run ``qpc scan start`` command with ``options`` returning its output."""
 
 source_show = functools.partial(cli_command, "{} source show".format(client_cmd))
@@ -427,7 +427,7 @@ source_show = functools.partial(cli_command, "{} source show".format(client_cmd)
 
 def scan_job(options=None, exitstatus=0):
     """Run ``qpc scan job`` command with ``options`` returning its output."""
-    return json.loads(cli_command("{} scan job".format(client_cmd), options, exitstatus))
+    return json.loads(cli_command("{} -v scan job".format(client_cmd), options, exitstatus))
 
 
 def setup_qpc():


### PR DESCRIPTION
This is essentially https://github.com/quipucords/camayoc/pull/394 .

Around Discovery 1.2 code freeze, we were a little panicked about all these failures and we wanted to make a smallest set of changes possible to get us going, fearing any possible regression. That's why we didn't move forward with #394 back then.

But I strongly feel that #394 is fundamentally correct solution to our problem - it's the test that should be responsible for deciding what CLI flags should be present or not. We should not rely on `quipucords_cli.executable` having some flag set for test to pass:

1. If flag is set at executable config level, it is hard or sometimes impossible to test system behavior *without* this flag. I believe this is a case for `-v` - right now it's not possible to write a test that would check how bare `qpc` executable will behave. (Whether we want such test is completely different discussion - but test framework shouldn't prevent us from having it).
2. "Executable" means script / binary / application *without* arguments and flags in literally every context out there. We should change meaning of established terms at the whim.