### PR TITLE
UI scan tests - provide better error message in case of failure

### DIFF
--- a/camayoc/ui/models/pages/scans.py
+++ b/camayoc/ui/models/pages/scans.py
@@ -5,6 +5,7 @@ import time
 from playwright.sync_api import Download
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
+from camayoc.exceptions import FailedScanException
 from camayoc.ui.decorators import creates_toast
 from camayoc.ui.decorators import record_action
 from camayoc.ui.decorators import service
@@ -28,6 +29,7 @@ class ScanListElem(AbstractListItem):
                 self._client.driver.locator(
                     "div.pf-c-toolbar button[data-ouia-component-id=refresh]"
                 ).click()
+        raise FailedScanException("Scan could not be downloaded")
 
 
 class ScansMainPage(MainPageMixin):


### PR DESCRIPTION
Sometimes UI tests fail when trying to download a scan report (usually because scan never started - thanks, thread-based scan manager!). Right now error message is rather unhelpful:

```
        credential_dto, source_dto, trigger_scan_dto = create_endtoend_dtos(source_name, data_provider)
        (
            ui_client.begin()
            .login(data_factories.LoginFormDTOFactory())
            .navigate_to(MainMenuPages.CREDENTIALS)
            .add_credential(credential_dto)
            .navigate_to(MainMenuPages.SOURCES)
            .add_source(source_dto)
            .trigger_scan(trigger_scan_dto)
            .navigate_to(MainMenuPages.SCANS)
            .download_scan(trigger_scan_dto.scan_form.scan_name)
            .logout()
        )
    
        is_network_scan = source_dto.select_source_type.source_type == SourceTypes.NETWORK_RANGE
        downloaded_report = ui_client.downloaded_files[-1]
        report_directory = Path(tempfile.mkdtemp(prefix="camayoc"))
>       report_file = report_directory / downloaded_report.suggested_filename
E       AttributeError: 'NoneType' object has no attribute 'suggested_filename'
```

With that patch applied, error message will be clearer:

```
        credential_dto, source_dto, trigger_scan_dto = create_endtoend_dtos(source_name, data_provider)
        (
            ui_client.begin()
            .login(data_factories.LoginFormDTOFactory())
            .navigate_to(MainMenuPages.CREDENTIALS)
            .add_credential(credential_dto)
            .navigate_to(MainMenuPages.SOURCES)
            .add_source(source_dto)
            .trigger_scan(trigger_scan_dto)
            .navigate_to(MainMenuPages.SCANS)
>           .download_scan(trigger_scan_dto.scan_form.scan_name)
            .logout()
        )

camayoc/tests/qpc/ui/test_endtoend.py:91: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
camayoc/ui/decorators.py:93: in inner
    page = func(*args, **kwargs)
camayoc/ui/decorators.py:25: in inner
    return func(*args, **kwargs)
camayoc/ui/decorators.py:47: in inner
    page = func(*args, **kwargs)
camayoc/ui/models/pages/scans.py:43: in download_scan
    downloaded_report = scan.download_scan()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <camayoc.ui.models.pages.scans.ScanListElem object at 0x7f3952136dd0>

    def download_scan(self) -> Download:
        scan_locator = "td.pf-c-table__action button[data-ouia-component-id=download]"
        timeout_start = time.monotonic()
        while 10 * 60 > (time.monotonic() - timeout_start):
            try:
                with self.locator.page.expect_download() as download_info:
                    self.locator.locator(scan_locator).click(timeout=10_000)
                download = download_info.value
                download.path()  # blocks the script while file is downloaded
                return download
            except PlaywrightTimeoutError:
                self._client.driver.locator(
                    "div.pf-c-toolbar button[data-ouia-component-id=refresh]"
                ).click()
>       raise FailedScanException("Scan could not be downloaded")
E       camayoc.exceptions.FailedScanException: Scan could not be downloaded
```