### PR TITLE
Draft: test_openshift: add coverage to ACM operator

### DIFF
--- a/camayoc/tests/qpc/cli/test_openshift.py
+++ b/camayoc/tests/qpc/cli/test_openshift.py
@@ -77,6 +77,13 @@ def validate_openshift_report(cluster, details, deployments):
     assert set(cluster_nodes) == set(seen_nodes), "The number of expected nodes diverged"
 
 
+def validate_operators(cluster, details):
+    expected_operators = cluster["operators"]
+    detected_operators = [op["name"] for op in details["sources"][0]["facts"][-1]["operators"]]
+    for operator in expected_operators:
+        assert operator in detected_operators, f"The operator '{operator}' was not detected."
+
+
 def validate_openshift_with_acm(cluster, details):
     EXPECTED_METRICS_KEYS = (
         "vendor",
@@ -148,5 +155,6 @@ def test_openshift_clusters(cluster, qpc_server_config):
     assert result["status"] == "completed"
     details, deployments = retrieve_report(scan_name, scan_job_id)
     validate_openshift_report(cluster, details, deployments)
+    validate_operators(cluster, details)
     if has_acm:
         validate_openshift_with_acm(cluster, details)

--- a/camayoc/types/settings.py
+++ b/camayoc/types/settings.py
@@ -35,6 +35,7 @@ class OpenShiftOptions(BaseModel):
     cluster_id: str
     version: str
     nodes: list[str]
+    operators: list[str]
 
 
 class VCenterOptions(BaseModel):

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -41,6 +41,9 @@ openshift:
           - 'worker-1.example.com'
           - 'worker-2.example.com'
           - 'worker-3.example.com'
+      operators:
+          - 'abc-operator'
+          - 'xyz-operator'
 
 # We host most of our test machines on a VCenter instance
 # and this section contains its URL and the credentials


### PR DESCRIPTION
If we have the ACM operator installed, then perform validations against their metrics collected.

Relates to JIRA: DISCOVERY-349
https://issues.redhat.com/browse/DISCOVERY-349