### PR TITLE
Make Credentials locators not depend on items order

### DIFF
--- a/camayoc/ui/models/pages/credentials.py
+++ b/camayoc/ui/models/pages/credentials.py
@@ -117,19 +117,19 @@ class CredentialsMainPage(MainPageMixin):
         create_credential_button = "div[data-ouia-component-id=add_credential] > button"
         source_type_map = {
             CredentialTypes.NETWORK: {
-                "selector": f"{create_credential_button} ~ ul li:nth-of-type(1) a",
+                "selector": f"{create_credential_button} ~ ul li a[data-value=network]",
                 "class": NetworkCredentialForm,
             },
             CredentialTypes.SATELLITE: {
-                "selector": f"{create_credential_button} ~ ul li:nth-of-type(3) a",
+                "selector": f"{create_credential_button} ~ ul li a[data-value=satellite]",
                 "class": SatelliteCredentialForm,
             },
             CredentialTypes.VCENTER: {
-                "selector": f"{create_credential_button} ~ ul li:nth-of-type(4) a",
+                "selector": f"{create_credential_button} ~ ul li a[data-value=vcenter]",
                 "class": VCenterCredentialForm,
             },
             CredentialTypes.ANSIBLE: {
-                "selector": f"{create_credential_button} ~ ul li:nth-of-type(5) a",
+                "selector": f"{create_credential_button} ~ ul li a[data-value=ansible]",
                 "class": AnsibleCredentialForm,
             },
         }


### PR DESCRIPTION
Change Credentials UI locators so they don't depend on items order.

This is in response to https://github.com/quipucords/quipucords-ui/pull/251 , which would cause some UI tests to fail, as it adds new Credential type in the middle of the list. But this PR can be merged already, as it is compatible with current UI code we ship.

```
$ pytest -ra camayoc/tests/qpc/ui/ --tracing retain-on-failure --browser chromium -s -v
camayoc/tests/qpc/ui/test_endtoend.py::test_trigger_scan[chromium-ansible-testlab-ansible] SKIPPED (Skipped due to intermittent failure - DISCOVERY-426)
camayoc/tests/qpc/ui/test_credentials.py::test_create_delete_credential[chromium-PlainNetworkCredentialFormDTO] PASSED
camayoc/tests/qpc/ui/test_endtoend.py::test_end_to_end[chromium-testlab-A-network] PASSED
camayoc/tests/qpc/ui/test_endtoend.py::test_trigger_scan[chromium-testlab-A-network] SKIPPED (Skipped due to intermittent failure - DISCOVERY-426)
camayoc/tests/qpc/ui/test_login.py::test_login_logout[chromium] PASSED
camayoc/tests/qpc/ui/test_long_running.py::test_long_running[chromium] SKIPPED (Not intended for CI run)
camayoc/tests/qpc/ui/test_sources.py::test_create_delete_source[chromium-NetworkSourceFormDTO] PASSED
camayoc/tests/qpc/ui/test_credentials.py::test_create_delete_credential[chromium-SSHNetworkCredentialFormDTO] PASSED
camayoc/tests/qpc/ui/test_endtoend.py::test_end_to_end[chromium-testlab-B-network] PASSED
camayoc/tests/qpc/ui/test_endtoend.py::test_trigger_scan[chromium-testlab-B-network] SKIPPED (Skipped due to intermittent failure - DISCOVERY-426)
camayoc/tests/qpc/ui/test_sources.py::test_create_delete_source[chromium-SatelliteSourceFormDTO] PASSED
camayoc/tests/qpc/ui/test_credentials.py::test_create_delete_credential[chromium-SatelliteCredentialFormDTO] PASSED
camayoc/tests/qpc/ui/test_endtoend.py::test_end_to_end[chromium-vcenter-vcenter] PASSED
camayoc/tests/qpc/ui/test_endtoend.py::test_trigger_scan[chromium-vcenter-vcenter] SKIPPED (Skipped due to intermittent failure - DISCOVERY-426)
camayoc/tests/qpc/ui/test_sources.py::test_create_delete_source[chromium-VCenterSourceFormDTO] PASSED
camayoc/tests/qpc/ui/test_credentials.py::test_create_delete_credential[chromium-VCenterCredentialFormDTO] PASSED
camayoc/tests/qpc/ui/test_endtoend.py::test_end_to_end[chromium-satellite-satellite] PASSED
camayoc/tests/qpc/ui/test_endtoend.py::test_trigger_scan[chromium-satellite-satellite] SKIPPED (Skipped due to intermittent failure - DISCOVERY-426)
camayoc/tests/qpc/ui/test_sources.py::test_create_delete_source[chromium-AnsibleSourceFormDTO] PASSED
camayoc/tests/qpc/ui/test_credentials.py::test_create_delete_credential[chromium-AnsibleCredentialFormDTO] PASSED
camayoc/tests/qpc/ui/test_endtoend.py::test_end_to_end[chromium-ansible-testlab-ansible] PASSED
=========================================================== 15 passed, 6 skipped, 5 warnings in 297.49s (0:04:57) ============================================================
```