### PR TITLE
Force order of camayoc/tests/qpc/cli/test_credentials.py::test_clear_all

### DIFF
--- a/camayoc/tests/conftest.py
+++ b/camayoc/tests/conftest.py
@@ -1,51 +1,14 @@
 # coding=utf-8
 """Pytest customizations and fixtures for the quipucords tests."""
 import ssl
-from pathlib import Path
 
 import pytest
 from pyVim.connect import Disconnect
 from pyVim.connect import SmartConnect
 
-try:
-    from pytest_ibutsu.pytest_plugin import ibutsu_plugin_key
-    from pytest_ibutsu.pytest_plugin import ibutsu_result_key
-except ImportError:
-    ibutsu_plugin_key = None
-
 from camayoc import utils
 from camayoc.config import get_config
 from camayoc.config import settings
-
-
-def _ibutsu_enabled(config: pytest.Config) -> bool:
-    if not ibutsu_plugin_key:
-        return False
-    ibutsu = config.stash.get(ibutsu_plugin_key, None)
-    if ibutsu is None:
-        return False
-    return ibutsu.enabled
-
-
-def _fill_ibutsu_result(item: pytest.Item):
-    ibutsu_result = item.stash[ibutsu_result_key]
-    component = ibutsu_result.metadata.get("component", None)
-    if not component:
-        testpath, _, _ = item.location
-        testpath = Path(testpath).relative_to("camayoc/tests/qpc/")
-        component = testpath.parts[0]
-    ibutsu_result.component = component
-
-
-@pytest.hookimpl(trylast=True)
-def pytest_collection_modifyitems(
-    session: pytest.Session, items: list[pytest.Item], config: pytest.Config
-) -> None:
-    ibutsu_enabled = _ibutsu_enabled(config)
-    if not ibutsu_enabled:
-        return
-    for item in items:
-        _fill_ibutsu_result(item)
 
 
 @pytest.fixture(scope="session")

--- a/camayoc/tests/conftest.py
+++ b/camayoc/tests/conftest.py
@@ -11,6 +11,16 @@ from camayoc.config import get_config
 from camayoc.config import settings
 
 
+def pytest_collection_modifyitems(
+    session: pytest.Session, items: list[pytest.Item], config: pytest.Config
+) -> None:
+    for clear_all_idx, node in enumerate(items):
+        if node.nodeid.endswith("test_credentials.py::test_clear_all"):
+            break
+    clear_all_node = items.pop(clear_all_idx)
+    items.insert(0, clear_all_node)
+
+
 @pytest.fixture(scope="session")
 def vcenter_client():
     """Create a vCenter client.


### PR DESCRIPTION
There are two commits:

* revert #385 - we now run all camayoc tests in single process (instead of api, cli and ui separately), all tests are passed or skipped, and this component setting never really worked as expected
* force `camayoc/tests/qpc/cli/test_credentials.py::test_clear_all` to run at the beginning of test run. If this test is executed in the middle of a test run (where pytest puts it by default), `qpc cred clear all` can't succeed - other tests already created sources and scans depending on credentials.

This is a hack, but Camayoc is not prepared to run tests in random order or in parallel, so it seems like an OK compromise.

```
$ pytest  -v -ra --ibutsu=local --ibutsu-project=discovery camayoc/tests/qpc/api camayoc/tests/qpc/cli
========================================================= 726 passed, 19 skipped, 756 warnings in 2749.53s (0:45:49) =========================================================
```