### PR TITLE
refactor: assert reports actually have IDs before trying to merge them

### DIFF
--- a/camayoc/tests/qpc/api/v1/reports/test_reports.py
+++ b/camayoc/tests/qpc/api/v1/reports/test_reports.py
@@ -153,9 +153,26 @@ def test_merge_reports_from_scanjob(data_provider):
     scanjob2.create()
     for scanjob in (scanjob1, scanjob2):
         wait_until_state(scanjob, state="stopped")
+
     report = Report()
-    reportid1 = Report().retrieve_from_scan_job(scanjob1._id).json().get("report_id")
-    reportid2 = Report().retrieve_from_scan_job(scanjob2._id).json().get("report_id")
+    report1_json = Report().retrieve_from_scan_job(scanjob1._id).json()
+    reportid1 = report1_json.get("report_id")
+    assert reportid1 is not None, (
+        "Report 1 response for Scan Job {scanjob_id} did not have a report_id.\n"
+        "Full report JSON response was:\n{report_json}".format(
+            scanjob_id=scanjob1._id, report_json=report1_json
+        )
+    )
+
+    report2_json = Report().retrieve_from_scan_job(scanjob2._id).json()
+    reportid2 = report2_json.get("report_id")
+    assert reportid2 is not None, (
+        "Report 2 response for Scan Job {scanjob_id} did not have a report_id.\n"
+        "Full report JSON response was:\n{report_json}".format(
+            scanjob_id=scanjob2._id, report_json=report2_json
+        )
+    )
+
     response = report.create_from_merge([reportid1, reportid2])
     deployments = report.deployments()
     details = report.details()


### PR DESCRIPTION
I encountered some difficulty troubleshooting a failing test that was being caused by quipucords not creating a scan job report, but the observed error from camayoc appeared to indicate that quipucords was failing to merge two reports.

This change adds a couple assertions to ensure that the reports returned by quipucords API are reasonably valid before attempting to merge them. Without these assertions, if one of the reports failed to create, the merge would correctly fail later due to one of the report IDs being `None`, but that failure masks an earlier failure that we should have observed and reported more specifically.

Here's an example output of the new assertion when one of the reports fails creation:
```
❯ poetry run pytest camayoc/tests/qpc/api/v1/reports/test_reports.py::test_merge_reports_from_scanjob
```
…
```
E       AssertionError: Report 1 response for Scan Job 4 did not have a report_id.
E         Full report JSON response was:
E         {'id': 4, 'scan': {'id': 3, 'name': 'Sat6-4d42d7e7-e831-46a1-a6c5-c5903d4592f5'}, 'sources': [{'id': 4, 'name': 'satellite', 'source_type': 'satellite'}], 'scan_type': 'inspect', 'status': 'failed', 'status_message': 'Scan manager failed job due to unexpected error.', 'tasks': [{'sequence_number': 1, 'source': 4, 'scan_type': 'connect', 'status': 'running', 'status_message': 'Task is running.', 'start_time': '2023-07-06T14:52:02.073903'}, {'sequence_number': 2, 'source': 4, 'scan_type': 'inspect', 'status': 'pending', 'status_message': 'Task is pending.'}, {'sequence_number': 3, 'scan_type': 'fingerprint', 'status': 'pending', 'status_message': 'Task is pending.', 'system_fingerprint_count': 0}], 'options': {'max_concurrency': 50}, 'start_time': '2023-07-06T14:52:02.024787', 'end_time': '2023-07-06T14:52:07.026107', 'systems_count': 0, 'systems_scanned': 0, 'systems_failed': 0, 'systems_unreachable': 0, 'system_fingerprint_count': 0}
E       assert None is not None

camayoc/tests/qpc/api/v1/reports/test_reports.py:164: AssertionError
=========================================================================== warnings summary ============================================================================
../../Library/Caches/pypoetry/virtualenvs/camayoc-uSBjm9lI-py3.11/lib/python3.11/site-packages/pkg_resources/__init__.py:121
  /Users/brasmith/Library/Caches/pypoetry/virtualenvs/camayoc-uSBjm9lI-py3.11/lib/python3.11/site-packages/pkg_resources/__init__.py:121: DeprecationWarning: pkg_resources is deprecated as an API
    warnings.warn("pkg_resources is deprecated as an API", DeprecationWarning)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================== short test summary info ========================================================================
FAILED camayoc/tests/qpc/api/v1/reports/test_reports.py::test_merge_reports_from_scanjob - AssertionError: Report 1 response for Scan Job 4 did not have a report_id.
===================================================================== 1 failed, 1 warning in 20.86s =====================================================================
```