### PR TITLE
Update OpenShift test to support operators, ACM and node-metrics

### DIFF
--- a/camayoc/tests/qpc/cli/test_openshift.py
+++ b/camayoc/tests/qpc/cli/test_openshift.py
@@ -49,19 +49,19 @@ def validate_openshift_report(cluster, details, deployments):
     cluster_nodes = cluster["nodes"]
     total_clusters = 0
     seen_nodes = []
-    facts = details["sources"][0]["facts"]
-    for fact in facts:
-        if "node" in fact:
-            assert fact["node"]["kind"] == "node"
-            seen_nodes.append(fact["node"]["name"])
-        if "cluster" in fact:
-            assert fact["cluster"]["uuid"] == cluster_id
-            assert fact["cluster"]["version"] == cluster_version
-            total_clusters += 1
-        if "projects" in fact:
-            assert len(fact["projects"]) > 0
-        if "workloads" in fact:
-            assert len(fact["workloads"]) > 0
+    for source in details["sources"]:
+        for fact in source["facts"]:
+            if "node" in fact:
+                assert fact["node"]["kind"] == "node"
+                seen_nodes.append(fact["node"]["name"])
+            if "cluster" in fact:
+                assert fact["cluster"]["uuid"] == cluster_id
+                assert fact["cluster"]["version"] == cluster_version
+                total_clusters += 1
+            if "projects" in fact:
+                assert len(fact["projects"]) > 0
+            if "workloads" in fact:
+                assert len(fact["workloads"]) > 0
     assert total_clusters == 1, "Only one system fact should have a 'cluster' key"
     assert set(cluster_nodes) == set(seen_nodes), "The number of expected nodes diverged"
     #
@@ -75,6 +75,64 @@ def validate_openshift_report(cluster, details, deployments):
         assert fact["architecture"] in ("x86_64",)
         seen_nodes.append(fact["name"])
     assert set(cluster_nodes) == set(seen_nodes), "The number of expected nodes diverged"
+
+
+def validate_node_metrics(cluster, details):
+    has_node_metrics = False
+    for source in details["sources"]:
+        for fact in source["facts"]:
+            if "node_metrics" in fact:
+                has_node_metrics = True
+                for metric in fact["node_metrics"]:
+                    package = int(metric["package"])
+                    assert package >= 0
+                    assert metric["label_node_hyperthread_enabled"] in ("true", "false")
+    assert has_node_metrics, "Could not found any node metrics."
+
+
+def validate_operators(cluster, details):
+    has_operators = False
+    expected_operators = cluster["operators"]
+    for source in details["sources"]:
+        for fact in source["facts"]:
+            if "operators" in fact:
+                has_operators = True
+                detected_operators = [operator["name"] for operator in fact["operators"]]
+                for operator in expected_operators:
+                    assert (
+                        operator in detected_operators
+                    ), f"The operator '{operator}' was not detected."
+    assert has_operators, "Could not found any operators."
+
+
+def validate_openshift_with_acm(cluster, details):
+    EXPECTED_METRIC_KEYS = (
+        "vendor",
+        "cloud",
+        "version",
+        "managed_cluster_id",
+        "available",
+        "core_worker",
+        "socket_worker",
+        "created_via",
+    )
+    cluster_id = cluster["cluster_id"]
+    for source in details["sources"]:
+        for fact in source["facts"]:
+            if "acm_metrics" in fact:
+                acm_metrics = fact["acm_metrics"]
+                assert (
+                    len(acm_metrics) > 0
+                ), "Cluster has ACM and no metrics were detected (expected at least one)."
+                managed_clusters = [metric["managed_cluster_id"] for metric in acm_metrics]
+                assert (
+                    cluster_id in managed_clusters
+                ), f"Cluster has ACM and its cluster-id 'f{cluster_id}' is not in metrics."
+                for metric in acm_metrics:
+                    assert set(EXPECTED_METRIC_KEYS) == set(list(metric))
+                    assert metric["available"] in (True, False)
+                    assert int(metric["core_worker"]) >= 0
+                    assert int(metric["socket_worker"]) >= 0
 
 
 @pytest.mark.parametrize(
@@ -102,6 +160,7 @@ def test_openshift_clusters(cluster, qpc_server_config):
     hostname = cluster["hostname"]
     port = cluster.get("port", 6443)
     ssl_cert_verify = not cluster["skip_tls_verify"]
+    is_acm_hub = "advanced-cluster-management" in cluster.get("operators", [])
     source_add_and_check(
         {
             "name": source_name,
@@ -123,3 +182,7 @@ def test_openshift_clusters(cluster, qpc_server_config):
     assert result["status"] == "completed"
     details, deployments = retrieve_report(scan_name, scan_job_id)
     validate_openshift_report(cluster, details, deployments)
+    validate_operators(cluster, details)
+    validate_node_metrics(cluster, details)
+    if is_acm_hub:
+        validate_openshift_with_acm(cluster, details)

--- a/camayoc/types/settings.py
+++ b/camayoc/types/settings.py
@@ -35,6 +35,7 @@ class OpenShiftOptions(BaseModel):
     cluster_id: str
     version: str
     nodes: list[str]
+    operators: list[str]
 
 
 class VCenterOptions(BaseModel):

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -41,6 +41,9 @@ openshift:
           - 'worker-1.example.com'
           - 'worker-2.example.com'
           - 'worker-3.example.com'
+      operators:
+          - 'abc-operator'
+          - 'xyz-operator'
 
 # We host most of our test machines on a VCenter instance
 # and this section contains its URL and the credentials


### PR DESCRIPTION
Extend coverage in the OpenShift tests to verify the following features:
* Check if some expected operators (listed in the configuration) were detected in report.
* Check if the node-metrics are sane at some level.
* Verify ACM metrics regarding a cluster hub with at least two cluster.

Test execution: `pytest -v -ra camayoc/tests/qpc/cli/test_openshift.py`

Sample configuration.

```yaml
---
openshift:
  - hostname: api.ocp413acm.abc.example.com
    port: 6443
    token: 'sha256~...'
    skip_tls_verify: true
    cluster_id: 'YYYYYYYY-YYYY-YYYY-YYYY-YYYYYYYYYYYY'
    version: '4.13.4'
    nodes:
      - 'master-0.ocp413acm.abc.example.com'
      - 'master-1.ocp413acm.abc.example.com'
      - 'master-2.ocp413acm.abc.example.com'
      - 'worker-0.ocp413acm.abc.example.com'
      - 'worker-1.ocp413acm.abc.example.com'
      - 'worker-2.ocp413acm.abc.example.com'
    operators:
      - 'multicluster-engine'
      - 'advanced-cluster-management'
  - hostname: api.ocp412tiny.xyz.example.com
    port: 6443
    token: 'sha256~...'
    skip_tls_verify: true
    cluster_id: 'XXXXXXXX-XXXX-XXXX-XXXXXXXXXXXXXXXXX'
    version: '4.12.25'
    nodes:
      - 'master-0.ocp412tiny.xyz.example.com'
      - 'master-1.ocp412tiny.xyz.example.com'
      - 'master-2.ocp412tiny.xyz.example.com'
    operators:
      - 'console'
      - 'dns'
      - 'network'
...

```

Relates to JIRA: DISCOVERY-348 DISCOVERY-349
https://issues.redhat.com/browse/DISCOVERY-348
https://issues.redhat.com/browse/DISCOVERY-349
