### PR TITLE
Stabilize test_scanjob_cancel

### DIFF
--- a/camayoc/tests/qpc/cli/test_scanjobs.py
+++ b/camayoc/tests/qpc/cli/test_scanjobs.py
@@ -12,6 +12,7 @@ import random
 import re
 
 import pytest
+from littletable import Table
 
 from camayoc.constants import QPC_OPTIONAL_PRODUCTS
 from camayoc.exceptions import NoMatchingDataDefinitionException
@@ -284,7 +285,12 @@ def test_scanjob_cancel(qpc_server_config, data_provider):
         3) Try to restart the scan by running ``qpc scan restart --id <id>``
     :expectedresults: The scan must be canceled and can't not be restarted.
     """
-    source = data_provider.sources.new_one({}, data_only=False)
+    # There's nothing fundamentally wrong with Ansible. In our environment,
+    # it finishes too quick, largely increasing a risk of test failing
+    # because job finished before we checked if it started.
+    source = data_provider.sources.new_one(
+        {"type": Table.not_in(("ansible", "openshift"))}, data_only=False
+    )
     scan_name = uuid4()
     scan_add_and_check({"name": scan_name, "sources": source.name})
     data_provider.mark_for_cleanup(Scan(name=scan_name))


### PR DESCRIPTION
This test fails every few runs.

Sometimes it fails because job never starts - this is a known problem with thread-based scan manager, and we can't do anything about this.

Sometimes it fails because we want scanjob to be running, but it completed already. This seems to only happen for Ansible source. There's nothing wrong with Ansible itself, but it seems that Ansible in our environment is relatively small and tends to finish too quick. For now let's ignore it as a source for this test.

I tried running this test 20 times with and without a patch locally. Without a patch, I got one failure that was the same as what we observe on Jenkins. With a patch, it never failed.