### PR TITLE
style: add black line-length config to pyproject.toml to match Makefile and .pre-commit-config.yaml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ koji = "^1.33.0"
 
 [tool.black]
 target-version = ['py311']
+line-length = 100
 
 [tool.pytest.ini_options]
 filterwarnings = "ignore::urllib3.exceptions.InsecureRequestWarning"


### PR DESCRIPTION
The means editors (like VS Code) that are configured to automatically run `black` upon save will not introduce changes that then get yanked back out by `make` or the pre-commit hook.