### PR TITLE
Refactor waits

### DIFF
--- a/camayoc/tests/qpc/api/v1/reports/test_reports.py
+++ b/camayoc/tests/qpc/api/v1/reports/test_reports.py
@@ -81,7 +81,8 @@ def test_report_content_consistency(data_provider):
     scan = data_provider.scans.new_one({}, new_dependencies=False, data_only=False)
     scanjob = ScanJob(scan_id=scan._id)
     scanjob.create()
-    wait_until_state(scanjob, state="stopped")
+    wait_until_state(scanjob, state="running", timeout=120)
+    wait_until_state(scanjob, state="stopped", timeout=900)
     report = Report()
     response = report.retrieve_from_scan_job(scanjob._id)
     if response.json().get("report_id") is None:
@@ -151,8 +152,9 @@ def test_merge_reports_from_scanjob(data_provider):
     scanjob1.create()
     scanjob2 = ScanJob(scan_id=scan2._id)
     scanjob2.create()
+    wait_until_state(scanjob1, state="running", timeout=120)
     for scanjob in (scanjob1, scanjob2):
-        wait_until_state(scanjob, state="stopped")
+        wait_until_state(scanjob, state="stopped", timeout=900)
 
     report = Report()
     report1_json = Report().retrieve_from_scan_job(scanjob1._id).json()
@@ -257,7 +259,8 @@ def test_products_found_deployment_report(data_provider, scan_info):
     scan = data_provider.scans.defined_one({"name": scan_info.get("name")})
     scanjob = ScanJob(scan_id=scan._id)
     scanjob.create()
-    wait_until_state(scanjob, state="stopped")
+    wait_until_state(scanjob, state="running", timeout=120)
+    wait_until_state(scanjob, state="stopped", timeout=900)
     report = Report()
     report.retrieve_from_scan_job(scan_job_id=scanjob._id)
     result = SCAN_DATA.get(scan.name)
@@ -339,7 +342,8 @@ def test_OS_found_deployment_report(data_provider, scan_info: ScanOptions):
     scan = data_provider.scans.defined_one({"name": scan_info.name})
     scanjob = ScanJob(scan_id=scan._id)
     scanjob.create()
-    wait_until_state(scanjob, state="stopped")
+    wait_until_state(scanjob, state="running", timeout=120)
+    wait_until_state(scanjob, state="stopped", timeout=900)
     report = Report()
     report.retrieve_from_scan_job(scan_job_id=scanjob._id)
     if not report._id:

--- a/camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py
+++ b/camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py
@@ -76,7 +76,8 @@ def test_scan_task_results(data_provider, scan_info: ScanOptions):
     scan = data_provider.scans.defined_one({"name": scan_info.name})
     scanjob = ScanJob(scan_id=scan._id)
     scanjob.create()
-    wait_until_state(scanjob, state="stopped")
+    wait_until_state(scanjob, state="running", timeout=120)
+    wait_until_state(scanjob, state="stopped", timeout=900)
     assertion_error_message = "Details of failed scan : {0}".format(pformat(scanjob.read().json()))
 
     task_results = scanjob.read().json().get("tasks")
@@ -131,7 +132,8 @@ def test_disabled_optional_products(data_provider):
     data_provider.mark_for_cleanup(scan)
     scanjob = ScanJob(scan_id=scan._id)
     scanjob.create()
-    wait_until_state(scanjob, state="stopped")
+    wait_until_state(scanjob, state="running", timeout=120)
+    wait_until_state(scanjob, state="stopped", timeout=900)
 
     errors_found = []
     # grab disabled products from results
@@ -183,7 +185,8 @@ def test_enabled_extended_product_search(data_provider):
     data_provider.mark_for_cleanup(scan)
     scanjob = ScanJob(scan_id=scan._id)
     scanjob.create()
-    wait_until_state(scanjob, state="stopped")
+    wait_until_state(scanjob, state="running", timeout=120)
+    wait_until_state(scanjob, state="stopped", timeout=900)
 
     errors_found = []
     # grab extended products from config file

--- a/camayoc/tests/qpc/cli/test_openshift.py
+++ b/camayoc/tests/qpc/cli/test_openshift.py
@@ -118,7 +118,8 @@ def test_openshift_clusters(cluster, qpc_server_config):
     match_scan_id = re.match(r'Scan "(\d+)" started.', output)
     assert match_scan_id is not None
     scan_job_id = match_scan_id.group(1)
-    wait_for_scan(scan_job_id, timeout=1200)
+    wait_for_scan(scan_job_id, status="running", timeout=120)
+    wait_for_scan(scan_job_id, status="completed", timeout=1200)
     result = scan_job({"id": scan_job_id})
     assert result["status"] == "completed"
     details, deployments = retrieve_report(scan_name, scan_job_id)

--- a/camayoc/tests/qpc/cli/test_reports.py
+++ b/camayoc/tests/qpc/cli/test_reports.py
@@ -313,7 +313,8 @@ def setup_reports_prerequisites(data_provider):
         assert match is not None, result
         scan_job_id = match.group(1)
         scan["scan-job"] = scan_job_id
-        wait_for_scan(scan_job_id)
+        wait_for_scan(scan_job_id, status="running", timeout=120)
+        wait_for_scan(scan_job_id, status="completed")
         result = scan_job({"id": scan_job_id})
         assert result["status"] == "completed"
         report_id = result["report_id"]

--- a/camayoc/tests/qpc/cli/test_scanjobs.py
+++ b/camayoc/tests/qpc/cli/test_scanjobs.py
@@ -61,7 +61,8 @@ def test_scanjob(qpc_server_config, data_provider):
     match = re.match(r'Scan "(\d+)" started.', result)
     assert match is not None
     scan_job_id = match.group(1)
-    wait_for_scan(scan_job_id, timeout=1800)
+    wait_for_scan(scan_job_id, status="running", timeout=120)
+    wait_for_scan(scan_job_id, status="completed", timeout=1800)
     result = scan_job({"id": scan_job_id})
     assert result["status"] == "completed"
     report_id = result["report_id"]
@@ -107,7 +108,8 @@ def test_scanjob_with_multiple_sources(qpc_server_config, data_provider):
     match = re.match(r'Scan "(\d+)" started.', result)
     assert match is not None
     scan_job_id = match.group(1)
-    wait_for_scan(scan_job_id, timeout=1200)
+    wait_for_scan(scan_job_id, status="running", timeout=120)
+    wait_for_scan(scan_job_id, status="completed", timeout=1200)
     result = scan_job({"id": scan_job_id})
     assert result["status"] == "completed"
     report_id = result["report_id"]
@@ -153,7 +155,8 @@ def test_scanjob_with_disabled_products(isolated_filesystem, qpc_server_config, 
     match = re.match(r'Scan "(\d+)" started.', result)
     assert match is not None
     scan_job_id = match.group(1)
-    wait_for_scan(scan_job_id, timeout=1200)
+    wait_for_scan(scan_job_id, status="running", timeout=120)
+    wait_for_scan(scan_job_id, status="completed", timeout=1200)
     result = scan_job({"id": scan_job_id})
     assert result["status"] == "completed"
     report_id = result["report_id"]
@@ -211,7 +214,8 @@ def test_scanjob_with_enabled_extended_products(qpc_server_config, data_provider
     match = re.match(r'Scan "(\d+)" started.', result)
     assert match is not None
     scan_job_id = match.group(1)
-    wait_for_scan(scan_job_id, timeout=1200)
+    wait_for_scan(scan_job_id, status="running", timeout=120)
+    wait_for_scan(scan_job_id, status="completed", timeout=1200)
     result = scan_job({"id": scan_job_id})
     assert result["status"] == "completed"
     report_id = result["report_id"]


### PR DESCRIPTION
There are 2 commits:

First, refactor `wait_until_state` API helper. `WaitTimeError` would never be raised, because it was hidden behind conflicting conditions. While I was at it, I made it a little easier to understand.

Second, consistently check that scan is running before checking if it finished. Scans take a long time to complete, and when Quipucords background job manager hangs, we wait a long time before failing a test. Assuming that scan must be running before it can finish, and that it takes longer than few seconds to complete a scan, consistently check scan for running status (with small timeout) before checking completed status (with long timeout).

We can't do anything about Quipucords hanging, but at least we can give up earlier.

In Ibutsu, I occasionally see that `camayoc/tests/qpc/cli/test_scanjobs.py::test_scanjob_cancel` fails - it waits for job to start, but it is already completed. So this idea might not be so great after all. That's why I want to keep it in separate commit - so we can easily revert.

```
$ pytest -ra -v camayoc/tests/qpc/api/v1/reports/test_reports.py camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py camayoc/tests/qpc/api/v1/utils.py camayoc/tests/qpc/cli/test_reports.py camayoc/tests/qpc/cli/test_scanjobs.py
camayoc/tests/qpc/cli/test_scanjobs.py::test_scanjob_cancel_paused SKIPPED (Skipping until Quipucords Issue #2040 resoloved)                                           [  2%]
camayoc/tests/qpc/api/v1/reports/test_reports.py::test_report_content_consistency PASSED                                                                               [  5%]
camayoc/tests/qpc/api/v1/reports/test_reports.py::test_merge_reports_from_scanjob PASSED                                                                               [  8%]
camayoc/tests/qpc/api/v1/reports/test_reports.py::test_merge_reports_negative PASSED                                                                                   [ 10%]
camayoc/tests/qpc/api/v1/reports/test_reports.py::test_products_found_deployment_report[testlab] SKIPPED (Skipped until Middleware are handled by Camayoc)             [ 13%]
camayoc/tests/qpc/api/v1/reports/test_reports.py::test_products_found_deployment_report[VCenterOnly] SKIPPED (Skipped until Middleware are handled by Camayoc)         [ 16%]
camayoc/tests/qpc/api/v1/reports/test_reports.py::test_products_found_deployment_report[Sat6] SKIPPED (Skipped until Middleware are handled by Camayoc)                [ 18%]
camayoc/tests/qpc/api/v1/reports/test_reports.py::test_OS_found_deployment_report[testlab] PASSED                                                                      [ 21%]
camayoc/tests/qpc/api/v1/reports/test_reports.py::test_OS_found_deployment_report[VCenterOnly] PASSED                                                                  [ 24%]
camayoc/tests/qpc/api/v1/reports/test_reports.py::test_OS_found_deployment_report[Sat6] PASSED                                                                         [ 27%]
camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py::test_scan_complete[testlab] SKIPPED (Test is flaky. Skipping until Quipucords Issue #2040 resoloved)           [ 29%]
camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py::test_scan_complete[VCenterOnly] SKIPPED (Test is flaky. Skipping until Quipucords Issue #2040 resoloved)       [ 32%]
camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py::test_scan_complete[Sat6] SKIPPED (Test is flaky. Skipping until Quipucords Issue #2040 resoloved)              [ 35%]
camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py::test_scan_task_results[testlab] PASSED                                                                         [ 37%]
camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py::test_scan_task_results[VCenterOnly] PASSED                                                                     [ 40%]
camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py::test_scan_task_results[Sat6] PASSED                                                                            [ 43%]
camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py::test_disabled_optional_products PASSED                                                                         [ 45%]
camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py::test_enabled_extended_product_search PASSED                                                                    [ 48%]
camayoc/tests/qpc/cli/test_reports.py::test_deployments_report[csv-report] PASSED                                                                                      [ 51%]
camayoc/tests/qpc/cli/test_reports.py::test_deployments_report[csv-scan-job] PASSED                                                                                    [ 54%]
camayoc/tests/qpc/cli/test_reports.py::test_deployments_report[json-report] PASSED                                                                                     [ 56%]
camayoc/tests/qpc/cli/test_reports.py::test_deployments_report[json-scan-job] PASSED                                                                                   [ 59%]
camayoc/tests/qpc/cli/test_reports.py::test_detail_report[csv-report] PASSED                                                                                           [ 62%]
camayoc/tests/qpc/cli/test_reports.py::test_detail_report[csv-scan-job] PASSED                                                                                         [ 64%]
camayoc/tests/qpc/cli/test_reports.py::test_detail_report[json-report] PASSED                                                                                          [ 67%]
camayoc/tests/qpc/cli/test_reports.py::test_detail_report[json-scan-job] PASSED                                                                                        [ 70%]
camayoc/tests/qpc/cli/test_reports.py::test_merge_report[report] PASSED                                                                                                [ 72%]
camayoc/tests/qpc/cli/test_reports.py::test_merge_report[scan-job] PASSED                                                                                              [ 75%]
camayoc/tests/qpc/cli/test_reports.py::test_merge_report[json-file] PASSED                                                                                             [ 78%]
camayoc/tests/qpc/cli/test_reports.py::test_download_report[report] PASSED                                                                                             [ 81%]
camayoc/tests/qpc/cli/test_reports.py::test_download_report[scan-job] PASSED                                                                                           [ 83%]
camayoc/tests/qpc/cli/test_scanjobs.py::test_scanjob PASSED                                                                                                            [ 86%]
camayoc/tests/qpc/cli/test_scanjobs.py::test_scanjob_with_multiple_sources PASSED                                                                                      [ 89%]
camayoc/tests/qpc/cli/test_scanjobs.py::test_scanjob_with_disabled_products PASSED                                                                                     [ 91%]
camayoc/tests/qpc/cli/test_scanjobs.py::test_scanjob_with_enabled_extended_products PASSED                                                                             [ 94%]
camayoc/tests/qpc/cli/test_scanjobs.py::test_scanjob_restart SKIPPED (Skipping until Quipucords Issue #2040 resoloved)                                                 [ 97%]
camayoc/tests/qpc/cli/test_scanjobs.py::test_scanjob_cancel PASSED                                                                                                     [100%]
=========================================================== 29 passed, 8 skipped, 6 warnings in 1137.20s (0:18:57) ===========================================================
```