### PR TITLE
Stabilize test_scanjob_cancel, again

### DIFF
--- a/camayoc/tests/qpc/cli/test_scanjobs.py
+++ b/camayoc/tests/qpc/cli/test_scanjobs.py
@@ -285,11 +285,12 @@ def test_scanjob_cancel(qpc_server_config, data_provider):
         3) Try to restart the scan by running ``qpc scan restart --id <id>``
     :expectedresults: The scan must be canceled and can't not be restarted.
     """
-    # There's nothing fundamentally wrong with Ansible. In our environment,
-    # it finishes too quick, largely increasing a risk of test failing
-    # because job finished before we checked if it started.
+    # There's nothing fundamentally wrong with other source types.
+    # In our environment, they tend to finish too quickly, largely
+    # increasing a risk of test failing because job finished before
+    # we checked if it started.
     source = data_provider.sources.new_one(
-        {"type": Table.not_in(("ansible", "openshift"))}, data_only=False
+        {"type": Table.is_in(("network", "vcenter"))}, data_only=False
     )
     scan_name = uuid4()
     scan_add_and_check({"name": scan_name, "sources": source.name})


### PR DESCRIPTION
This is another attempt at stabilizing this test. See 9894ffd52517bf0c22a0b8442f6a1651b25ad8d5 / PR #443 for more details, as it still applies.

In last few runs this test failed only when it was run against Satellite. So run it only against network and vcenter scans for now, as these seem to work.

I have run the test 60 times with this patch and it did not fail once, which gives me confidence we should be good.