### PR TITLE
fix(rhacs): use appropriate naming conventions

### DIFF
--- a/camayoc/tests/qpc/cli/test_reports.py
+++ b/camayoc/tests/qpc/cli/test_reports.py
@@ -88,7 +88,7 @@ DEPLOYMENTS_REPORT_FIELDS = (
 """Common deployments report expected fields."""
 
 CSV_DEPLOYMENTS_REPORT_FIELDS = DEPLOYMENTS_REPORT_FIELDS + (
-    "detection-acs",
+    "detection-rhacs",
     "detection-ansible",
     "detection-network",
     "detection-openshift",


### PR DESCRIPTION
Use correct [naming]([https://docs.google.com/spreadsheets/d/1DLS_lS3VKidgZIvcLmLp9BoiqptkvqHWfe1D5FD2kfk/edit#gid=1259317633&range=A146](https://www.google.com/url?q=https://docs.google.com/spreadsheets/d/1DLS_lS3VKidgZIvcLmLp9BoiqptkvqHWfe1D5FD2kfk/edit%23gid%3D1259317633%26range%3DA146&sa=D&source=docs&ust=1698766696479657&usg=AOvVaw0qAhVK8_mlgQN77-U0b40t)) conventions for Red Hat product RHACS.
