### PR TITLE
Ensure UI tests have clean database to work around DISCOVERY-162

### DIFF
--- a/camayoc/tests/qpc/ui/conftest.py
+++ b/camayoc/tests/qpc/ui/conftest.py
@@ -140,6 +140,13 @@ def browser_context_args(browser_context_args):
     return {**browser_context_args, **extra_context_args}
 
 
+@pytest.fixture(scope="module")
+def data_provider(data_provider):
+    data_provider.cleanup()
+    clear_all_entities()
+    return data_provider
+
+
 @pytest.fixture
 def ui_client(page):
     client_session = BasicSession()


### PR DESCRIPTION
DISCOVERY-162 will cause UI tests to fail, unless you run them module-by-module and clean db in between.

This patch introduces a workaround - before each UI module, call `data_provider.cleanup()` and a helper that removes all scans / sources / credentials using CLI. This ensures that UI has clean DB when then start, and allows them to pass.

With this and #430 merged in, you can run entire Camayoc suite against local container: https://url.corp.redhat.com/ibutsu-runs-1bccfe98-ad65-4905-90b5-6e47d540bd49