### PR TITLE
Limit scope of scan_list fixture

### DIFF
--- a/camayoc/tests/qpc/api/v1/conftest.py
+++ b/camayoc/tests/qpc/api/v1/conftest.py
@@ -88,5 +88,13 @@ def run_scan(
 
 
 def scan_list():
-    """Generate list of scan dict objects found in config file."""
-    return settings.scans
+    """Generate list of netwok / VCenter / Satellite scan objects found in config file."""
+    scans = []
+    supported_source_types = ("network", "vcenter", "satellite")
+    source_names_types = {s.name: s.type for s in settings.sources}
+    for scan in settings.scans:
+        source_types = [source_names_types.get(source) for source in scan.sources]
+        if not all(source_type in supported_source_types for source_type in source_types):
+            continue
+        scans.append(scan)
+    return scans


### PR DESCRIPTION
Fix `camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py::test_scan_task_results[ansible-testlab]`.

This test doesn't make sense for scans that use Ansible (and OpenShift) sources. Other tests using this fixture are on the same boat, but they are either skipped, or technically pass (but don't check anything meaningful).