### PR TITLE
Refactor: Rename camayoc.cli module to camayoc.command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ test:
 
 test-coverage:
 	pytest --verbose --cov-report term --cov-report xml:coverage.xml \
-	--cov=camayoc.cli \
+	--cov=camayoc.command \
 	--cov=camayoc.config \
 	--cov=camayoc.exceptions \
 	--cov=camayoc.utils \

--- a/camayoc/command.py
+++ b/camayoc/command.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""A client for running local or remote commands."""
+"""Execute local or remote commands."""
 import socket
 from collections import namedtuple
 
@@ -21,7 +21,7 @@ def code_handler(completed_proc):
     """Check the process for a non-zero return code. Return the process.
 
     Check the return code by calling ``completed_proc.check_returncode()``.
-    See: :meth:`camayoc.cli.CompletedProcess.check_returncode`.
+    See: :meth:`camayoc.command.CompletedProcess.check_returncode`.
     """
     completed_proc.check_returncode()
     return completed_proc
@@ -41,7 +41,7 @@ class CompletedProcess(object):
     All constructor arguments are stored as instance attributes.
 
     :param args: A string or a sequence. The arguments passed to
-        :meth:`camayoc.cli.Client.run`.
+        :meth:`camayoc.command.Command.run`.
     :param returncode: The integer exit code of the executed process. Negative
         for signals.
     :param stdout: The standard output of the executed process.
@@ -100,16 +100,16 @@ class CompletedProcess(object):
             )
 
 
-class Client(object):
-    """A convenience object for working with a CLI.
+class Command(object):
+    """A convenience class for working with local or remote commands.
 
     This class provides the ability to execute shell commands on either the
     local system or a remote system. Here is a pedagogic usage example:
 
-    >>> from camayoc import cli
-    >>> system = cli.System(hostname='localhost', transport='local')
-    >>> client = cli.Client(system)
-    >>> response = client.run(('echo', '-n', 'foo'))
+    >>> from camayoc import command
+    >>> system = command.System(hostname='localhost', transport='local')
+    >>> cmd = command.Command(system)
+    >>> response = cmd.run(('echo', '-n', 'foo'))
     >>> response.returncode == 0
     True
     >>> response.stdout == 'foo'
@@ -121,7 +121,7 @@ class Client(object):
     verbose: smartly chosen defaults mean that most real code is much more
     concise.
 
-    You can customize how ``Client`` objects execute commands and handle
+    You can customize how ``Command`` objects execute commands and handle
     responses by fiddling with the two public instance attributes:
 
     ``machine``
@@ -139,10 +139,10 @@ class Client(object):
     against the current system's hostname.  If they match, ``machine`` is set
     to execute commands locally; and vice versa.
 
-    :param camayoc.cli.System system: Information about the system on which
+    :param camayoc.command.System system: Information about the system on which
         commands will be executed.
     :param response_handler: A callback function. Defaults to
-        :func:`camayoc.cli.code_handler`.
+        :func:`camayoc.command.code_handler`.
 
     .. _Plumbum: http://plumbum.readthedocs.io/en/latest/index.html
     """
@@ -173,7 +173,7 @@ class Client(object):
         This method is a thin wrapper around Plumbum's `BaseCommand.run`_
         method, which is itself a thin wrapper around the standard library's
         `subprocess.Popen`_ class. See their documentation for detailed usage
-        instructions. See :class:`camayoc.cli.Client` for a usage example.
+        instructions. See :class:`camayoc.command.Command` for a usage example.
 
         .. _BaseCommand.run:
            http://plumbum.readthedocs.io/en/latest/api/commands.html#plumbum.commands.base.BaseCommand.run

--- a/camayoc/exceptions.py
+++ b/camayoc/exceptions.py
@@ -3,9 +3,9 @@
 
 
 class CalledProcessError(Exception):
-    """Indicates a CLI process has a non-zero return code.
+    """Indicates a command process has a non-zero return code.
 
-    See :meth:`camayoc.cli.CompletedProcess` for more information.
+    See :meth:`camayoc.command.CompletedProcess` for more information.
     """
 
     def __str__(self):

--- a/camayoc/tests/utils.py
+++ b/camayoc/tests/utils.py
@@ -5,7 +5,7 @@ import time
 
 from pyVmomi import vim
 
-from camayoc import cli
+from camayoc import command
 
 
 def get_vcenter_vms(vcenter_client):
@@ -95,13 +95,13 @@ def vcenter_vms(vms):
         power_off_vms(vms)
 
 
-def is_live(client, server, num_pings=10):
+def is_live(cmd, server, num_pings=10):
     """Test if server responds to ping.
 
     Returns true if server is reachable, false otherwise.
     """
-    client.response_handler = cli.echo_handler
-    ping = client.run(("ping", "-c", num_pings, server))
+    cmd.response_handler = command.echo_handler
+    ping = cmd.run(("ping", "-c", num_pings, server))
     return ping.returncode == 0
 
 
@@ -118,11 +118,11 @@ def wait_until_live(servers, timeout=360):
     valid host, the scan will go on and only facts about reached hosts will be
     tested.
     """
-    system = cli.System(hostname="localhost", transport="local")
-    client = cli.Client(system)
+    system = command.System(hostname="localhost", transport="local")
+    cmd = command.Command(system)
 
     unreached = servers
     while unreached and timeout > 0:
-        unreached = [host for host in unreached if not is_live(client, host)]
+        unreached = [host for host in unreached if not is_live(cmd, host)]
         time.sleep(10)
         timeout -= 10

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -43,6 +43,7 @@ reference for developers, not a gospel.
     api/camayoc.tests.qpc.cli.conftest
     api/camayoc.tests.qpc.cli.csv_report_parsing
     api/camayoc.tests.qpc.cli.test_credentials
+    api/camayoc.tests.qpc.cli.test_openshift
     api/camayoc.tests.qpc.cli.test_reports
     api/camayoc.tests.qpc.cli.test_scanjobs
     api/camayoc.tests.qpc.cli.test_scans
@@ -59,6 +60,8 @@ reference for developers, not a gospel.
     api/camayoc.tests.qpc.ui.views
     api/camayoc.tests.qpc.utils
     api/camayoc.tests.utils
+    api/camayoc.types
+    api/camayoc.types.settings
     api/camayoc.ui
     api/camayoc.ui.client
     api/camayoc.ui.decorators

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,7 +9,7 @@ reference for developers, not a gospel.
 
     api/camayoc
     api/camayoc.api
-    api/camayoc.cli
+    api/camayoc.command
     api/camayoc.config
     api/camayoc.constants
     api/camayoc.exceptions
@@ -77,5 +77,6 @@ reference for developers, not a gospel.
     api/camayoc.utils
     api/tests
     api/tests.test_api
-    api/tests.test_cli
+    api/tests.test_command
+    api/tests.test_settings
     api/tests.test_utils

--- a/docs/api/camayoc.cli.rst
+++ b/docs/api/camayoc.cli.rst
@@ -1,7 +1,0 @@
-camayoc.cli module
-==================
-
-.. automodule:: camayoc.cli
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/api/camayoc.command.rst
+++ b/docs/api/camayoc.command.rst
@@ -1,7 +1,7 @@
-tests.test\_cli module
+camayoc.command module
 ======================
 
-.. automodule:: tests.test_cli
+.. automodule:: camayoc.command
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/api/camayoc.rst
+++ b/docs/api/camayoc.rst
@@ -13,6 +13,7 @@ Subpackages
    :maxdepth: 4
 
    camayoc.tests
+   camayoc.types
    camayoc.ui
 
 Submodules
@@ -22,7 +23,7 @@ Submodules
    :maxdepth: 4
 
    camayoc.api
-   camayoc.cli
+   camayoc.command
    camayoc.config
    camayoc.constants
    camayoc.exceptions

--- a/docs/api/camayoc.tests.qpc.cli.rst
+++ b/docs/api/camayoc.tests.qpc.cli.rst
@@ -15,6 +15,7 @@ Submodules
    camayoc.tests.qpc.cli.conftest
    camayoc.tests.qpc.cli.csv_report_parsing
    camayoc.tests.qpc.cli.test_credentials
+   camayoc.tests.qpc.cli.test_openshift
    camayoc.tests.qpc.cli.test_reports
    camayoc.tests.qpc.cli.test_scanjobs
    camayoc.tests.qpc.cli.test_scans

--- a/docs/api/camayoc.tests.qpc.cli.test_openshift.rst
+++ b/docs/api/camayoc.tests.qpc.cli.test_openshift.rst
@@ -1,0 +1,7 @@
+camayoc.tests.qpc.cli.test\_openshift module
+============================================
+
+.. automodule:: camayoc.tests.qpc.cli.test_openshift
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/camayoc.types.rst
+++ b/docs/api/camayoc.types.rst
@@ -1,0 +1,15 @@
+camayoc.types package
+=====================
+
+.. automodule:: camayoc.types
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   camayoc.types.settings

--- a/docs/api/camayoc.types.settings.rst
+++ b/docs/api/camayoc.types.settings.rst
@@ -1,0 +1,7 @@
+camayoc.types.settings module
+=============================
+
+.. automodule:: camayoc.types.settings
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/tests.rst
+++ b/docs/api/tests.rst
@@ -13,5 +13,6 @@ Submodules
    :maxdepth: 4
 
    tests.test_api
-   tests.test_cli
+   tests.test_command
+   tests.test_settings
    tests.test_utils

--- a/docs/api/tests.test_command.rst
+++ b/docs/api/tests.test_command.rst
@@ -1,0 +1,7 @@
+tests.test\_command module
+==========================
+
+.. automodule:: tests.test_command
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/tests.test_settings.rst
+++ b/docs/api/tests.test_settings.rst
@@ -1,0 +1,7 @@
+tests.test\_settings module
+===========================
+
+.. automodule:: tests.test_settings
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,24 +1,24 @@
 # coding=utf-8
-"""Unit tests for :mod:`camayoc.cli`."""
+"""Unit tests for :mod:`camayoc.command`."""
 import socket
 import unittest
 from unittest import mock
 
 from plumbum.machines.local import LocalMachine
 
-from camayoc import cli
+from camayoc import command
 from camayoc import exceptions
 from camayoc import utils
 
 
 class EchoHandlerTestCase(unittest.TestCase):
-    """Tests for :func:`camayoc.cli.echo_handler`."""
+    """Tests for :func:`camayoc.command.echo_handler`."""
 
     @classmethod
     def setUpClass(cls):
         """Call the function under test, and record inputs and outputs."""
         cls.completed_proc = mock.Mock()
-        cls.output = cli.echo_handler(cls.completed_proc)
+        cls.output = command.echo_handler(cls.completed_proc)
 
     def test_input_returned(self):
         """Assert the passed-in ``completed_proc`` is returned."""
@@ -30,13 +30,13 @@ class EchoHandlerTestCase(unittest.TestCase):
 
 
 class CodeHandlerTestCase(unittest.TestCase):
-    """Tests for :func:`camayoc.cli.code_handler`."""
+    """Tests for :func:`camayoc.command.code_handler`."""
 
     @classmethod
     def setUpClass(cls):
         """Call the function under test, and record inputs and outputs."""
         cls.completed_proc = mock.Mock()
-        cls.output = cli.code_handler(cls.completed_proc)
+        cls.output = command.code_handler(cls.completed_proc)
 
     def test_input_returned(self):
         """Assert the passed-in ``completed_proc`` is returned."""
@@ -48,7 +48,7 @@ class CodeHandlerTestCase(unittest.TestCase):
 
 
 class CompletedProcessTestCase(unittest.TestCase):
-    """Tests for :class:`camayoc.cli.CompletedProcess`."""
+    """Tests for :class:`camayoc.command.CompletedProcess`."""
 
     def setUp(self):
         """Generate kwargs that can be used to instantiate a completed proc."""
@@ -56,7 +56,7 @@ class CompletedProcessTestCase(unittest.TestCase):
 
     def test_init(self):
         """Assert all constructor arguments are saved as instance attrs."""
-        completed_proc = cli.CompletedProcess(**self.kwargs)
+        completed_proc = command.CompletedProcess(**self.kwargs)
         for key, value in self.kwargs.items():
             with self.subTest(key=key):
                 self.assertTrue(hasattr(completed_proc, key))
@@ -65,53 +65,53 @@ class CompletedProcessTestCase(unittest.TestCase):
     def test_check_returncode_zero(self):
         """Call ``check_returncode`` when ``returncode`` is zero."""
         self.kwargs["returncode"] = 0
-        completed_proc = cli.CompletedProcess(**self.kwargs)
+        completed_proc = command.CompletedProcess(**self.kwargs)
         self.assertIsNone(completed_proc.check_returncode())
 
     def test_check_returncode_nonzero(self):
         """Call ``check_returncode`` when ``returncode`` is not zero."""
         self.kwargs["returncode"] = 1
-        completed_proc = cli.CompletedProcess(**self.kwargs)
+        completed_proc = command.CompletedProcess(**self.kwargs)
         with self.assertRaises(exceptions.CalledProcessError):
             completed_proc.check_returncode()
 
     def test_can_eval(self):
         """Assert ``__repr__()`` can be parsed by ``eval()``."""
-        string = repr(cli.CompletedProcess(**self.kwargs))
-        from camayoc.cli import CompletedProcess  # noqa pylint:disable=unused-variable
+        string = repr(command.CompletedProcess(**self.kwargs))
+        from camayoc.command import CompletedProcess  # noqa pylint:disable=unused-variable
 
         # pylint:disable=eval-used
         self.assertEqual(string, repr(eval(string)))
 
 
-class ClientTestCase(unittest.TestCase):
-    """Tests for :class:`camayoc.cli.Client`."""
+class CommandTestCase(unittest.TestCase):
+    """Tests for :class:`camayoc.command.Command`."""
 
     def test_explicit_local_transport(self):
         """Assert it is possible to explicitly ask for a "local" transport."""
-        system = cli.System(hostname=utils.uuid4(), transport="local")
-        self.assertIsInstance(cli.Client(system).machine, LocalMachine)
+        system = command.System(hostname=utils.uuid4(), transport="local")
+        self.assertIsInstance(command.Command(system).machine, LocalMachine)
 
     def test_implicit_local_transport(self):
         """Assert it is possible to implicitly ask for a "local" transport."""
-        system = cli.System(hostname=socket.getfqdn(), transport=None)
-        self.assertIsInstance(cli.Client(system).machine, LocalMachine)
+        system = command.System(hostname=socket.getfqdn(), transport=None)
+        self.assertIsInstance(command.Command(system).machine, LocalMachine)
 
     def test_explicit_ssh_transport(self):
         """Assert it is possible to explicitly ask for a "ssh" transport."""
-        system = cli.System(hostname=utils.uuid4(), transport="ssh")
-        with mock.patch("camayoc.cli.plumbum.machines.SshMachine") as SshMachine:
+        system = command.System(hostname=utils.uuid4(), transport="ssh")
+        with mock.patch("camayoc.command.plumbum.machines.SshMachine") as SshMachine:
             machine = mock.Mock()
             SshMachine.return_value = machine
-            self.assertIs(cli.Client(system).machine, machine)
+            self.assertIs(command.Command(system).machine, machine)
 
     def test_default_response_handler(self):
         """Assert the default response handler checks return codes."""
-        system = cli.System(hostname=utils.uuid4(), transport="local")
-        self.assertIs(cli.Client(system).response_handler, cli.code_handler)
+        system = command.System(hostname=utils.uuid4(), transport="local")
+        self.assertIs(command.Command(system).response_handler, command.code_handler)
 
     def test_explicit_response_handler(self):
         """Assert it is possible to explicitly set a response handler."""
-        system = cli.System(hostname=utils.uuid4(), transport="local")
+        system = command.System(hostname=utils.uuid4(), transport="local")
         handler = mock.Mock()
-        self.assertIs(cli.Client(system, handler).response_handler, handler)
+        self.assertIs(command.Command(system, handler).response_handler, handler)


### PR DESCRIPTION
The `camayoc.cli` module is for running local and remote commands, it's basically a wrapper around the plumbum module. Let's rename it to `camayoc.command` to avoid mixing with the idea of CLI as in `qpc`/`dsc` CLI tests.
    
The main class `Client` was renamed to `Command`.
