### PR TITLE
Draft: Skip some of credentials and sources tests if sshkeyfile is missing in configuration

### DIFF
--- a/camayoc/constants.py
+++ b/camayoc/constants.py
@@ -88,3 +88,8 @@ QPC_BECOME_METHODS = ("doas", "dzdo", "ksu", "pbrun", "pfexec", "runas", "su", "
 
 QPC_OPTIONAL_PRODUCTS = ("jboss_brms", "jboss_eap", "jboss_fuse", "jboss_ws")
 """Optional products that can be enabled or disabled for a scan."""
+
+SKIP_ADD_CRED_WITH_SSHKEYFILE_IN_CONFIG = (
+    "Make sure you have at least one network credential with sshkeyfile "
+    "on the config file to run this test."
+)

--- a/camayoc/tests/qpc/api/v1/credentials/test_network_creds.py
+++ b/camayoc/tests/qpc/api/v1/credentials/test_network_creds.py
@@ -13,6 +13,8 @@ from littletable import Table
 
 from camayoc import api
 from camayoc.constants import QPC_BECOME_METHODS
+from camayoc.constants import SKIP_ADD_CRED_WITH_SSHKEYFILE_IN_CONFIG
+from camayoc.exceptions import NoMatchingDataDefinitionException
 from camayoc.qpc_models import Credential
 from camayoc.tests.qpc.utils import assert_matches_server
 from camayoc.utils import uuid4
@@ -35,10 +37,13 @@ def test_update_password_to_sshkeyfile(shared_client, data_provider):
     cred.create()
     data_provider.mark_for_cleanup(cred)
     assert_matches_server(cred)
-    sshkeyfile_cred = data_provider.credentials.new_one(
-        {"type": "network", "sshkeyfile": Table.is_not_null()},
-        data_only=True,
-    )
+    try:
+        sshkeyfile_cred = data_provider.credentials.new_one(
+            {"type": "network", "sshkeyfile": Table.is_not_null()},
+            data_only=True,
+        )
+    except NoMatchingDataDefinitionException:
+        pytest.skip(SKIP_ADD_CRED_WITH_SSHKEYFILE_IN_CONFIG)
 
     cred.ssh_keyfile = sshkeyfile_cred.ssh_keyfile
     cred.password = None
@@ -60,10 +65,13 @@ def test_update_sshkey_to_password(data_provider):
         3) Confirm network credential has been updated.
     :expectedresults: The network credential is updated.
     """
-    cred = data_provider.credentials.new_one(
-        {"type": "network", "sshkeyfile": Table.is_not_null()},
-        data_only=False,
-    )
+    try:
+        cred = data_provider.credentials.new_one(
+            {"type": "network", "sshkeyfile": Table.is_not_null()},
+            data_only=False,
+        )
+    except NoMatchingDataDefinitionException:
+        pytest.skip(SKIP_ADD_CRED_WITH_SSHKEYFILE_IN_CONFIG)
     assert_matches_server(cred)
     cred.client.response_handler = api.echo_handler
     cred.password = uuid4()
@@ -86,10 +94,13 @@ def test_negative_update_to_invalid(data_provider):
     :expectedresults: Error codes are returned and the network credentials are
         not updated.
     """
-    cred = data_provider.credentials.new_one(
-        {"type": "network", "sshkeyfile": Table.is_not_null()},
-        data_only=False,
-    )
+    try:
+        cred = data_provider.credentials.new_one(
+            {"type": "network", "sshkeyfile": Table.is_not_null()},
+            data_only=False,
+        )
+    except NoMatchingDataDefinitionException:
+        pytest.skip(SKIP_ADD_CRED_WITH_SSHKEYFILE_IN_CONFIG)
     assert_matches_server(cred)
 
     cred.client = api.Client(api.echo_handler)
@@ -124,10 +135,13 @@ def test_create_with_sshkey(data_provider):
     :steps: Send POST with necessary data to documented api endpoint.
     :expectedresults: A new network credential entry is created with the data.
     """
-    cred = data_provider.credentials.new_one(
-        {"type": "network", "sshkeyfile": Table.is_not_null()},
-        data_only=False,
-    )
+    try:
+        cred = data_provider.credentials.new_one(
+            {"type": "network", "sshkeyfile": Table.is_not_null()},
+            data_only=False,
+        )
+    except NoMatchingDataDefinitionException:
+        pytest.skip(SKIP_ADD_CRED_WITH_SSHKEYFILE_IN_CONFIG)
     assert_matches_server(cred)
 
 
@@ -142,10 +156,13 @@ def test_negative_create_key_and_pass(data_provider):
     :steps: Send POST with necessary data to the credential api endpoint.
     :expectedresults: Error is thrown and no new network credential is created.
     """
-    sshkeyfile_cred = data_provider.credentials.new_one(
-        {"type": "network", "sshkeyfile": Table.is_not_null()},
-        data_only=True,
-    )
+    try:
+        sshkeyfile_cred = data_provider.credentials.new_one(
+            {"type": "network", "sshkeyfile": Table.is_not_null()},
+            data_only=True,
+        )
+    except NoMatchingDataDefinitionException:
+        pytest.skip(SKIP_ADD_CRED_WITH_SSHKEYFILE_IN_CONFIG)
 
     client = api.Client(api.echo_handler)
     cred = Credential(

--- a/camayoc/tests/qpc/api/v1/sources/test_network_sources.py
+++ b/camayoc/tests/qpc/api/v1/sources/test_network_sources.py
@@ -13,6 +13,8 @@ import pytest
 from littletable import Table
 
 from camayoc import api
+from camayoc.constants import SKIP_ADD_CRED_WITH_SSHKEYFILE_IN_CONFIG
+from camayoc.exceptions import NoMatchingDataDefinitionException
 from camayoc.qpc_models import Credential
 from camayoc.qpc_models import Source
 from camayoc.tests.qpc.utils import assert_matches_server
@@ -68,10 +70,13 @@ def test_create_multiple_creds(shared_client, data_provider, scan_host):
         2) Send POST with data to create network source using the credentials
     :expectedresults: The source is created.
     """
-    ssh_key_cred = data_provider.credentials.new_one(
-        {"type": NETWORK_TYPE, "sshkeyfile": Table.is_not_null()},
-        data_only=False,
-    )
+    try:
+        ssh_key_cred = data_provider.credentials.new_one(
+            {"type": NETWORK_TYPE, "sshkeyfile": Table.is_not_null()},
+            data_only=False,
+        )
+    except NoMatchingDataDefinitionException:
+        pytest.skip(SKIP_ADD_CRED_WITH_SSHKEYFILE_IN_CONFIG)
     pwd_cred = Credential(cred_type=NETWORK_TYPE, client=shared_client, password=uuid4())
     pwd_cred.create()
 
@@ -101,10 +106,13 @@ def test_create_multiple_creds_and_sources(shared_client, data_provider, scan_ho
            CIDR, individual IPv4 address, etc.)
     :expectedresults: The source is created.
     """
-    ssh_key_cred = data_provider.credentials.new_one(
-        {"type": NETWORK_TYPE, "sshkeyfile": Table.is_not_null()},
-        data_only=False,
-    )
+    try:
+        ssh_key_cred = data_provider.credentials.new_one(
+            {"type": NETWORK_TYPE, "sshkeyfile": Table.is_not_null()},
+            data_only=False,
+        )
+    except NoMatchingDataDefinitionException:
+        pytest.skip(SKIP_ADD_CRED_WITH_SSHKEYFILE_IN_CONFIG)
     pwd_cred = Credential(cred_type=NETWORK_TYPE, client=shared_client, password=uuid4())
     pwd_cred.create()
 

--- a/camayoc/tests/qpc/cli/test_credentials.py
+++ b/camayoc/tests/qpc/cli/test_credentials.py
@@ -19,6 +19,8 @@ from camayoc import utils
 from camayoc.constants import BECOME_PASSWORD_INPUT
 from camayoc.constants import CONNECTION_PASSWORD_INPUT
 from camayoc.constants import MASKED_PASSWORD_OUTPUT
+from camayoc.constants import SKIP_ADD_CRED_WITH_SSHKEYFILE_IN_CONFIG
+from camayoc.exceptions import NoMatchingDataDefinitionException
 from camayoc.tests.qpc.cli.utils import cred_add_and_check
 from camayoc.tests.qpc.cli.utils import cred_show_and_check
 from camayoc.tests.qpc.cli.utils import source_add_and_check
@@ -125,10 +127,13 @@ def test_add_with_username_sshkeyfile(data_provider, qpc_server_config):
     """
     name = utils.uuid4()
     username = utils.uuid4()
-    sshkeyfile_cred = data_provider.credentials.new_one(
-        {"type": "network", "sshkeyfile": Table.is_not_null()},
-        data_only=True,
-    )
+    try:
+        sshkeyfile_cred = data_provider.credentials.new_one(
+            {"type": "network", "sshkeyfile": Table.is_not_null()},
+            data_only=True,
+        )
+    except NoMatchingDataDefinitionException:
+        pytest.skip(SKIP_ADD_CRED_WITH_SSHKEYFILE_IN_CONFIG)
 
     cred_add_and_check(
         {"name": name, "username": username, "sshkeyfile": sshkeyfile_cred.ssh_keyfile}
@@ -160,10 +165,13 @@ def test_add_with_username_sshkeyfile_become_password(data_provider, qpc_server_
     """
     name = utils.uuid4()
     username = utils.uuid4()
-    sshkeyfile_cred = data_provider.credentials.new_one(
-        {"type": "network", "sshkeyfile": Table.is_not_null()},
-        data_only=True,
-    )
+    try:
+        sshkeyfile_cred = data_provider.credentials.new_one(
+            {"type": "network", "sshkeyfile": Table.is_not_null()},
+            data_only=True,
+        )
+    except NoMatchingDataDefinitionException:
+        pytest.skip(SKIP_ADD_CRED_WITH_SSHKEYFILE_IN_CONFIG)
 
     cred_add_and_check(
         {
@@ -355,10 +363,13 @@ def test_edit_sshkeyfile_negative(data_provider, qpc_server_config):
     """
     name = utils.uuid4()
     username = utils.uuid4()
-    sshkeyfile_cred = data_provider.credentials.new_one(
-        {"type": "network", "sshkeyfile": Table.is_not_null()},
-        data_only=True,
-    )
+    try:
+        sshkeyfile_cred = data_provider.credentials.new_one(
+            {"type": "network", "sshkeyfile": Table.is_not_null()},
+            data_only=True,
+        )
+    except NoMatchingDataDefinitionException:
+        pytest.skip(SKIP_ADD_CRED_WITH_SSHKEYFILE_IN_CONFIG)
     cred_add_and_check(
         {"name": name, "username": username, "sshkeyfile": sshkeyfile_cred.ssh_keyfile}
     )


### PR DESCRIPTION
I was working with a minimal configuration file for Camayoc and notice that if the sshkeyfile in any credential configuration is missing, then some of the tests will fail with a misleading message.

I'm creating this PR to skip some of credentials and sources tests if sshkeyfile is missing in configuration.

Example.

Before:

```
FAILED camayoc/tests/qpc/cli/test_credentials.py::test_add_with_username_sshkeyfile - camayoc.exceptions.NoMatchingDataDefinitionException: No data matching provided criteria. Try changing 'match_criteria' or revi...
FAILED camayoc/tests/qpc/cli/test_credentials.py::test_add_with_username_sshkeyfile_become_password - camayoc.exceptions.NoMatchingDataDefinitionException: No data matching provided criteria. Try changing 'match_criteria' or revi...
FAILED camayoc/tests/qpc/cli/test_credentials.py::test_edit_sshkeyfile_negative - camayoc.exceptions.NoMatchingDataDefinitionException: No data matching provided criteria. Try changing 'match_criteria' or revi... ...
```

After:

```
SKIPPED [1] camayoc/tests/qpc/cli/test_credentials.py:140: Make sure you have at least one network credential with sshkeyfile on the config file to run this test. 
SKIPPED [1] camayoc/tests/qpc/cli/test_credentials.py:178: Make sure you have at least one network credential with sshkeyfile on the config file to run this test. 
SKIPPED [1] camayoc/tests/qpc/cli/test_credentials.py:376: Make sure you have at least one network credential with sshkeyfile on the config file to run this test. ...
SKIPPED [3] camayoc/tests/qpc/api/v1/sources/test_network_sources.py:79: Make sure you have at least one network credential with sshkeyfile on the config file to run this test. 
SKIPPED [4] camayoc/tests/qpc/api/v1/sources/test_network_sources.py:115: Make sure you have at least one network credential with sshkeyfile on the config file to run this test.
```