### PR TITLE
Port API SSH key credential tests to DataProvider

### DIFF
--- a/camayoc/data_provider.py
+++ b/camayoc/data_provider.py
@@ -131,12 +131,13 @@ class DataProvider:
         self.scans = ModelWorker(data_provider=self, definitions=scans, model_class=Scan)
         self._stores = ("credentials", "sources", "scans")
 
-    def mark_for_cleanup(self, obj):
-        obj_name = f"manually-added-{obj.name}"
-        for store in self._stores:
-            worker = getattr(self, store)
-            if isinstance(obj, worker._model_class):
-                worker._created_models[obj_name] = obj
+    def mark_for_cleanup(self, *objects):
+        for obj in objects:
+            obj_name = f"manually-added-{obj.name}"
+            for store in self._stores:
+                worker = getattr(self, store)
+                if isinstance(obj, worker._model_class):
+                    worker._created_models[obj_name] = obj
 
     def cleanup(self):
         trash = chain.from_iterable(

--- a/camayoc/tests/qpc/api/v1/credentials/test_network_creds.py
+++ b/camayoc/tests/qpc/api/v1/credentials/test_network_creds.py
@@ -160,7 +160,7 @@ def test_negative_create_key_and_pass(data_provider):
 
 
 @pytest.mark.parametrize("method", QPC_BECOME_METHODS)
-def test_create_become_method(cleanup, shared_client, method):
+def test_create_become_method(data_provider, shared_client, method):
     """Create a network credential that uses become options.
 
     :id: e49e497d-abb7-4d6a-8366-3409e297062a
@@ -179,7 +179,7 @@ def test_create_become_method(cleanup, shared_client, method):
     )
     cred.create()
     # add the id to the list to destroy after the test is done
-    cleanup.append(cred)
+    data_provider.mark_for_cleanup(cred)
     assert_matches_server(cred)
 
 

--- a/camayoc/tests/qpc/api/v1/sources/test_network_sources.py
+++ b/camayoc/tests/qpc/api/v1/sources/test_network_sources.py
@@ -29,7 +29,7 @@ MIXED_DATA = CREATE_DATA + HOST_FORMAT_DATA
 
 
 @pytest.mark.parametrize("scan_host", HOST_FORMAT_DATA)
-def test_create_multiple_hosts(shared_client, cleanup, scan_host):
+def test_create_multiple_hosts(shared_client, data_provider, scan_host):
     """Create a Network Source using multiple hosts.
 
     :id: 248f701c-b4d4-408a-80b0-c4863a8007e1
@@ -52,7 +52,7 @@ def test_create_multiple_hosts(shared_client, cleanup, scan_host):
     src.create()
 
     # add the ids to the lists to destroy after the test is done
-    cleanup.extend([cred, src])
+    data_provider.mark_for_cleanup(cred, src)
 
     src.hosts = RESULTING_HOST_FORMAT_DATA
     assert_matches_server(src)
@@ -130,7 +130,7 @@ def test_create_multiple_creds_and_sources(shared_client, data_provider, scan_ho
 
 
 @pytest.mark.parametrize("scan_host", CREATE_DATA)
-def test_negative_update_invalid(shared_client, cleanup, isolated_filesystem, scan_host):
+def test_negative_update_invalid(shared_client, data_provider, scan_host):
     """Create a network source and then update it with invalid data.
 
     :id: e0d72f2b-2490-445e-b646-f06ceb4ad23f
@@ -158,8 +158,7 @@ def test_negative_update_invalid(shared_client, cleanup, isolated_filesystem, sc
     )
     src.create()
 
-    # add the ids to the lists to destroy after the test is done
-    cleanup.extend([net_cred, sat_cred, src])
+    data_provider.mark_for_cleanup(net_cred, sat_cred, src)
 
     original_data = copy.deepcopy(src.fields())
     src.client = api.Client(api.echo_handler)
@@ -171,7 +170,7 @@ def test_negative_update_invalid(shared_client, cleanup, isolated_filesystem, sc
     assert_source_update_fails(original_data, src)
 
 
-def test_create_empty_str_host_valid(shared_client, cleanup):
+def test_create_empty_str_host_valid(shared_client, data_provider):
     """Create a host manager source and then add host data with empty string.
 
     :id: 4bfbf5b0-81bd-48a3-8C57-bae55590285d
@@ -198,11 +197,10 @@ def test_create_empty_str_host_valid(shared_client, cleanup):
     created_data = src.create()
     created_data = created_data.json()
     assert created_data["hosts"] == hosts_without_empty_str
-    # add the ids to the lists to destroy after the test is done
-    cleanup.extend([pwd_cred, src])
+    data_provider.mark_for_cleanup(pwd_cred, src)
 
 
-def test_update_empty_str_host_valid(shared_client, cleanup):
+def test_update_empty_str_host_valid(shared_client, data_provider):
     """Create a host manager source and then add host data with empty string.
 
     :id: 850b06ba-8e3f-4699-b24b-e75aad20a63a
@@ -228,8 +226,7 @@ def test_update_empty_str_host_valid(shared_client, cleanup):
     )
     src.create()
 
-    # add the ids to the lists to destroy after the test is done
-    cleanup.extend([pwd_cred, src])
+    data_provider.mark_for_cleanup(pwd_cred, src)
     src.hosts = empty_str_host_data
     updated_data = src.update().json()
     assert updated_data["hosts"] == hosts_without_empty_str

--- a/camayoc/tests/qpc/conftest.py
+++ b/camayoc/tests/qpc/conftest.py
@@ -2,7 +2,17 @@
 import pytest
 
 from camayoc import api
+from camayoc.data_provider import DataProvider
 from camayoc.tests.qpc.utils import sort_and_delete
+
+
+@pytest.fixture(scope="session")
+def data_provider():
+    dp = DataProvider()
+
+    yield dp
+
+    dp.cleanup()
 
 
 @pytest.fixture(scope="function")

--- a/camayoc/types/settings.py
+++ b/camayoc/types/settings.py
@@ -78,14 +78,19 @@ class VCenterCredentialOptions(BaseModel):
     password: str
 
 
-CredentialOptions = Annotated[
+VCenterSatelliteCredentialOptions = Annotated[
     Union[
-        PlainNetworkCredentialOptions,
-        SSHNetworkCredentialOptions,
-        SatelliteCredentialOptions,
         VCenterCredentialOptions,
+        SatelliteCredentialOptions,
     ],
     Field(discriminator="type"),
+]
+
+
+CredentialOptions = Union[
+    PlainNetworkCredentialOptions,
+    SSHNetworkCredentialOptions,
+    VCenterSatelliteCredentialOptions,
 ]
 
 

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -64,6 +64,10 @@ credentials:
       # must be the path that exists in the container.
       sshkeyfile: ~/.ssh/id_rsa
       username: root
+    - name: root2
+      type: 'network'
+      username: root
+      password: "mysecretpassword"
     - name: 'vcenter'
       type: 'vcenter'
       password: 'example1'


### PR DESCRIPTION
There are few commits, broken down logically:

40bdfd5925c24620e86fdc103b388cde04a6c5ec is the most important one. It ports all API tests that use SSH key credential to DataProvider. As a result, these tests are passing :tada:  When running against Discovery 1.2 or quipucords master, all API tests are passing or skipped (skips are DISCOVERY-293 and DISCOVERY-294). See https://url.corp.redhat.com/ibutsu-runs-d9b7a3c7-6064-44d6-b2eb-e342249f5ffa 

12b55cf0f20f7107f60e48a9bdf7c826ea69f5d2 introduces DataProvider to other tests in files modified by previous commit. This is not strictly necessary, but provides consistency.

d8ce9d21e4d85d589fccb86351dbc54c28a3b2bb and 44f3496f47094024f9873644ca67a0a94739dff9 are minor fixes in data provider and settings. These issues became apparent as I was working on other things here.

I would ask to not squash commits during merge, so this logical division is still visible after merge.