### PR TITLE
Enable scan tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,6 @@ help:
 	@echo "  test              to run unit tests"
 	@echo "  test-coverage     to run unit tests and measure test coverage"
 	@echo "  test-qpc          to run all camayoc tests for quipucords"
-	@echo "  test-qpc-no-scans to run same tests as 'test-qpc' except"
-	@echo "                    skips scans at beginning of session."
 	@echo "  test-qpc-ui       to run all tests for quipucords UI"
 	@echo "  test-qpc-cli      to run all tests for quipucords CLI"
 	@echo "  test-qpc-api      to run all tests for quipucords API"
@@ -78,9 +76,6 @@ test-coverage:
 	--cov=camayoc.api \
 	tests
 
-test-qpc-no-scans:
-	RUN_SCANS=False pytest $(PYTEST_OPTIONS) camayoc/tests/qpc
-
 test-qpc:
 	pytest $(PYTEST_OPTIONS) camayoc/tests/qpc
 
@@ -99,4 +94,4 @@ validate-docstrings:
 
 .PHONY: all clean docs-clean docs-html install install-dev lint package \
 	package-clean package-upload test test-coverage test-qpc \
-	test-qpc-api test-qpc-ui test-qpc-cli test-qpc-no-scans
+	test-qpc-api test-qpc-ui test-qpc-cli

--- a/README.rst
+++ b/README.rst
@@ -183,18 +183,6 @@ any others, run::
 Any other valid pytest options may be included as well in this
 variable.
 
-By default scans defined in the config file are run at the beginning of the test session and results are cached to be used by other tests. This causes there to be some latency between when the test session begins and tests begin reporting results. If you want to run a test quickly without running the scans, you can include the environment variable ``RUN_SCANS=False`` in your ``py.test`` invocation. There is also a make target that provides this functionality::
-
-    # Runs all tests except ones that require results of scanjobs
-
-    make test-qpc-no-scans
-
-    # You can do this manually as well
-    # For example, if I just want to run a few login/logout
-    # This would just run those without the scans running first.
-
-    RUN_SCANS=False py.test camayoc/tests/qpc/api/v1/authentication/
-
 Testing Camayoc
 ^^^^^^^^^^^^^^^
 Testing Camayoc requires that you have installed the development dependencies. Do that by running ``make install-dev``.

--- a/camayoc/api.py
+++ b/camayoc/api.py
@@ -51,7 +51,9 @@ def raise_error_for_status(response):
             ]
         )
         error_msgs += "\n============================================================\n"
-        raise HTTPError(error_msgs)
+        exception = HTTPError(error_msgs)
+        exception.api_error_message = response_message
+        raise exception
 
 
 def echo_handler(response):

--- a/camayoc/qpc_models.py
+++ b/camayoc/qpc_models.py
@@ -457,6 +457,7 @@ class Scan(QPCObject):
                 definition_key = "source_ids"
                 definition_value = dependencies
             definition_data[definition_key] = definition_value
+        definition_data.pop("expected_data")
         return cls(**definition_data)
 
     def delete(self, **kwargs):
@@ -687,10 +688,10 @@ class Report(QPCObject):
             `request.request()` method.
         """
         path = urljoin(self.endpoint, "merge/")
-        payload = {"jobs": ids}
+        payload = {"reports": ids}
         response = self.client.put(path, payload, **kwargs)
         if response.status_code in range(200, 203):
-            self._id = response.json().get("id")
+            self._id = response.json().get("report_id")
         return response
 
     def details(self, **kwargs):

--- a/camayoc/tests/qpc/api/v1/conftest.py
+++ b/camayoc/tests/qpc/api/v1/conftest.py
@@ -1,20 +1,15 @@
 """Pytest customizations and fixtures for the quipucords tests."""
 from pprint import pformat
 
-import pytest
 import requests
 
-from camayoc.config import get_config
-from camayoc.exceptions import ConfigFileNotFoundError
+from camayoc.config import settings
 from camayoc.exceptions import WaitTimeError
 from camayoc.qpc_models import Credential
 from camayoc.qpc_models import Scan
 from camayoc.qpc_models import ScanJob
 from camayoc.qpc_models import Source
 from camayoc.tests.qpc.api.v1.utils import wait_until_state
-from camayoc.tests.utils import get_vcenter_vms
-from camayoc.tests.utils import vcenter_vms
-from camayoc.utils import run_scans
 
 
 SCAN_DATA = {}
@@ -48,6 +43,10 @@ def run_scan(
 
     If errors are encountered, save those and they can be included
     in test results.
+
+    This is dead code. It is left around as a visible reference of data
+    structure that has been used. It might serve as inspiration for better
+    solution in the future.
     """
     src_ids = scan["source_ids"]
     scan_name = scan["name"]
@@ -89,168 +88,6 @@ def run_scan(
         SCAN_DATA[scan_name]["errors"].append("{}".format(pformat(str(e))))
 
 
-@pytest.fixture(scope="session", autouse=run_scans())
-def run_all_scans(vcenter_client):
-    """Run all configured scans caching the report id associated with each.
-
-    Run each scan defined in the ``qpc`` section of the configuration file.
-
-    Cache the report id of the scan, associating it with its scan.
-
-    The expected configuration in the Camayoc's configuration file is as
-    follows::
-
-        qpc:
-        # other needed qpc config data
-        #
-        # specific for scans:
-            - scans:
-                - name: network-vcenter-sat-mix
-                  sources:
-                      - sample-none-rhel-5-vc
-                      - sample-sat-6
-                      - sample-vcenter
-                  disabled_optional_products: {'jboss_fuse': True}
-                  type: 'connect'
-                  enabled_extended_product_search: {'jboss_eap': True,
-                     'search_directories': ['/foo/bar']}
-        inventory:
-          - hostname: sample-none-rhel-5-vc
-            ipv4: 10.10.10.1
-            hypervisor: vcenter
-            distribution:
-                name: rhel
-                version: '5.9'
-            products: {}
-            credentials:
-                - root
-          - hostname: sample-sat-6
-            type: 'vcenter'
-            options:
-                ssl_cert_verify: false
-            credentials:
-                - sat6_admin
-          - hostname: sample-vcenter
-            type: 'vcenter'
-            credentials:
-                - vcenter_admin
-
-        credentials:
-            - name: root
-              sshkeyfile: /path/to/.ssh/id_rsa
-              username: root
-              type: network
-
-            - name: sat6_admin
-              password: foo
-              username: admin
-              type: satellite
-
-            - name: vcenter_admin
-              password: foo
-              username: admin
-              type: vcenter
-
-    In the sample configuration file above, one machine will be turned on,
-    and one scan will be run against the three sources each created with
-    their own credential.
-    """
-    cleanup = []
-    config = get_config()
-
-    config_scans = config.get("qpc", {}).get("scans", [])
-    if not config_scans:
-        # if no scans are defined, no need to go any further
-        return
-
-    config_creds = {credential["name"]: credential for credential in config.get("credentials", [])}
-    inventory = {machine["hostname"]: machine for machine in config["inventory"]}
-    vcenter_inventory = {
-        machine["hostname"]: machine
-        for machine in config["inventory"]
-        if machine.get("hypervisor") == "vcenter"
-    }
-
-    if not config_creds or not inventory:
-        raise ValueError("Make sure to have credentials and inventory" " items in the config file")
-
-    credential_ids = {}
-    source_ids = {}
-    expected_products = {}
-    for scan in config_scans:
-        scan_vms = {
-            vm.name: vm
-            for vm in get_vcenter_vms(vcenter_client)
-            if (vm.name in vcenter_inventory) and (vm.name in scan["sources"])
-        }
-
-        with vcenter_vms(scan_vms.values()):
-            for source_name in scan["sources"]:
-                if source_name not in source_ids:
-                    machine = inventory[source_name]
-                    for credential_name in machine["credentials"]:
-                        if credential_name not in credential_ids:
-                            credential = config_creds[credential_name].copy()
-                            credential["cred_type"] = credential.pop("type")
-                            credential["ssh_keyfile"] = credential.pop("sshkeyfile", None)
-                            credential_ids[credential_name] = create_cred(credential, cleanup)
-                    if machine.get("type", "network") == "network":
-                        vm = scan_vms[machine["hostname"]]
-                        machine["ipv4"] = vm.guest.ipAddress
-                    source_info = {
-                        "source_type": machine.get("type", "network"),
-                        "hosts": [machine.get("ipv4") or machine["hostname"]],
-                        "credential_ids": [
-                            credential_ids[credential] for credential in machine["credentials"]
-                        ],
-                    }
-                    if "options" in machine:
-                        source_info["options"] = machine["options"].copy()
-                    source_ids[source_name] = create_source(source_info, cleanup)
-                    expected_products[source_name] = machine.get("products", {})
-                    expected_products[source_name].update(
-                        {"distribution": source_info.get("distribution", {})}
-                    )
-
-            scan_info = {
-                "expected_products": [],
-                "name": scan["name"],
-                "source_id_to_hostname": {},
-                "source_ids": [],
-            }
-            for source_name in scan["sources"]:
-                source_id = source_ids[source_name]
-                scan_info["expected_products"].append({source_id: expected_products[source_name]})
-                scan_info["source_id_to_hostname"][source_id] = source_name
-                scan_info["source_ids"].append(source_id)
-
-            run_scan(
-                scan_info,
-                scan.get("disabled_optional_products", {}),
-                scan.get("enabled_extended_product_search", {}),
-                cleanup=cleanup,
-                scan_type=scan.get("type", "inspect"),
-            )
-
-
 def scan_list():
     """Generate list of scan dict objects found in config file."""
-    try:
-        return get_config().get("scans", [])
-    except (ConfigFileNotFoundError, KeyError):
-        return []
-
-
-def get_scan_result(scan_name):
-    """Collect scan results from global cache.
-
-    Raise an error if no results are available, because this means the scan
-    was not even attempted.
-    """
-    result = SCAN_DATA.get(scan_name)
-    if result is None:
-        raise RuntimeError(
-            "Absolutely no results available for scan named {0},\n"
-            "because no scan was even attempted.\n".format(scan_name)
-        )
-    return result
+    return settings.scans

--- a/camayoc/tests/qpc/api/v1/reports/test_reports.py
+++ b/camayoc/tests/qpc/api/v1/reports/test_reports.py
@@ -21,7 +21,6 @@ from camayoc.qpc_models import ScanJob
 from camayoc.tests.qpc.api.v1.conftest import SCAN_DATA
 from camayoc.tests.qpc.api.v1.conftest import scan_list
 from camayoc.tests.qpc.api.v1.utils import wait_until_state
-from camayoc.tests.qpc.utils import mark_runs_scans
 from camayoc.types.settings import ScanOptions
 
 
@@ -61,7 +60,7 @@ def validate_json_response(response):
         assert False, 'Report is not expected content-type "json".'
 
 
-@mark_runs_scans
+@pytest.mark.runs_scan
 def test_report_content_consistency(data_provider):
     """Confirm that a report is created with the correct content type.
 
@@ -125,7 +124,7 @@ def assert_merge_fails(ids, errors_found, report):
     return errors_found
 
 
-@mark_runs_scans
+@pytest.mark.runs_scan
 def test_merge_reports_from_scanjob(data_provider):
     """Confirm that a report is created from valid scan job identifiers.
 
@@ -186,7 +185,7 @@ def test_merge_reports_from_scanjob(data_provider):
     assert len(errors_found) == 0, "\n================\n".join(errors_found)
 
 
-@mark_runs_scans
+@pytest.mark.runs_scan
 def test_merge_reports_negative():
     """Confirm that merging invalid scan job ids does not result in a report.
 
@@ -223,7 +222,7 @@ def test_merge_reports_negative():
 
 
 @pytest.mark.skip("Skipped until Middleware are handled by Camayoc")
-@mark_runs_scans
+@pytest.mark.runs_scan
 @pytest.mark.parametrize("scan_info", scan_list(), ids=utils.name_getter)
 def test_products_found_deployment_report(data_provider, scan_info):
     """Test that products reported as present are correct for the source.
@@ -306,7 +305,7 @@ def test_products_found_deployment_report(data_provider, scan_info):
     )
 
 
-@mark_runs_scans
+@pytest.mark.runs_scan
 @pytest.mark.parametrize("scan_info", scan_list(), ids=utils.name_getter)
 def test_OS_found_deployment_report(data_provider, scan_info: ScanOptions):
     """Test that OS identified are correct for the source.

--- a/camayoc/tests/qpc/api/v1/reports/test_reports.py
+++ b/camayoc/tests/qpc/api/v1/reports/test_reports.py
@@ -145,8 +145,6 @@ def test_merge_reports_from_scanjob(data_provider):
     scan_generator = data_provider.scans.new_many({}, new_dependencies=False, data_only=False)
     scan1 = next(scan_generator)
     scan2 = next(scan_generator)
-    # if either scan is None, they were not in the config file or the
-    # tests have been ran with RUN_SCANS=False and there are no scan results
     if scan1.equivalent(scan2):
         pytest.xfail(reason="Config file does not have two different scans.")
 

--- a/camayoc/tests/qpc/api/v1/scanjobs/test_pause_cancel_restart.py
+++ b/camayoc/tests/qpc/api/v1/scanjobs/test_pause_cancel_restart.py
@@ -15,11 +15,10 @@ import pytest
 import camayoc.tests.qpc.api.v1.utils as util
 from camayoc.constants import QPC_SOURCE_TYPES
 from camayoc.qpc_models import ScanJob
-from camayoc.tests.qpc.utils import mark_runs_scans
 
 
 @pytest.mark.skip(reason="Test is flaky. Skipping until Quipucords Issue #2040 resoloved")
-@mark_runs_scans
+@pytest.mark.runs_scan
 @pytest.mark.parametrize("source_type", QPC_SOURCE_TYPES)
 def test_pause_cancel(shared_client, cleanup, source_type):
     """Run a scan on a system and confirm we can pause and cancel it.
@@ -47,7 +46,7 @@ def test_pause_cancel(shared_client, cleanup, source_type):
 
 
 @pytest.mark.skip(reason="Test is flaky. Skipping until Quipucords Issue #2040 resoloved")
-@mark_runs_scans
+@pytest.mark.runs_scan
 @pytest.mark.parametrize("source_type", QPC_SOURCE_TYPES)
 def test_restart(shared_client, cleanup, source_type):
     """Run a scan on a system and confirm we can pause and restart it.

--- a/camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py
+++ b/camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py
@@ -26,12 +26,11 @@ from camayoc.qpc_models import Scan
 from camayoc.qpc_models import ScanJob
 from camayoc.tests.qpc.api.v1.conftest import scan_list
 from camayoc.tests.qpc.api.v1.utils import wait_until_state
-from camayoc.tests.qpc.utils import mark_runs_scans
 from camayoc.types.settings import ScanOptions
 
 
 @pytest.mark.skip(reason="Test is flaky. Skipping until Quipucords Issue #2040 resoloved")
-@mark_runs_scans
+@pytest.mark.runs_scan
 @pytest.mark.parametrize("scan_info", scan_list(), ids=utils.name_getter)
 def test_scan_complete(scan_info: ScanOptions):
     """Test that each scan completed without failures.
@@ -66,7 +65,7 @@ def test_scan_complete(scan_info: ScanOptions):
         )
 
 
-@mark_runs_scans
+@pytest.mark.runs_scan
 @pytest.mark.parametrize("scan_info", scan_list(), ids=utils.name_getter)
 def test_scan_task_results(data_provider, scan_info: ScanOptions):
     """Test the scan task results of each scan.
@@ -111,7 +110,7 @@ def test_scan_task_results(data_provider, scan_info: ScanOptions):
         assert num_scanned == (sys_count - num_failed - num_unreachable), assertion_error_message
 
 
-@mark_runs_scans
+@pytest.mark.runs_scan
 def test_disabled_optional_products_facts(data_provider):
     """Test scan jobs from scans with disabled optional products.
 
@@ -174,7 +173,7 @@ def test_disabled_optional_products_facts(data_provider):
     assert len(errors_found) == 0, "\n================\n".join(errors_found)
 
 
-@mark_runs_scans
+@pytest.mark.runs_scan
 def test_disabled_optional_products(data_provider):
     """Test scan jobs from scans with disabled_optional_products.
 
@@ -223,7 +222,7 @@ def test_disabled_optional_products(data_provider):
     assert len(errors_found) == 0, "\n================\n".join(errors_found)
 
 
-@mark_runs_scans
+@pytest.mark.runs_scan
 def test_enabled_extended_product_search_facts(data_provider):
     """Test scan jobs from scans with enabled extended products search.
 
@@ -296,7 +295,7 @@ def test_enabled_extended_product_search_facts(data_provider):
     assert len(errors_found) == 0, "\n================\n".join(errors_found)
 
 
-@mark_runs_scans
+@pytest.mark.runs_scan
 def test_enabled_extended_product_search(data_provider):
     """Test scan jobs from scans with enabled extended product search.
 

--- a/camayoc/tests/qpc/cli/conftest.py
+++ b/camayoc/tests/qpc/cli/conftest.py
@@ -1,7 +1,6 @@
 """Test utilities for quipucords' ``qpc`` tests."""
 import pytest
 
-from .utils import clear_all_entities
 from .utils import config_credentials
 from .utils import config_sources
 from .utils import setup_qpc
@@ -26,12 +25,6 @@ def source_type(request):
 def scan_type(request):
     """Fixture that returns the quipucords scan types."""
     return request.param
-
-
-@pytest.fixture(scope="module", autouse=True)
-def cleanup_server():
-    """Cleanup objects on the server after each module runs."""
-    clear_all_entities()
 
 
 @pytest.fixture(params=config_credentials(), ids=name_getter)

--- a/camayoc/tests/qpc/cli/conftest.py
+++ b/camayoc/tests/qpc/cli/conftest.py
@@ -3,7 +3,6 @@ import pytest
 
 from .utils import clear_all_entities
 from .utils import config_credentials
-from .utils import config_scans
 from .utils import config_sources
 from .utils import cred_add_and_check
 from .utils import setup_qpc
@@ -88,10 +87,4 @@ def credential(request):
 @pytest.fixture(params=config_sources(), ids=name_getter)
 def source(request):
     """Return each source available on the config file."""
-    return request.param
-
-
-@pytest.fixture(params=config_scans(), ids=name_getter)
-def scan(request):
-    """Return each scan available on the config file."""
     return request.param

--- a/camayoc/tests/qpc/cli/conftest.py
+++ b/camayoc/tests/qpc/cli/conftest.py
@@ -4,54 +4,10 @@ import pytest
 from .utils import clear_all_entities
 from .utils import config_credentials
 from .utils import config_sources
-from .utils import cred_add_and_check
 from .utils import setup_qpc
-from .utils import source_add_and_check
-from camayoc.constants import BECOME_PASSWORD_INPUT
-from camayoc.constants import CONNECTION_PASSWORD_INPUT
 from camayoc.constants import QPC_SCAN_TYPES
 from camayoc.constants import QPC_SOURCE_TYPES
 from camayoc.utils import name_getter
-
-
-@pytest.fixture(autouse=True, scope="module")
-def setup_scan_prerequisites(request):
-    """Create all credentials and sources on the server."""
-    module_path = request.node.fspath.strpath
-    if not (
-        module_path.endswith("test_reports.py")
-        or module_path.endswith("test_scans.py")
-        or module_path.endswith("test_scanjobs.py")
-    ):
-        return
-
-    setup_qpc()
-
-    # Create new creds
-    for credential_data in config_credentials():
-        credential = {key: value for key, value in credential_data.items() if value is not None}
-        inputs = []
-        # Both password and become-password are options to the cred add
-        # command. Update the credentials dictionary to mark them as flag
-        # options and capture their value, if present, to be provided as input
-        # for the prompts.
-        if "password" in credential:
-            inputs.append((CONNECTION_PASSWORD_INPUT, credential["password"]))
-            credential["password"] = None
-        if "become_password" in credential:
-            inputs.append((BECOME_PASSWORD_INPUT, credential["become-password"]))
-            credential["become-password"] = None
-        cred_add_and_check(credential, inputs)
-
-    # create sources
-    for source in config_sources():
-        source["cred"] = source.pop("credentials")
-        options = source.pop("options", {})
-        if options is None:
-            options = {}
-        for k, v in options.items():
-            source[k.replace("_", "-")] = v
-        source_add_and_check(source)
 
 
 @pytest.fixture()

--- a/camayoc/tests/qpc/cli/test_scanjobs.py
+++ b/camayoc/tests/qpc/cli/test_scanjobs.py
@@ -30,11 +30,10 @@ from camayoc.constants import QPC_FUSE_RAW_FACTS
 from camayoc.constants import QPC_OPTIONAL_PRODUCTS
 from camayoc.exceptions import NoMatchingDataDefinitionException
 from camayoc.qpc_models import Scan
-from camayoc.tests.qpc.utils import mark_runs_scans
 from camayoc.utils import uuid4
 
 
-@mark_runs_scans
+@pytest.mark.runs_scan
 def test_scanjob(qpc_server_config, data_provider):
     """Scan a single source type.
 
@@ -78,7 +77,7 @@ def test_scanjob(qpc_server_config, data_provider):
         assert report.get("sources", []) != []
 
 
-@mark_runs_scans
+@pytest.mark.runs_scan
 def test_scanjob_with_multiple_sources(qpc_server_config, data_provider):
     """Scan multiple source types.
 
@@ -125,7 +124,7 @@ def test_scanjob_with_multiple_sources(qpc_server_config, data_provider):
 
 
 @pytest.mark.skip(reason="Skipped until Quipucords Issue #2038 us resolved")
-@mark_runs_scans
+@pytest.mark.runs_scan
 def test_scanjob_with_disabled_products(isolated_filesystem, qpc_server_config):
     """Perform a scan with optional products disabled.
 
@@ -183,7 +182,7 @@ def test_scanjob_with_disabled_products(isolated_filesystem, qpc_server_config):
     assert len(errors_found) == 0, "\n================\n".join(errors_found)
 
 
-@mark_runs_scans
+@pytest.mark.runs_scan
 def test_scanjob_with_enabled_extended_products(qpc_server_config, data_provider):
     """Perform a scan with extended products enabled.
 
@@ -243,7 +242,7 @@ def test_scanjob_with_enabled_extended_products(qpc_server_config, data_provider
 
 
 @pytest.mark.skip(reason="Skipping until Quipucords Issue #2040 resoloved")
-@mark_runs_scans
+@pytest.mark.runs_scan
 def test_scanjob_restart(isolated_filesystem, qpc_server_config):
     """Perform a scan and ensure it can be paused and restarted.
 
@@ -278,7 +277,7 @@ def test_scanjob_restart(isolated_filesystem, qpc_server_config):
         assert report.get("sources", []) != []
 
 
-@mark_runs_scans
+@pytest.mark.runs_scan
 def test_scanjob_cancel(qpc_server_config, data_provider):
     """Perform a scan and ensure it can be canceled.
 
@@ -309,7 +308,7 @@ def test_scanjob_cancel(qpc_server_config, data_provider):
 
 
 @pytest.mark.skip(reason="Skipping until Quipucords Issue #2040 resoloved")
-@mark_runs_scans
+@pytest.mark.runs_scan
 def test_scanjob_cancel_paused(isolated_filesystem, qpc_server_config):
     """Perform a scan and ensure it can be canceled even when paused.
 

--- a/camayoc/tests/qpc/utils.py
+++ b/camayoc/tests/qpc/utils.py
@@ -2,15 +2,11 @@
 import hashlib
 from pathlib import Path
 
-import pytest
-
 from camayoc import api
 from camayoc.qpc_models import Credential
 from camayoc.qpc_models import Scan
 from camayoc.qpc_models import Source
 from camayoc.utils import uuid4
-
-mark_runs_scans = pytest.mark.skipif(False, reason="We are always running scans now")
 
 
 def assert_matches_server(qpcobject):

--- a/camayoc/tests/qpc/utils.py
+++ b/camayoc/tests/qpc/utils.py
@@ -8,11 +8,9 @@ from camayoc import api
 from camayoc.qpc_models import Credential
 from camayoc.qpc_models import Scan
 from camayoc.qpc_models import Source
-from camayoc.utils import run_scans
 from camayoc.utils import uuid4
 
-mark_runs_scans = pytest.mark.skipif(run_scans() is False, reason="RUN_SCANS set to False")
-"""Decorator that skips tests if RUN_SCANS environment variable is 'False'."""
+mark_runs_scans = pytest.mark.skipif(False, reason="We are always running scans now")
 
 
 def assert_matches_server(qpcobject):

--- a/camayoc/tests/qpc/utils.py
+++ b/camayoc/tests/qpc/utils.py
@@ -168,8 +168,11 @@ def sort_and_delete(trash):
             obj.client = client
             # Get object id based on the name.
             # This allows us to clean up objects created from UI and CLI.
+            # If object id could not be found, assume object was already deleted.
             if not obj._id and obj.name:
                 obj._id = get_object_id(obj)
+            if obj._id is None:
+                continue
             # Only assert that we do not hit an internal server error, in case
             # for some reason the object was already cleaned up by the test
             response = obj.delete()

--- a/camayoc/types/settings.py
+++ b/camayoc/types/settings.py
@@ -106,19 +106,20 @@ class SourceOptions(BaseModel):
     options: Optional[SourceOptionsOptions]
 
 
+class ExpectedDistributionData(BaseModel):
+    name: str
+    version: str
+    release: str
+
+
 class ExpectedScanData(BaseModel):
-    hostname: str
-    credentials: list[str]
-    ipv4: str
-    hypervisor: str  # FIXME: should be enum
-    distribution: dict[str, str]  # FIXME: should be strongly-types
-    products: dict[str, dict[str, str]]  # FIXME: should be strongly-types
+    distribution: Optional[ExpectedDistributionData]
 
 
 class ScanOptions(BaseModel):
     name: str
     sources: list[str]
-    expected_data: Optional[list[ExpectedScanData]]
+    expected_data: Optional[dict[str, ExpectedScanData]]
 
 
 class Configuration(BaseModel):

--- a/camayoc/utils.py
+++ b/camayoc/utils.py
@@ -3,7 +3,6 @@
 import base64
 import contextlib
 import json
-import operator
 import os
 import shutil
 import tempfile
@@ -19,8 +18,14 @@ _XDG_ENV_VARS = ("XDG_DATA_HOME", "XDG_CONFIG_HOME", "XDG_CACHE_HOME")
 """Environment variables related to the XDG Base Directory specification."""
 
 
-name_getter = operator.itemgetter("name")
-"""Generate test IDs by fetching the ``name`` item."""
+def name_getter(obj):
+    """Generate test IDs by fetching the ``name`` item."""
+    try:
+        name = obj.get("name")
+        if not name:
+            raise KeyError
+    except (AttributeError, KeyError):
+        return obj.name
 
 
 client_cmd = settings.quipucords_cli.executable

--- a/camayoc/utils.py
+++ b/camayoc/utils.py
@@ -37,11 +37,6 @@ client_cmd_name = settings.quipucords_cli.display_name
 # or even when we finally support running tests with proper dsc.
 
 
-def run_scans():
-    """Check if scans should be run."""
-    return bool(settings.camayoc.run_scans)
-
-
 def get_qpc_url():
     """Return the base url for the qpc server."""
     cfg = get_config().get("qpc", {})

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -3,8 +3,7 @@
 # with and camayoc itself.
 
 # Camayoc test framework settings
-camayoc:
-    run_scans: false
+camayoc: {}
 
 # Quipucords / Discovery server
 # Settings below allow you to connect to quipucords development server

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -114,35 +114,17 @@ scans:
           - 'myfav'
           - 'vcenter'
       expected_data:
-          - hostname: jbossamq-rhel-5-vc
-            credentials:
-                - root
-            ipv4: 10.10.181.14
-            hypervisor: vcenter
-            distribution:
-                name: 'Red Hat Enterprise Linux'
-                version: '5.9'
-            products:
-                jbossamq:
-                    install-process: zip
-                    version: '6.2.0'
-                openjdk:
-                    version: '1.7'
-          - hostname: jbossamq-rhel-6-vc
-            credentials:
-                - root
-            ipv4: 10.10.181.132
-            hypervisor: vcenter
-            distribution:
-                # Name of OS should be substring of name found
-                # with quipucords
-                name: 'Red Hat Enterprise Linux'
-                # version should be substring of version found
-                # in /etc/redhat-release
-                version: '6.9'
-            products:
-                jbossamq:
-                    install-process: zip
-                    version: '7.0.2'
-                openjdk:
-                    version: '1.8'
+          jbossamq-rhel-5-vc:
+              distribution:
+                  # Name of OS should be substring of name found
+                  # with quipucords
+                  name: 'Red Hat Enterprise Linux'
+                  # version should be substring of version found
+                  # in /etc/redhat-release
+                  version: '5.9'
+                  release: ''
+          jbossamq-rhel-6-vc:
+              distribution:
+                  name: 'Red Hat Enterprise Linux'
+                  version: '6.9'
+                  release: ''

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 filterwarnings = ignore::urllib3.exceptions.InsecureRequestWarning
 markers =
     ssh_keyfile_path: mark test with SSH key file path mapped to /sshkeys/ on the server (deselect with '-m "not ssh_keyfile_path"')
+    runs_scan: tests that run scans (might be slow!)

--- a/tests/test_data_provider.py
+++ b/tests/test_data_provider.py
@@ -157,7 +157,8 @@ def test_automatic_cleanup():
     dp = DataProvider(credentials=CREDENTIALS, sources=SOURCES, scans=SCANS)
     with mock.patch("camayoc.api.Client"):
         with mock.patch.object(dp.credentials._model_class, "delete") as mock_delete:
-            dp.credentials.new_one({"type": "network"}, data_only=False)
+            cred = dp.credentials.new_one({"type": "network"}, data_only=False)
+            cred._id = 123
             mock_delete.return_value = mock.Mock
             mock_delete.return_value.status_code = mock.PropertyMock(return_value=200)
             dp.cleanup()
@@ -169,6 +170,7 @@ def test_mark_for_cleanup():
     with mock.patch("camayoc.api.Client"):
         with mock.patch.object(dp.credentials._model_class, "delete") as mock_delete:
             cred = dp.credentials.new_one({"type": "network"}, data_only=True)
+            cred._id = 123
             mock_delete.return_value = mock.Mock
             mock_delete.return_value.status_code = mock.PropertyMock(return_value=200)
             dp.cleanup()


### PR DESCRIPTION
This PR enables reports and scan / scanjobs tests. I tried to make commits relatively complete, so it's best to review things commit-by-commit.

It depends on config changes introduced in discovery-ci PR #7.

Most changes revolve around using DataProvider and untangling dependencies between functions and fixtures. I decided to not port tests that are marked as skipped - I ran them before starting this work, and it seems that referenced issues are still not solved.

Performance of current version is not great, as most tests run scans they need - this leads to servers being scanned multiple times. I think this is something we can try to tackle later on.

Test results are below. There's one failure, but that tests seems flaky - it usually fails, but I saw it passing few times. Another thing to tackle later.

```
$ pytest -v camayoc/tests/qpc/api/v1/reports/test_reports.py camayoc/tests/qpc/api/v1/scanjobs/ camayoc/tests/qpc/cli/test_reports.py camayoc/tests/qpc/cli/test_scanjobs.py
camayoc/tests/qpc/api/v1/reports/test_reports.py::test_report_content_consistency PASSED                                                                               [  2%]
camayoc/tests/qpc/api/v1/reports/test_reports.py::test_merge_reports_from_scanjob PASSED                                                                               [  4%]
camayoc/tests/qpc/api/v1/reports/test_reports.py::test_merge_reports_negative PASSED                                                                                   [  6%]
camayoc/tests/qpc/api/v1/reports/test_reports.py::test_products_found_deployment_report[testlab] SKIPPED (Skipped until Middleware are handled by Camayoc)             [  8%]
camayoc/tests/qpc/api/v1/reports/test_reports.py::test_products_found_deployment_report[VCenterOnly] SKIPPED (Skipped until Middleware are handled by Camayoc)         [ 10%]
camayoc/tests/qpc/api/v1/reports/test_reports.py::test_products_found_deployment_report[Sat6] SKIPPED (Skipped until Middleware are handled by Camayoc)                [ 12%]
camayoc/tests/qpc/api/v1/reports/test_reports.py::test_OS_found_deployment_report[testlab] PASSED                                                                      [ 14%]
camayoc/tests/qpc/api/v1/reports/test_reports.py::test_OS_found_deployment_report[VCenterOnly] PASSED                                                                  [ 17%]
camayoc/tests/qpc/api/v1/reports/test_reports.py::test_OS_found_deployment_report[Sat6] PASSED                                                                         [ 19%]
camayoc/tests/qpc/api/v1/scanjobs/test_pause_cancel_restart.py::test_pause_cancel[vcenter] SKIPPED (Test is flaky. Skipping until Quipucords Issue #2040 resoloved)    [ 21%]
camayoc/tests/qpc/api/v1/scanjobs/test_pause_cancel_restart.py::test_pause_cancel[network] SKIPPED (Test is flaky. Skipping until Quipucords Issue #2040 resoloved)    [ 23%]
camayoc/tests/qpc/api/v1/scanjobs/test_pause_cancel_restart.py::test_pause_cancel[satellite] SKIPPED (Test is flaky. Skipping until Quipucords Issue #2040 resoloved)  [ 25%]
camayoc/tests/qpc/api/v1/scanjobs/test_pause_cancel_restart.py::test_pause_cancel[openshift] SKIPPED (Test is flaky. Skipping until Quipucords Issue #2040 resoloved)  [ 27%]
camayoc/tests/qpc/api/v1/scanjobs/test_pause_cancel_restart.py::test_restart[vcenter] SKIPPED (Test is flaky. Skipping until Quipucords Issue #2040 resoloved)         [ 29%]
camayoc/tests/qpc/api/v1/scanjobs/test_pause_cancel_restart.py::test_restart[network] SKIPPED (Test is flaky. Skipping until Quipucords Issue #2040 resoloved)         [ 31%]
camayoc/tests/qpc/api/v1/scanjobs/test_pause_cancel_restart.py::test_restart[satellite] SKIPPED (Test is flaky. Skipping until Quipucords Issue #2040 resoloved)       [ 34%]
camayoc/tests/qpc/api/v1/scanjobs/test_pause_cancel_restart.py::test_restart[openshift] SKIPPED (Test is flaky. Skipping until Quipucords Issue #2040 resoloved)       [ 36%]
camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py::test_scan_complete[testlab] SKIPPED (Test is flaky. Skipping until Quipucords Issue #2040 resoloved)           [ 38%]
camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py::test_scan_complete[VCenterOnly] SKIPPED (Test is flaky. Skipping until Quipucords Issue #2040 resoloved)       [ 40%]
camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py::test_scan_complete[Sat6] SKIPPED (Test is flaky. Skipping until Quipucords Issue #2040 resoloved)              [ 42%]
camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py::test_scan_task_results[testlab] PASSED                                                                         [ 44%]
camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py::test_scan_task_results[VCenterOnly] PASSED                                                                     [ 46%]
camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py::test_scan_task_results[Sat6] PASSED                                                                            [ 48%]
camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py::test_disabled_optional_products_facts FAILED                                                                   [ 51%]
camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py::test_disabled_optional_products PASSED                                                                         [ 53%]
camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py::test_enabled_extended_product_search_facts PASSED                                                              [ 55%]
camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py::test_enabled_extended_product_search PASSED                                                                    [ 57%]
camayoc/tests/qpc/cli/test_reports.py::test_deployments_report[csv-report] PASSED                                                                                      [ 59%]
camayoc/tests/qpc/cli/test_reports.py::test_deployments_report[csv-scan-job] PASSED                                                                                    [ 61%]
camayoc/tests/qpc/cli/test_reports.py::test_deployments_report[json-report] PASSED                                                                                     [ 63%]
camayoc/tests/qpc/cli/test_reports.py::test_deployments_report[json-scan-job] PASSED                                                                                   [ 65%]
camayoc/tests/qpc/cli/test_reports.py::test_detail_report[csv-report] PASSED                                                                                           [ 68%]
camayoc/tests/qpc/cli/test_reports.py::test_detail_report[csv-scan-job] PASSED                                                                                         [ 70%]
camayoc/tests/qpc/cli/test_reports.py::test_detail_report[json-report] PASSED                                                                                          [ 72%]
camayoc/tests/qpc/cli/test_reports.py::test_detail_report[json-scan-job] PASSED                                                                                        [ 74%]
camayoc/tests/qpc/cli/test_reports.py::test_merge_report[report] PASSED                                                                                                [ 76%]
camayoc/tests/qpc/cli/test_reports.py::test_merge_report[scan-job] PASSED                                                                                              [ 78%]
camayoc/tests/qpc/cli/test_reports.py::test_merge_report[json-file] PASSED                                                                                             [ 80%]
camayoc/tests/qpc/cli/test_reports.py::test_download_report[report] PASSED                                                                                             [ 82%]
camayoc/tests/qpc/cli/test_reports.py::test_download_report[scan-job] PASSED                                                                                           [ 85%]
camayoc/tests/qpc/cli/test_scanjobs.py::test_scanjob PASSED                                                                                                            [ 87%]
camayoc/tests/qpc/cli/test_scanjobs.py::test_scanjob_with_multiple_sources PASSED                                                                                      [ 89%]
camayoc/tests/qpc/cli/test_scanjobs.py::test_scanjob_with_disabled_products SKIPPED (Skipped until Quipucords Issue #2038 us resolved)                                 [ 91%]
camayoc/tests/qpc/cli/test_scanjobs.py::test_scanjob_with_enabled_extended_products PASSED                                                                             [ 93%]
camayoc/tests/qpc/cli/test_scanjobs.py::test_scanjob_restart SKIPPED (Skipping until Quipucords Issue #2040 resoloved)                                                 [ 95%]
camayoc/tests/qpc/cli/test_scanjobs.py::test_scanjob_cancel PASSED                                                                                                     [ 97%]
camayoc/tests/qpc/cli/test_scanjobs.py::test_scanjob_cancel_paused SKIPPED (Skipping until Quipucords Issue #2040 resoloved)                                           [100%]
====================================================== 1 failed, 29 passed, 17 skipped, 1 warning in 1325.72s (0:22:05) ======================================================
```