### PR TITLE
Bring 'test_products_found_deployment_report' back to execution

### DIFF
--- a/camayoc/tests/qpc/api/v1/conftest.py
+++ b/camayoc/tests/qpc/api/v1/conftest.py
@@ -87,10 +87,16 @@ def run_scan(
         SCAN_DATA[scan_name]["errors"].append("{}".format(pformat(str(e))))
 
 
-def scan_list():
-    """Generate list of netwok / VCenter / Satellite scan objects found in config file."""
+def scan_list(source_types=None):
+    """Generate list of network / VCenter / Satellite scan objects found in config file.
+
+    Optionally filter by a custom iterable of source types (network, vcenter, satellite).
+    """
     scans = []
-    supported_source_types = ("network", "vcenter", "satellite")
+    if source_types is None:
+        supported_source_types = ("network", "vcenter", "satellite")
+    else:
+        supported_source_types = source_types
     source_names_types = {s.name: s.type for s in settings.sources}
     for scan in settings.scans:
         source_types = [source_names_types.get(source) for source in scan.sources]

--- a/camayoc/tests/qpc/api/v1/reports/test_reports.py
+++ b/camayoc/tests/qpc/api/v1/reports/test_reports.py
@@ -100,7 +100,7 @@ def test_report_content_consistency(data_provider):
 
 
 @pytest.mark.runs_scan
-@pytest.mark.parametrize("scan_info", scan_list(), ids=utils.name_getter)
+@pytest.mark.parametrize("scan_info", scan_list(["network"]), ids=utils.name_getter)
 def test_products_found_deployment_report(data_provider, scan_info: ScanOptions):
     """Test that products reported as present are correct for the source.
 

--- a/camayoc/types/settings.py
+++ b/camayoc/types/settings.py
@@ -121,8 +121,14 @@ class ExpectedDistributionData(BaseModel):
     release: str
 
 
+class ExpectedProductData(BaseModel):
+    name: str
+    presence: str
+
+
 class ExpectedScanData(BaseModel):
     distribution: Optional[ExpectedDistributionData]
+    products: Optional[list[ExpectedProductData]]
 
 
 class ScanOptions(BaseModel):


### PR DESCRIPTION
Bring middle-ware inspection test back to execution.

Sample output:

```
E       AssertionError: Found 1 unexpected products!                                                                                                                                                                                           
E         Errors are listed below:                                                                                                                                                                                                             
E          Found ['jbossfuse'] but only expected to find                                                                                                                                                                                       
E         ['jbosseap', 'jbosswebserver'] on discovery-mw.
...
FAILED camayoc/tests/qpc/api/v1/reports/test_reports.py::test_products_found_deployment_report[testlab-middleware] - AssertionError: Found 1 unexpected products!
```

Sample configuration:

```yaml
  - name: testlab-middleware
    sources:
      - testlab-middleware
    expected_data:
      discovery-mw:
        distribution:
          release: "Red Hat Enterprise Linux release 9.2"
          name: "Red Hat Enterprise Linux"
          version: "9.2"
        products:
          - name: "JBoss EAP"
            presence: "present"
          - name: "JBoss Web Server"
            presence: "present"
          - name: "JBoss Fuse"
            presence: "absent"
          - name: "JBoss BRMS"
            presence: "absent"

```

Related to JIRA: DISCOVERY-432
https://issues.redhat.com/browse/DISCOVERY-432