### PR TITLE
Revert "Check that scan is running before checking if it finished"

### DIFF
--- a/camayoc/tests/qpc/api/v1/reports/test_reports.py
+++ b/camayoc/tests/qpc/api/v1/reports/test_reports.py
@@ -81,8 +81,7 @@ def test_report_content_consistency(data_provider):
     scan = data_provider.scans.new_one({}, new_dependencies=False, data_only=False)
     scanjob = ScanJob(scan_id=scan._id)
     scanjob.create()
-    wait_until_state(scanjob, state="running", timeout=120)
-    wait_until_state(scanjob, state="stopped", timeout=900)
+    wait_until_state(scanjob, state="stopped")
     report = Report()
     response = report.retrieve_from_scan_job(scanjob._id)
     if response.json().get("report_id") is None:
@@ -152,9 +151,8 @@ def test_merge_reports_from_scanjob(data_provider):
     scanjob1.create()
     scanjob2 = ScanJob(scan_id=scan2._id)
     scanjob2.create()
-    wait_until_state(scanjob1, state="running", timeout=120)
     for scanjob in (scanjob1, scanjob2):
-        wait_until_state(scanjob, state="stopped", timeout=900)
+        wait_until_state(scanjob, state="stopped")
 
     report = Report()
     report1_json = Report().retrieve_from_scan_job(scanjob1._id).json()
@@ -259,8 +257,7 @@ def test_products_found_deployment_report(data_provider, scan_info):
     scan = data_provider.scans.defined_one({"name": scan_info.get("name")})
     scanjob = ScanJob(scan_id=scan._id)
     scanjob.create()
-    wait_until_state(scanjob, state="running", timeout=120)
-    wait_until_state(scanjob, state="stopped", timeout=900)
+    wait_until_state(scanjob, state="stopped")
     report = Report()
     report.retrieve_from_scan_job(scan_job_id=scanjob._id)
     result = SCAN_DATA.get(scan.name)
@@ -342,8 +339,7 @@ def test_OS_found_deployment_report(data_provider, scan_info: ScanOptions):
     scan = data_provider.scans.defined_one({"name": scan_info.name})
     scanjob = ScanJob(scan_id=scan._id)
     scanjob.create()
-    wait_until_state(scanjob, state="running", timeout=120)
-    wait_until_state(scanjob, state="stopped", timeout=900)
+    wait_until_state(scanjob, state="stopped")
     report = Report()
     report.retrieve_from_scan_job(scan_job_id=scanjob._id)
     if not report._id:

--- a/camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py
+++ b/camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py
@@ -76,8 +76,7 @@ def test_scan_task_results(data_provider, scan_info: ScanOptions):
     scan = data_provider.scans.defined_one({"name": scan_info.name})
     scanjob = ScanJob(scan_id=scan._id)
     scanjob.create()
-    wait_until_state(scanjob, state="running", timeout=120)
-    wait_until_state(scanjob, state="stopped", timeout=900)
+    wait_until_state(scanjob, state="stopped")
     assertion_error_message = "Details of failed scan : {0}".format(pformat(scanjob.read().json()))
 
     task_results = scanjob.read().json().get("tasks")
@@ -132,8 +131,7 @@ def test_disabled_optional_products(data_provider):
     data_provider.mark_for_cleanup(scan)
     scanjob = ScanJob(scan_id=scan._id)
     scanjob.create()
-    wait_until_state(scanjob, state="running", timeout=120)
-    wait_until_state(scanjob, state="stopped", timeout=900)
+    wait_until_state(scanjob, state="stopped")
 
     errors_found = []
     # grab disabled products from results
@@ -185,8 +183,7 @@ def test_enabled_extended_product_search(data_provider):
     data_provider.mark_for_cleanup(scan)
     scanjob = ScanJob(scan_id=scan._id)
     scanjob.create()
-    wait_until_state(scanjob, state="running", timeout=120)
-    wait_until_state(scanjob, state="stopped", timeout=900)
+    wait_until_state(scanjob, state="stopped")
 
     errors_found = []
     # grab extended products from config file

--- a/camayoc/tests/qpc/cli/test_openshift.py
+++ b/camayoc/tests/qpc/cli/test_openshift.py
@@ -118,8 +118,7 @@ def test_openshift_clusters(cluster, qpc_server_config):
     match_scan_id = re.match(r'Scan "(\d+)" started.', output)
     assert match_scan_id is not None
     scan_job_id = match_scan_id.group(1)
-    wait_for_scan(scan_job_id, status="running", timeout=120)
-    wait_for_scan(scan_job_id, status="completed", timeout=1200)
+    wait_for_scan(scan_job_id, timeout=1200)
     result = scan_job({"id": scan_job_id})
     assert result["status"] == "completed"
     details, deployments = retrieve_report(scan_name, scan_job_id)

--- a/camayoc/tests/qpc/cli/test_reports.py
+++ b/camayoc/tests/qpc/cli/test_reports.py
@@ -313,8 +313,7 @@ def setup_reports_prerequisites(data_provider):
         assert match is not None, result
         scan_job_id = match.group(1)
         scan["scan-job"] = scan_job_id
-        wait_for_scan(scan_job_id, status="running", timeout=120)
-        wait_for_scan(scan_job_id, status="completed")
+        wait_for_scan(scan_job_id)
         result = scan_job({"id": scan_job_id})
         assert result["status"] == "completed"
         report_id = result["report_id"]

--- a/camayoc/tests/qpc/cli/test_scanjobs.py
+++ b/camayoc/tests/qpc/cli/test_scanjobs.py
@@ -61,8 +61,7 @@ def test_scanjob(qpc_server_config, data_provider):
     match = re.match(r'Scan "(\d+)" started.', result)
     assert match is not None
     scan_job_id = match.group(1)
-    wait_for_scan(scan_job_id, status="running", timeout=120)
-    wait_for_scan(scan_job_id, status="completed", timeout=1800)
+    wait_for_scan(scan_job_id, timeout=1800)
     result = scan_job({"id": scan_job_id})
     assert result["status"] == "completed"
     report_id = result["report_id"]
@@ -108,8 +107,7 @@ def test_scanjob_with_multiple_sources(qpc_server_config, data_provider):
     match = re.match(r'Scan "(\d+)" started.', result)
     assert match is not None
     scan_job_id = match.group(1)
-    wait_for_scan(scan_job_id, status="running", timeout=120)
-    wait_for_scan(scan_job_id, status="completed", timeout=1200)
+    wait_for_scan(scan_job_id, timeout=1200)
     result = scan_job({"id": scan_job_id})
     assert result["status"] == "completed"
     report_id = result["report_id"]
@@ -155,8 +153,7 @@ def test_scanjob_with_disabled_products(isolated_filesystem, qpc_server_config, 
     match = re.match(r'Scan "(\d+)" started.', result)
     assert match is not None
     scan_job_id = match.group(1)
-    wait_for_scan(scan_job_id, status="running", timeout=120)
-    wait_for_scan(scan_job_id, status="completed", timeout=1200)
+    wait_for_scan(scan_job_id, timeout=1200)
     result = scan_job({"id": scan_job_id})
     assert result["status"] == "completed"
     report_id = result["report_id"]
@@ -214,8 +211,7 @@ def test_scanjob_with_enabled_extended_products(qpc_server_config, data_provider
     match = re.match(r'Scan "(\d+)" started.', result)
     assert match is not None
     scan_job_id = match.group(1)
-    wait_for_scan(scan_job_id, status="running", timeout=120)
-    wait_for_scan(scan_job_id, status="completed", timeout=1200)
+    wait_for_scan(scan_job_id, timeout=1200)
     result = scan_job({"id": scan_job_id})
     assert result["status"] == "completed"
     report_id = result["report_id"]


### PR DESCRIPTION
This reverts commit 527a7d549be93e4ed751c0d61ebb0a6eebdb72c2, which was a part of PR #432 .

The risk I saw turned out to be true - since this commit was merged, all pipeline runs have one or two failed tests. Earlier we had failures only once in couple of runs. 

From what I see, usually the problem is that we expect scan to be running, but it is already completed. It doesn't sound right - looks like scans complete in just few seconds. I find it more likely that we check wrong scan, before it even started.

But either way, we need to go back to drawing board and think about this problem a little more. I'll create a jira ticket, as this turns out to require more time.