### PR TITLE
Introduce OpenShift as a new source (CRUD operations)

### DIFF
--- a/camayoc/constants.py
+++ b/camayoc/constants.py
@@ -5,6 +5,9 @@ from camayoc import utils
 MASKED_PASSWORD_OUTPUT = r"\*{8}"
 """Regex that matches password on outputs."""
 
+MASKED_TOKEN_OUTPUT = r"\*{8}"
+"""Regex that matches token on outputs."""
+
 TOKEN_INPUT = "Provide a token for authentication.\r\nToken:"
 """Connection token input prompt."""
 

--- a/camayoc/constants.py
+++ b/camayoc/constants.py
@@ -5,11 +5,11 @@ from camayoc import utils
 MASKED_PASSWORD_OUTPUT = r"\*{8}"
 """Regex that matches password on outputs."""
 
-MASKED_TOKEN_OUTPUT = r"\*{8}"
-"""Regex that matches token on outputs."""
+MASKED_AUTH_TOKEN_OUTPUT = r"\*{8}"
+"""Regex that matches auth_token on outputs."""
 
-TOKEN_INPUT = "Provide a token for authentication.\r\nToken:"
-"""Connection token input prompt."""
+AUTH_TOKEN_INPUT = "Provide a token for authentication.\r\nToken:"
+"""Connection auth_token input prompt."""
 
 BECOME_PASSWORD_INPUT = (
     "Provide a privilege escalation password to be used when running a "

--- a/camayoc/constants.py
+++ b/camayoc/constants.py
@@ -50,13 +50,26 @@ QPC_SCAN_STATES = QPC_SCAN_TERMINAL_STATES + ("running",)
 QPC_TOKEN_PATH = "token/"
 """The path to the endpoint used for obtaining an authentication token."""
 
-QPC_SOURCE_TYPES = ("vcenter", "network", "satellite")
+QPC_SOURCE_TYPES = (
+    "vcenter",
+    "network",
+    "satellite",
+    "openshift",
+)
 """Types of sources that the quipucords server supports."""
+
+QPC_SOURCES_DEFAULT_PORT = {
+    "network": 22,
+    "vcenter": 443,
+    "satellite": 443,
+    "openshift": 6443,
+}
+"""Default sources port that the quipucords server supports."""
 
 QPC_SCAN_TYPES = ("inspect", "connect")
 """Types of scans that the quipucords server supports."""
 
-QPC_HOST_MANAGER_TYPES = ("vcenter", "satellite")
+QPC_HOST_MANAGER_TYPES = ("vcenter", "satellite", "openshift")
 """Types of host managers that the quipucords server supports."""
 
 QPC_BECOME_METHODS = ("doas", "dzdo", "ksu", "pbrun", "pfexec", "runas", "su", "sudo")

--- a/camayoc/qpc_models.py
+++ b/camayoc/qpc_models.py
@@ -6,8 +6,8 @@ from typing import Optional
 from urllib.parse import urljoin
 
 from camayoc import api
+from camayoc.constants import MASKED_AUTH_TOKEN_OUTPUT
 from camayoc.constants import MASKED_PASSWORD_OUTPUT
-from camayoc.constants import MASKED_TOKEN_OUTPUT
 from camayoc.constants import QPC_CREDENTIALS_PATH
 from camayoc.constants import QPC_HOST_MANAGER_TYPES
 from camayoc.constants import QPC_REPORTS_PATH
@@ -153,7 +153,7 @@ class Credential(QPCObject):
     Host credentials can be created by instantiating a Credential
     object. A unique name and username are provided by default.
     In order to create a valid host credential you must specify either a
-    password or ssh_keyfile or token (auth_token).
+    password or ssh_keyfile or auth_token.
 
     Example::
         >>> from camayoc import api
@@ -173,7 +173,7 @@ class Credential(QPCObject):
         username=None,
         password=None,
         ssh_keyfile=None,
-        token=None,
+        auth_token=None,
         cred_type=None,
         become_method=None,
         become_password=None,
@@ -191,10 +191,10 @@ class Credential(QPCObject):
         super().__init__(client=client, _id=_id)
         self.name = uuid4() if name is None else name
         self.endpoint = QPC_CREDENTIALS_PATH
-        self.username = uuid4() if (username is None) and (token is None) else username
+        self.username = uuid4() if (username is None) and (auth_token is None) else username
         self.password = password
         self.ssh_keyfile = ssh_keyfile
-        self.auth_token = token
+        self.auth_token = auth_token
         self.cred_type = cred_type
         if become_method is not None:
             self.become_method = become_method
@@ -239,7 +239,7 @@ class Credential(QPCObject):
             )
 
         password_matcher = re.compile(MASKED_PASSWORD_OUTPUT)
-        token_matcher = re.compile(MASKED_TOKEN_OUTPUT)
+        token_matcher = re.compile(MASKED_AUTH_TOKEN_OUTPUT)
         local_items = self.fields()
         local_keys = local_items.keys()
         other_keys = other.keys()

--- a/camayoc/qpc_models.py
+++ b/camayoc/qpc_models.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """Models for use with the Quipucords API."""
 import re
 from pprint import pformat
@@ -184,14 +183,14 @@ class Credential(QPCObject):
 
         If no arguments are passed, then a api.Client will be initialized and a
         uuid4 generated for the name and username.
-
-        For a Credential to be successfully created on the QPC server,
-        a password XOR a ssh_keyfile XOR a token must be provided.
         """
         super().__init__(client=client, _id=_id)
         self.name = uuid4() if name is None else name
         self.endpoint = QPC_CREDENTIALS_PATH
-        self.username = uuid4() if (username is None) and (auth_token is None) else username
+        if auth_token is None:
+            if username is None:
+                username = uuid4()
+        self.username = username
         self.password = password
         self.ssh_keyfile = ssh_keyfile
         self.auth_token = auth_token

--- a/camayoc/qpc_models.py
+++ b/camayoc/qpc_models.py
@@ -187,9 +187,8 @@ class Credential(QPCObject):
         super().__init__(client=client, _id=_id)
         self.name = uuid4() if name is None else name
         self.endpoint = QPC_CREDENTIALS_PATH
-        if auth_token is None:
-            if username is None:
-                username = uuid4()
+        if auth_token is None and username is None:
+            username = uuid4()
         self.username = username
         self.password = password
         self.ssh_keyfile = ssh_keyfile

--- a/camayoc/tests/qpc/api/v1/credentials/test_creds_common.py
+++ b/camayoc/tests/qpc/api/v1/credentials/test_creds_common.py
@@ -38,6 +38,20 @@ def test_create_with_password(cred_type, shared_client, cleanup):
     assert_matches_server(cred)
 
 
+def test_create_with_token(shared_client, cleanup):
+    """Create a credential with token.
+
+    :id: 525096c3-d492-4231-988b-4491009c23b2
+    :description: Create a credential with an authentication token
+    :steps: Send POST with necessary data to documented api endpoint.
+    :expectedresults: A new credential entry is created with the data.
+    """
+    cred = Credential(cred_type="openshift", client=shared_client, token=uuid4())
+    cred.create()
+    cleanup.append(cred)
+    assert_matches_server(cred)
+
+
 @pytest.mark.parametrize("cred_type", QPC_SOURCE_TYPES)
 @pytest.mark.parametrize("field", ["name", "username", "password"])
 def test_update(cred_type, field, shared_client, cleanup):

--- a/camayoc/tests/qpc/api/v1/credentials/test_creds_common.py
+++ b/camayoc/tests/qpc/api/v1/credentials/test_creds_common.py
@@ -46,7 +46,7 @@ def test_create_with_token(shared_client, data_provider):
     :steps: Send POST with necessary data to documented api endpoint.
     :expectedresults: A new credential entry is created with the data.
     """
-    cred = Credential(cred_type="openshift", client=shared_client, token=uuid4())
+    cred = Credential(cred_type="openshift", client=shared_client, auth_token=uuid4())
     cred.create()
     data_provider.mark_for_cleanup(cred)
     assert_matches_server(cred)

--- a/camayoc/tests/qpc/api/v1/credentials/test_creds_common.py
+++ b/camayoc/tests/qpc/api/v1/credentials/test_creds_common.py
@@ -78,25 +78,6 @@ def test_update(cred_type, field, shared_client, data_provider):
     assert_matches_server(cred)
 
 
-@pytest.mark.parametrize("cred_type", QPC_SOURCE_TYPES)
-def test_negative_update_to_invalid(cred_type, shared_client, data_provider):
-    """Attempt to update valid credential with invalid data.
-
-    :id: d3002d47-daee-4fcc-ac7c-477738ffc447
-    :description: Create valid credentials, then attempt to update to be
-        invalid.
-    :steps:
-        1) Create valid credentials with passwords.
-        2) Update the credentials:
-            a) missing username
-            c) missing password
-    :expectedresults: Error codes are returned and the credentials are
-        not updated.
-    :caseautomation: notautomated
-    """
-    pass
-
-
 @pytest.mark.parametrize("field", ["name", "username", "password"])
 @pytest.mark.parametrize("cred_type", QPC_SOURCE_TYPES)
 def test_negative_create_missing_field(cred_type, field, data_provider):
@@ -275,20 +256,3 @@ def test_delete_with_dependencies(obj_type, shared_client, data_provider):
 
     # now we should be able to delete the credential
     cred.delete()
-
-
-@pytest.mark.parametrize("cred_type", QPC_SOURCE_TYPES)
-def test_negative_update_to_other_type(shared_client, data_provider, cred_type):
-    """Attempt to update valid credential to be another type.
-
-    :id: 6ad285a0-7aa9-4ff7-8749-de73b33090c4
-    :description: Create a valid credential of one type, then attempt to update
-        to be another type.
-    :steps:
-        1) Create valid credential with password
-        2) Update the credential with another type.
-    :expectedresults: Error codes are returned and the credential is
-        not updated.
-    :caseautomation: notautomated
-    """
-    pass

--- a/camayoc/tests/qpc/api/v1/sources/test_sources_common.py
+++ b/camayoc/tests/qpc/api/v1/sources/test_sources_common.py
@@ -17,6 +17,7 @@ import pytest
 
 from camayoc import api
 from camayoc.constants import QPC_SOURCE_TYPES
+from camayoc.constants import QPC_SOURCES_DEFAULT_PORT
 from camayoc.qpc_models import Credential
 from camayoc.qpc_models import Scan
 from camayoc.qpc_models import Source
@@ -27,8 +28,7 @@ from camayoc.tests.qpc.utils import gen_valid_source
 from camayoc.utils import uuid4
 
 CREATE_DATA = ["localhost", "127.0.0.1", "example.com"]
-DEFAULT_PORT = {"network": 22, "vcenter": 443, "satellite": 443}
-INCOMPATIBLE_SRC_TYPES = ("vcenter", "satellite")
+INCOMPATIBLE_SRC_TYPES = ("vcenter", "satellite", "openshift")
 
 
 @pytest.mark.parametrize("src_type", QPC_SOURCE_TYPES)
@@ -445,7 +445,7 @@ def test_port_default(src_type, cleanup, shared_client):
     src.create()
     cleanup.append(src)
     server_src = src.read().json()
-    assert server_src.get("port") == DEFAULT_PORT[src_type]
+    assert server_src.get("port") == QPC_SOURCES_DEFAULT_PORT[src_type]
     assert src.equivalent(server_src)
 
 

--- a/camayoc/tests/qpc/cli/test_openshift.py
+++ b/camayoc/tests/qpc/cli/test_openshift.py
@@ -16,7 +16,7 @@ import tarfile
 import pytest
 
 from camayoc import utils
-from camayoc.constants import TOKEN_INPUT
+from camayoc.constants import AUTH_TOKEN_INPUT
 from camayoc.tests.qpc.cli.utils import config_openshift
 from camayoc.tests.qpc.cli.utils import cred_add_and_check
 from camayoc.tests.qpc.cli.utils import report_download
@@ -98,7 +98,7 @@ def test_openshift_clusters(cluster, qpc_server_config):
     cred_name = utils.uuid4()
     cred_add_and_check(
         {"name": cred_name, "token": None, "type": "openshift"},
-        [(TOKEN_INPUT, cluster["token"])],
+        [(AUTH_TOKEN_INPUT, cluster["token"])],
     )
     source_name = utils.uuid4()
     hostname = cluster["hostname"]

--- a/camayoc/tests/qpc/cli/test_sources.py
+++ b/camayoc/tests/qpc/cli/test_sources.py
@@ -20,6 +20,7 @@ import pytest
 from camayoc import utils
 from camayoc.constants import CONNECTION_PASSWORD_INPUT
 from camayoc.constants import QPC_HOST_MANAGER_TYPES
+from camayoc.constants import QPC_SOURCES_DEFAULT_PORT
 from camayoc.tests.qpc.cli.utils import convert_ip_format
 from camayoc.tests.qpc.cli.utils import cred_add_and_check
 from camayoc.tests.qpc.cli.utils import scan_add_and_check
@@ -46,6 +47,8 @@ VALID_SOURCE_TYPE_HOSTS = (
     ("network", "host.example.com"),
     ("vcenter", "192.168.0.42"),
     ("vcenter", "vcenter.example.com"),
+    ("openshift", "192.168.0.42"),
+    ("openshift", "openshift.example.com"),
 )
 
 VALID_SOURCE_TYPE_HOSTS_WITH_EXCLUDE = (
@@ -62,15 +65,8 @@ VALID_SOURCE_TYPE_HOSTS_WITH_EXCLUDE = (
 INVALID_SOURCE_TYPE_HOSTS_WITH_EXCLUDE = (
     ("vcenter", "192.168.0.42", "192.168.0.43"),
     ("satellite", "192.168.0.42", "192.168.0.43"),
+    ("openshift", "192.168.0.42", "192.168.0.43"),
 )
-
-
-def default_port_for_source(source_type):
-    """Resolve the default port for a given source type."""
-    if source_type in QPC_HOST_MANAGER_TYPES:
-        return 443
-    else:
-        return 22
 
 
 def generate_show_output(data):
@@ -125,7 +121,7 @@ def test_add_with_cred_hosts(isolated_filesystem, qpc_server_config, hosts, sour
     """
     cred_name = utils.uuid4()
     name = utils.uuid4()
-    port = default_port_for_source(source_type)
+    port = QPC_SOURCES_DEFAULT_PORT[source_type]
     cred_add_and_check(
         {
             "name": cred_name,
@@ -176,7 +172,7 @@ def test_add_with_cred_hosts_file(isolated_filesystem, qpc_server_config, hosts,
     """
     cred_name = utils.uuid4()
     name = utils.uuid4()
-    port = default_port_for_source(source_type)
+    port = QPC_SOURCES_DEFAULT_PORT[source_type]
     cred_add_and_check(
         {
             "name": cred_name,
@@ -350,7 +346,7 @@ def test_add_with_ssl_cert_verify(
                 "hosts": hosts,
                 "name": name,
                 "options": {"ssl_cert_verify": ssl_cert_verify.lower()},
-                "port": default_port_for_source(source_type),
+                "port": QPC_SOURCES_DEFAULT_PORT[source_type],
                 "source_type": source_type,
             }
         ),
@@ -375,7 +371,7 @@ def test_add_with_ssl_cert_verify_negative(isolated_filesystem, qpc_server_confi
     cred_name = utils.uuid4()
     hosts = "127.0.0.1"
     name = utils.uuid4()
-    port = default_port_for_source(source_type)
+    port = QPC_SOURCES_DEFAULT_PORT[source_type]
     if source_type == "network":
         ssl_cert_verify = random.choice(QPC_BOOLEAN_VALUES)
         expected_error = "Error: Invalid SSL options for network source: ssl_cert_verify"
@@ -453,7 +449,7 @@ def test_add_with_ssl_protocol(isolated_filesystem, qpc_server_config, source_ty
                 "hosts": hosts,
                 "name": name,
                 "options": {"ssl_protocol": ssl_protocol},
-                "port": default_port_for_source(source_type),
+                "port": QPC_SOURCES_DEFAULT_PORT[source_type],
                 "source_type": source_type,
             }
         ),
@@ -477,7 +473,7 @@ def test_add_with_ssl_protocol_negative(isolated_filesystem, qpc_server_config, 
     cred_name = utils.uuid4()
     hosts = "127.0.0.1"
     name = utils.uuid4()
-    port = default_port_for_source(source_type)
+    port = QPC_SOURCES_DEFAULT_PORT[source_type]
     if source_type == "network":
         ssl_protocol = random.choice(QPC_SSL_PROTOCOL_VALUES)
         expected_error = "Error: Invalid SSL options for network source: ssl_protocol"
@@ -555,7 +551,7 @@ def test_add_with_disable_ssl(isolated_filesystem, qpc_server_config, source_typ
                 "hosts": hosts,
                 "name": name,
                 "options": {"disable_ssl": disable_ssl.lower()},
-                "port": default_port_for_source(source_type),
+                "port": QPC_SOURCES_DEFAULT_PORT[source_type],
                 "source_type": source_type,
             }
         ),
@@ -579,7 +575,7 @@ def test_add_with_disable_ssl_negative(isolated_filesystem, qpc_server_config, s
     cred_name = utils.uuid4()
     hosts = "127.0.0.1"
     name = utils.uuid4()
-    port = default_port_for_source(source_type)
+    port = QPC_SOURCES_DEFAULT_PORT[source_type]
     if source_type == "network":
         disable_ssl = random.choice(QPC_BOOLEAN_VALUES)
         expected_error = "Error: Invalid SSL options for network source: disable_ssl"
@@ -630,7 +626,7 @@ def test_add_with_exclude_hosts(
     """
     cred_name = utils.uuid4()
     name = utils.uuid4()
-    port = default_port_for_source(source_type)
+    port = QPC_SOURCES_DEFAULT_PORT[source_type]
     cred_add_and_check(
         {
             "name": cred_name,
@@ -686,7 +682,7 @@ def test_add_with_cred_hosts_exclude_file(
     """
     cred_name = utils.uuid4()
     name = utils.uuid4()
-    port = default_port_for_source(source_type)
+    port = QPC_SOURCES_DEFAULT_PORT[source_type]
     cred_add_and_check(
         {
             "name": cred_name,
@@ -784,7 +780,7 @@ def test_edit_cred(isolated_filesystem, qpc_server_config, source_type):
     name = utils.uuid4()
     hosts = "127.0.0.1"
     new_cred_name = utils.uuid4()
-    port = default_port_for_source(source_type)
+    port = QPC_SOURCES_DEFAULT_PORT[source_type]
     for cred_name in (cred_name, new_cred_name):
         cred_add_and_check(
             {
@@ -895,7 +891,7 @@ def test_edit_hosts(isolated_filesystem, qpc_server_config, new_hosts, source_ty
     cred_name = utils.uuid4()
     name = utils.uuid4()
     hosts = "127.0.0.1"
-    port = default_port_for_source(source_type)
+    port = QPC_SOURCES_DEFAULT_PORT[source_type]
     cred_add_and_check(
         {
             "name": cred_name,
@@ -964,7 +960,7 @@ def test_edit_hosts_file(isolated_filesystem, qpc_server_config, new_hosts, sour
     cred_name = utils.uuid4()
     name = utils.uuid4()
     hosts = "127.0.0.1"
-    port = default_port_for_source(source_type)
+    port = QPC_SOURCES_DEFAULT_PORT[source_type]
     cred_add_and_check(
         {
             "name": cred_name,
@@ -1092,7 +1088,7 @@ def test_edit_exclude_hosts(
     cred_name = utils.uuid4()
     name = utils.uuid4()
     exclude_hosts = "10.10.10.10"
-    port = default_port_for_source(source_type)
+    port = QPC_SOURCES_DEFAULT_PORT[source_type]
     cred_add_and_check(
         {
             "name": cred_name,
@@ -1153,7 +1149,7 @@ def test_edit_exclude_hosts_file(
     cred_name = utils.uuid4()
     name = utils.uuid4()
     exclude_hosts = "10.10.10.10"
-    port = default_port_for_source(source_type)
+    port = QPC_SOURCES_DEFAULT_PORT[source_type]
     cred_add_and_check(
         {
             "name": cred_name,
@@ -1324,7 +1320,7 @@ def test_edit_ssl_cert_verify(isolated_filesystem, qpc_server_config, source_typ
     cred_name = utils.uuid4()
     name = utils.uuid4()
     hosts = "127.0.0.1"
-    port = default_port_for_source(source_type)
+    port = QPC_SOURCES_DEFAULT_PORT[source_type]
     ssl_cert_verify, new_ssl_cert_verify = random.sample(QPC_BOOLEAN_VALUES, 2)
     cred_add_and_check(
         {
@@ -1398,7 +1394,7 @@ def test_edit_ssl_cert_verify_negative(isolated_filesystem, qpc_server_config, s
     cred_name = utils.uuid4()
     hosts = "127.0.0.1"
     name = utils.uuid4()
-    port = default_port_for_source(source_type)
+    port = QPC_SOURCES_DEFAULT_PORT[source_type]
     show_output_dict = {
         "cred_name": cred_name,
         "hosts": hosts,
@@ -1470,7 +1466,7 @@ def test_edit_ssl_protocol(isolated_filesystem, qpc_server_config, source_type):
     cred_name = utils.uuid4()
     name = utils.uuid4()
     hosts = "127.0.0.1"
-    port = default_port_for_source(source_type)
+    port = QPC_SOURCES_DEFAULT_PORT[source_type]
     ssl_protocol, new_ssl_protocol = random.sample(QPC_SSL_PROTOCOL_VALUES, 2)
     cred_add_and_check(
         {
@@ -1542,7 +1538,7 @@ def test_edit_ssl_protocol_negative(isolated_filesystem, qpc_server_config, sour
     cred_name = utils.uuid4()
     hosts = "127.0.0.1"
     name = utils.uuid4()
-    port = default_port_for_source(source_type)
+    port = QPC_SOURCES_DEFAULT_PORT[source_type]
     show_output_dict = {
         "cred_name": cred_name,
         "hosts": hosts,
@@ -1612,7 +1608,7 @@ def test_edit_disable_ssl(isolated_filesystem, qpc_server_config, source_type):
     cred_name = utils.uuid4()
     name = utils.uuid4()
     hosts = "127.0.0.1"
-    port = default_port_for_source(source_type)
+    port = QPC_SOURCES_DEFAULT_PORT[source_type]
     disable_ssl, new_disable_ssl = random.sample(QPC_BOOLEAN_VALUES, 2)
     cred_add_and_check(
         {
@@ -1684,7 +1680,7 @@ def test_edit_disable_ssl_negative(isolated_filesystem, qpc_server_config, sourc
     cred_name = utils.uuid4()
     hosts = "127.0.0.1"
     name = utils.uuid4()
-    port = default_port_for_source(source_type)
+    port = QPC_SOURCES_DEFAULT_PORT[source_type]
     show_output_dict = {
         "cred_name": cred_name,
         "hosts": hosts,
@@ -1753,7 +1749,7 @@ def test_clear(isolated_filesystem, qpc_server_config, source_type):
     cred_name = utils.uuid4()
     name = utils.uuid4()
     hosts = "127.0.0.1"
-    port = default_port_for_source(source_type)
+    port = QPC_SOURCES_DEFAULT_PORT[source_type]
     cred_add_and_check(
         {
             "name": cred_name,
@@ -1823,7 +1819,7 @@ def test_clear_with_scans(isolated_filesystem, qpc_server_config, source_type):
     cred_name = utils.uuid4()
     name = utils.uuid4()
     hosts = "127.0.0.1"
-    port = default_port_for_source(source_type)
+    port = QPC_SOURCES_DEFAULT_PORT[source_type]
     cred_add_and_check(
         {
             "name": cred_name,
@@ -1928,7 +1924,7 @@ def test_clear_all(isolated_filesystem, qpc_server_config, source_type):
     :expectedresults: All source entries are removed.
     """
     cred_name = utils.uuid4()
-    port = default_port_for_source(source_type)
+    port = QPC_SOURCES_DEFAULT_PORT[source_type]
     cred_add_and_check(
         {
             "name": cred_name,
@@ -1958,9 +1954,7 @@ def test_clear_all(isolated_filesystem, qpc_server_config, source_type):
             "port": port,
             "source_type": source_type,
         }
-        if source_type == "satellite":
-            source["options"] = {"ssl_cert_verify": True}
-        if source_type == "vcenter":
+        if source_type != "network":
             source["options"] = {"ssl_cert_verify": True}
         sources.append(source)
         qpc_source_add = pexpect.spawn(


### PR DESCRIPTION
Introduce OpenShift as a source for API and CLI tests. These tests are meant for CRUD operations and it adds support for testing with a token (only OpenShift has make use of it). It somehow takes parts of PR #378.

Notes:
* The OpenShift E2E testing (test_openshift.py) requires refactor after this PR is merged.
* Requires Discovery greater than version `1.2` (refer to card DISCOVERY-2.3.5). It will break and produce test failures results for Discover `1.2.5` (current stable) and bellow -- we (IMO) can't filter out tests based on Discovery server versions.

Running test locally against

```
REPOSITORY TAG IMAGE
quay.io/quipucords/quipucords latest df91f12cecff
```

API tests failing. These are already know issues from current and previous version, due the way we run camoyoc not in the same machine as the discovery server.

```
FAILED camayoc/tests/qpc/api/v1/credentials/test_network_creds.py::test_negative_update_to_invalid - assert 'either a password or an ssh_keyfile, not both' in '{"ssh_keyfile":["ssh_keyfile, /sshke...
FAILED camayoc/tests/qpc/api/v1/credentials/test_network_creds.py::test_negative_create_key_and_pass - assert 'either a password or an ssh_keyfile, not both' in '{"ssh_keyfile":["ssh_keyfile, /priva...
================ 2 failed, 288 passed, 35 skipped, 5 warnings in 601.55s (0:10:01) =================
```



CLI tests failing. These tests are already failing for other sources besides openshift and the test for cluster will be address after this PR.

```
FAILED camayoc/tests/qpc/cli/test_openshift.py::test_openshift_clusters[api.discopop.example.com] - camayoc.exceptions.FailedScanException: The scan with ID "6" has failed unexpectedly.
FAILED camayoc/tests/qpc/cli/test_openshift.py::test_openshift_clusters[api.sharedocp4upi412ovn.example.com] - camayoc.exceptions.FailedScanException: The scan with ID "7" has failed unexpectedly.
FAILED camayoc/tests/qpc/cli/test_openshift.py::test_openshift_clusters[api.sharedocp4upi411ovn.example.com] - camayoc.exceptions.FailedScanException: The scan with ID "8" has failed unexpectedly.
FAILED camayoc/tests/qpc/cli/test_openshift.py::test_openshift_clusters[api.sharedocp4upi410ovn.example.com] - camayoc.exceptions.FailedScanException: The scan with ID "9" has failed unexpectedly.
FAILED camayoc/tests/qpc/cli/test_sources.py::test_add_with_ssl_cert_verify_negative[vcenter] - pexpect.exceptions.EOF: End Of File (EOF). Empty string style platform.
FAILED camayoc/tests/qpc/cli/test_sources.py::test_add_with_ssl_cert_verify_negative[satellite] - pexpect.exceptions.EOF: End Of File (EOF). Empty string style platform.
FAILED camayoc/tests/qpc/cli/test_sources.py::test_add_with_ssl_cert_verify_negative[openshift] - pexpect.exceptions.EOF: End Of File (EOF). Empty string style platform.
FAILED camayoc/tests/qpc/cli/test_sources.py::test_add_with_disable_ssl_negative[vcenter] - pexpect.exceptions.EOF: End Of File (EOF). Empty string style platform.
FAILED camayoc/tests/qpc/cli/test_sources.py::test_add_with_disable_ssl_negative[satellite] - pexpect.exceptions.EOF: End Of File (EOF). Empty string style platform.
FAILED camayoc/tests/qpc/cli/test_sources.py::test_add_with_disable_ssl_negative[openshift] - pexpect.exceptions.EOF: End Of File (EOF). Empty string style platform.
FAILED camayoc/tests/qpc/cli/test_sources.py::test_edit_ssl_cert_verify_negative[vcenter] - pexpect.exceptions.EOF: End Of File (EOF). Empty string style platform.
FAILED camayoc/tests/qpc/cli/test_sources.py::test_edit_ssl_cert_verify_negative[satellite] - pexpect.exceptions.EOF: End Of File (EOF). Empty string style platform.
FAILED camayoc/tests/qpc/cli/test_sources.py::test_edit_ssl_cert_verify_negative[openshift] - pexpect.exceptions.EOF: End Of File (EOF). Empty string style platform.
FAILED camayoc/tests/qpc/cli/test_sources.py::test_edit_disable_ssl_negative[vcenter] - pexpect.exceptions.EOF: End Of File (EOF). Empty string style platform.
FAILED camayoc/tests/qpc/cli/test_sources.py::test_edit_disable_ssl_negative[satellite] - pexpect.exceptions.EOF: End Of File (EOF). Empty string style platform.
FAILED camayoc/tests/qpc/cli/test_sources.py::test_edit_disable_ssl_negative[openshift] - pexpect.exceptions.EOF: End Of File (EOF). Empty string style platform.
================ 16 failed, 316 passed, 9 skipped, 6 warnings in 1138.38s (0:18:58) ================
```

