### PR TITLE
Don't crash if configuration is missing expected data

### DIFF
--- a/camayoc/qpc_models.py
+++ b/camayoc/qpc_models.py
@@ -457,7 +457,7 @@ class Scan(QPCObject):
                 definition_key = "source_ids"
                 definition_value = dependencies
             definition_data[definition_key] = definition_value
-        definition_data.pop("expected_data")
+        definition_data.pop("expected_data", None)
         return cls(**definition_data)
 
     def delete(self, **kwargs):


### PR DESCRIPTION
I forgot that `dict.pop("key")` will raise exception when key is not present in dictionary. I was thinking about `dict.get("key")`, which will return `None`.

Since we don't assign popped value to anything, let's set any default value and move on.

This should fix a failure when running scanjob tests.