### PR TITLE
First batch of UI changes

### DIFF
--- a/camayoc/ui/models/components/items_list.py
+++ b/camayoc/ui/models/components/items_list.py
@@ -21,15 +21,8 @@ class ItemsList(UIPage):
 
     def _get_item_from_current_list(self, name: str):
         default_timeout = 5000  # 5s
-        name_selectors = [
-            f'div.{class_name}:text-is("{name}")'
-            for class_name in ("list-group-item-heading", "list-item-name")
-        ]
-        item_elem = self._driver.locator(",".join(name_selectors))
-        item_elem_locator = (
-            "xpath=./ancestor::div[contains(@class, 'list-group-item')]"
-            "[not(contains(@class, 'list-group-item-text'))]"
-        )
+        item_elem = self._driver.locator("css=strong").filter(has_text=name)
+        item_elem_locator = "xpath=./ancestor::tr[contains(@class, 'quipucords-table__tr')]"
         item_elem = item_elem.locator(item_elem_locator)
         item_elem.hover(timeout=default_timeout, trial=True)
         return item_elem
@@ -39,12 +32,14 @@ class ItemsList(UIPage):
     # by multiple fileds, clearing filters, sorting?).
     # But YAGNI tells us this will do for now
     def _search_for_item_by_name(self, name: str):
-        filter_field_button = self._driver.locator("button#filterFieldTypeMenu")
+        filter_field_button = self._driver.locator(
+            "div.pf-c-toolbar__content button[id]:has(span.pf-c-select__toggle-arrow)"
+        ).locator("nth=0")
         if filter_field_button.text_content() != "Name":
             filter_field_button.click()
             values_list = filter_field_button.locator("xpath=following-sibling::ul")
             values_list.locator("text='Name'").click()
-        self._driver.fill("input[placeholder$=Name]", name)
+        self._driver.fill("input[placeholder$=name]", name)
         self._driver.keyboard.press("Enter")
 
     def _get_item(self, name: str):

--- a/camayoc/ui/models/components/popup.py
+++ b/camayoc/ui/models/components/popup.py
@@ -5,8 +5,8 @@ from camayoc.ui.types import UIPage
 
 
 class PopUp(UIPage):
-    SAVE_LOCATOR = ".modal-footer button.btn-primary"
-    CANCEL_LOCATOR = ".modal-footer button.btn-cancel"
+    SAVE_LOCATOR = ".pf-c-modal-box__footer button.pf-m-primary"
+    CANCEL_LOCATOR = ".pf-c-modal-box__footer button.pf-m-secondary"
     SAVE_RESULT_CLASS = None
     CANCEL_RESULT_CLASS = None
 

--- a/camayoc/ui/models/components/vertical_navigation.py
+++ b/camayoc/ui/models/components/vertical_navigation.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
     NavigateToPage = Union[CredentialsMainPage, ScansMainPage, SourcesMainPage]
 
-LEFT_NAV = ".nav-pf-vertical"
+LEFT_NAV = "nav.pf-c-nav"
 
 
 class VerticalNavigation(UIPage):

--- a/camayoc/ui/models/components/wizard.py
+++ b/camayoc/ui/models/components/wizard.py
@@ -10,9 +10,9 @@ class Wizard(UIPage):
 
 
 class WizardStep(PopUp, UIPage):
-    NEXT_STEP_LOCATOR = '.modal-footer button:has-text("Next")'
-    PREV_STEP_LOCATOR = '.modal-footer button:has-text("Back")'
-    CANCEL_LOCATOR = ".modal-footer button.btn-cancel"
+    NEXT_STEP_LOCATOR = '.pf-c-wizard__footer button:has-text("Next")'
+    PREV_STEP_LOCATOR = '.pf-c-wizard__footer button:has-text("Back")'
+    CANCEL_LOCATOR = ".pf-c-wizard__footer .pf-c-wizard__footer-cancel button"
     NEXT_STEP_RESULT_CLASS = None
     PREV_STEP_RESULT_CLASS = None
     CANCEL_RESULT_CLASS = None

--- a/camayoc/ui/models/pages/credentials.py
+++ b/camayoc/ui/models/pages/credentials.py
@@ -38,8 +38,8 @@ class NetworkCredentialForm(CredentialForm):
     class FormDefinition:
         credential_name = InputField("input[placeholder$=credential]")
         authentication_type = SelectField("button#auth-type-select")
-        username = InputField("input[placeholder$=Username]")
-        password = InputField("input[placeholder$=Password]")
+        username = InputField("input[placeholder$=username]")
+        password = InputField("input[placeholder$=password]")
         ssh_key_file = InputField('label:has-text("SSH Key File") + div input')
         passphrase = InputField('label:has-text("Passphrase") + div input')
         become_method = SelectField("button#become-method-select")
@@ -59,8 +59,8 @@ class NetworkCredentialForm(CredentialForm):
 class SatelliteCredentialForm(CredentialForm):
     class FormDefinition:
         credential_name = InputField("input[placeholder$=credential]")
-        username = InputField("input[placeholder$=Username]")
-        password = InputField("input[placeholder$=Password]")
+        username = InputField("input[placeholder$=username]")
+        password = InputField("input[placeholder$=password]")
 
     @overload
     def fill(self, data: SatelliteCredentialFormDTO):
@@ -75,8 +75,8 @@ class SatelliteCredentialForm(CredentialForm):
 class VCenterCredentialForm(CredentialForm):
     class FormDefinition:
         credential_name = InputField("input[placeholder$=credential]")
-        username = InputField("input[placeholder$=Username]")
-        password = InputField("input[placeholder$=Password]")
+        username = InputField("input[placeholder$=username]")
+        password = InputField("input[placeholder$=password]")
 
     @overload
     def fill(self, data: VCenterCredentialFormDTO):
@@ -104,11 +104,11 @@ class CredentialsMainPage(MainPageMixin):
                 "class": NetworkCredentialForm,
             },
             CredentialTypes.SATELLITE: {
-                "selector": f"{create_credential_button} ~ ul li:nth-of-type(2) a",
+                "selector": f"{create_credential_button} ~ ul li:nth-of-type(3) a",
                 "class": SatelliteCredentialForm,
             },
             CredentialTypes.VCENTER: {
-                "selector": f"{create_credential_button} ~ ul li:nth-of-type(3) a",
+                "selector": f"{create_credential_button} ~ ul li:nth-of-type(4) a",
                 "class": VCenterCredentialForm,
             },
         }

--- a/camayoc/ui/models/pages/sources.py
+++ b/camayoc/ui/models/pages/sources.py
@@ -29,8 +29,8 @@ from .abstract_page import AbstractPage
 
 
 class CancelWizardPopup(PopUp, AbstractPage):
-    SAVE_LOCATOR = ".modal-footer button.btn-primary:text-is('Yes')"
-    CANCEL_LOCATOR = ".modal-footer button.btn-cancel:text-is('No')"
+    SAVE_LOCATOR = ".pf-c-modal-box__footer button.pf-m-primary:text-is('Yes')"
+    CANCEL_LOCATOR = ".pf-c-modal-box__footer button.pf-m-secondary:text-is('No')"
     SAVE_RESULT_CLASS = Pages.SOURCES
     CANCEL_RESULT_CLASS = None
 
@@ -41,7 +41,7 @@ class SelectSourceTypeForm(Form, WizardStep, AbstractPage):
     CANCEL_RESULT_CLASS = CancelWizardPopup
 
     class FormDefinition:
-        source_type = RadioGroupField("div.wizard-pf-contents:not(.hidden)")
+        source_type = RadioGroupField("div.pf-c-wizard__main-body:not(.hidden)")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -65,7 +65,7 @@ class SelectSourceTypeForm(Form, WizardStep, AbstractPage):
 
 
 class SourceCredentialsForm(Form, WizardStep, AbstractPage):
-    NEXT_STEP_LOCATOR = '.modal-footer button:has-text("Save")'
+    NEXT_STEP_LOCATOR = '.pf-c-wizard__footer button:has-text("Save")'
     NEXT_STEP_RESULT_CLASS = Pages.SOURCES_RESULTS_PAGE
     PREV_STEP_RESULT_CLASS = SelectSourceTypeForm
     CANCEL_RESULT_CLASS = CancelWizardPopup
@@ -134,7 +134,7 @@ class VCenterSourceCredentialsForm(SourceCredentialsForm):
 
 
 class ResultForm(WizardStep, AbstractPage):
-    NEXT_STEP_LOCATOR = ".modal-footer button.btn-primary"
+    NEXT_STEP_LOCATOR = ".pf-c-wizard__footer button.pf-m-primary"
     NEXT_STEP_RESULT_CLASS = Pages.SOURCES
 
 
@@ -163,7 +163,7 @@ class ScanForm(Form, PopUp, AbstractPage):
 
 class SourceListElem(AbstractListItem):
     def open_scan(self) -> ScanForm:
-        scan_locator = 'div.list-view-pf-actions button:has-text("Scan")'
+        scan_locator = 'td.quipucords-table__td-action button:has-text("Scan")'
         self.locator.locator(scan_locator).click()
         return ScanForm(client=self._client)
 
@@ -185,7 +185,7 @@ class SourcesMainPage(MainPageMixin):
 
     @record_action
     def open_add_source(self) -> SelectSourceTypeForm:
-        create_source_button = 'button.btn-primary:has-text("Add")'
+        create_source_button = 'button.pf-m-primary:has-text("Add")'
         self._driver.click(create_source_button)
         return self._new_page(SelectSourceTypeForm)
 


### PR DESCRIPTION
These changes are done by running `camayoc/tests/qpc/ui/test_playwright_demo.py::test_demo_endtoend` until it started to pass. However:

- I only tested Satellite and VCenter credentials. We don't have any coverage for Ansible and OpenShift, which were added after UI tests were implemented. I decided to skip Network scans for now, as Network form is much more complex and see next point
- I had to do a lot of changes in form models, which are not included here. For a lot of form elements, we lost nice ids and now we have to match label by text and get input / button relative to label. I think instead of using terrible locators, it's better to work on quipucords-ui on bringing back nice ids.

So, this is not enough to start running any UI tests, but that's probably most I can do before I resume work on pipelines.