### PR TITLE
Introduce Ansible as a new source (CRUD operations)

### DIFF
--- a/camayoc/constants.py
+++ b/camayoc/constants.py
@@ -64,6 +64,7 @@ QPC_SOURCE_TYPES = (
     "network",
     "satellite",
     "openshift",
+    "ansible",
 )
 """Types of sources that the quipucords server supports."""
 
@@ -72,13 +73,14 @@ QPC_SOURCES_DEFAULT_PORT = {
     "vcenter": 443,
     "satellite": 443,
     "openshift": 6443,
+    "ansible": 443,
 }
 """Default sources port that the quipucords server supports."""
 
 QPC_SCAN_TYPES = ("inspect", "connect")
 """Types of scans that the quipucords server supports."""
 
-QPC_HOST_MANAGER_TYPES = ("vcenter", "satellite", "openshift")
+QPC_HOST_MANAGER_TYPES = ("vcenter", "satellite", "openshift", "ansible")
 """Types of host managers that the quipucords server supports."""
 
 QPC_BECOME_METHODS = ("doas", "dzdo", "ksu", "pbrun", "pfexec", "runas", "su", "sudo")

--- a/camayoc/types/settings.py
+++ b/camayoc/types/settings.py
@@ -78,10 +78,18 @@ class VCenterCredentialOptions(BaseModel):
     password: str
 
 
-VCenterSatelliteCredentialOptions = Annotated[
+class AnsibleCredentialOptions(BaseModel):
+    name: str
+    type: Literal["ansible"]
+    username: str
+    password: str
+
+
+ServicesCredentialOptions = Annotated[
     Union[
         VCenterCredentialOptions,
         SatelliteCredentialOptions,
+        AnsibleCredentialOptions,
     ],
     Field(discriminator="type"),
 ]
@@ -90,7 +98,7 @@ VCenterSatelliteCredentialOptions = Annotated[
 CredentialOptions = Union[
     PlainNetworkCredentialOptions,
     SSHNetworkCredentialOptions,
-    VCenterSatelliteCredentialOptions,
+    ServicesCredentialOptions,
 ]
 
 


### PR DESCRIPTION
Introduce Ansible (Controller) as a source for API and CLI tests (CRUD operations basically). So far, it doesn't validates the reports (it's not an E2E thing).