### PR TITLE
Add RHACS automation

### DIFF
--- a/camayoc/tests/qpc/cli/test_rhacs.py
+++ b/camayoc/tests/qpc/cli/test_rhacs.py
@@ -1,0 +1,81 @@
+"""Tests for Red Hat Advanced Cluster Security sources.
+
+:caseautomation: automated
+:casecomponent: cli
+:caseimportance: high
+:caselevel: integration
+:testtype: functional
+"""
+import re
+from uuid import uuid4
+
+import pytest
+
+from camayoc.config import settings
+from camayoc.qpc_models import Scan
+from camayoc.tests.qpc.cli.utils import scan_job
+from camayoc.tests.qpc.cli.utils import scan_start
+from camayoc.tests.qpc.cli.utils import wait_for_scan
+from camayoc.types.settings import SourceOptions
+
+from .utils import retrieve_report
+from .utils import scan_add_and_check
+
+
+def rhacs_sources():
+    for source_definition in settings.sources:
+        if source_definition.type != "rhacs":
+            continue
+        fixture_id = source_definition.name
+        yield pytest.param(source_definition, id=fixture_id)
+
+
+@pytest.mark.parametrize("source_definition", rhacs_sources())
+def test_rhacs_data(qpc_server_config, data_provider, source_definition: SourceOptions):
+    """Perform Advanced Cluster Security scan and ensure data is valid and correct.
+
+    :id: 6638b3e8-5001-40dc-9acd-23d652de6ec4
+    :description: Perform Advanced Cluster Security scan and check if
+        details report contain expected structure, as well as data
+        matches basic expectations.
+    :steps:
+        1. Add source with credential for a RHACS
+        2. Perform a scan
+        3. Collect the report
+    :expectedresults: Scan finishes, report can be downloaded, there are two
+        basic facts (secured_units_max and secured_units_current), current Nodes
+        and CPU units are not larger than max Nodes and CPU units.
+    """
+    source = data_provider.sources.new_one({"name": source_definition.name}, data_only=False)
+    scan_name = uuid4()
+    scan_add_and_check(
+        {
+            "name": scan_name,
+            "sources": source.name,
+        }
+    )
+    data_provider.mark_for_cleanup(Scan(name=scan_name))
+    # is often repeated, could be extracted / is extracted?
+    # from here
+    output = scan_start({"name": scan_name})
+    match_scan_id = re.match(r'Scan "(\d+)" started.', output)
+    assert match_scan_id is not None
+    scan_job_id = match_scan_id.group(1)
+    wait_for_scan(scan_job_id, timeout=1200)
+    result = scan_job({"id": scan_job_id})
+    assert result["status"] == "completed"
+    # to here
+    details, deployments = retrieve_report(scan_job_id)
+    for report_source in details.get("sources"):
+        assert report_source.get("source_name") == source.name
+        for fact in report_source.get("facts"):
+            max_nodes = fact.get("secured_units_max").get("maxNodes")
+            max_cpu_units = fact.get("secured_units_max").get("maxCpuUnits")
+            current_nodes = fact.get("secured_units_current").get("numNodes")
+            current_cpu_units = fact.get("secured_units_current").get("numCpuUnits")
+            for max_date_key in ("maxNodesAt", "maxCpuUnitsAt"):
+                assert fact.get("secured_units_max").get(max_date_key) is not None
+            for numeric_value in (max_nodes, max_cpu_units, current_nodes, current_cpu_units):
+                assert float(numeric_value) > 0
+            assert float(max_nodes) >= float(current_nodes)
+            assert float(max_cpu_units) >= float(current_cpu_units)

--- a/camayoc/tests/qpc/ui/test_credentials.py
+++ b/camayoc/tests/qpc/ui/test_credentials.py
@@ -18,6 +18,7 @@ from camayoc.types.ui import AnsibleCredentialFormDTO
 from camayoc.types.ui import CredentialFormDTO
 from camayoc.types.ui import NetworkCredentialFormDTO
 from camayoc.types.ui import PlainNetworkCredentialFormDTO
+from camayoc.types.ui import RHACSCredentialFormDTO
 from camayoc.types.ui import SatelliteCredentialFormDTO
 from camayoc.types.ui import SSHNetworkCredentialFormDTO
 from camayoc.types.ui import VCenterCredentialFormDTO
@@ -31,6 +32,7 @@ CREDENTIAL_TYPE_MAP = {
     SatelliteCredentialFormDTO: CredentialTypes.SATELLITE,
     VCenterCredentialFormDTO: CredentialTypes.VCENTER,
     AnsibleCredentialFormDTO: CredentialTypes.ANSIBLE,
+    RHACSCredentialFormDTO: CredentialTypes.RHACS,
 }
 
 

--- a/camayoc/tests/qpc/ui/test_endtoend.py
+++ b/camayoc/tests/qpc/ui/test_endtoend.py
@@ -57,7 +57,7 @@ def create_endtoend_dtos(source_name, data_provider):
 
 def source_names():
     for source_definition in settings.sources:
-        if source_definition.type in ("openshift", "rhacs"):
+        if source_definition.type in ("openshift",):
             continue
         fixture_id = f"{source_definition.name}-{source_definition.type}"
         yield pytest.param(source_definition.name, id=fixture_id)

--- a/camayoc/tests/qpc/ui/test_endtoend.py
+++ b/camayoc/tests/qpc/ui/test_endtoend.py
@@ -57,6 +57,8 @@ def create_endtoend_dtos(source_name, data_provider):
 
 def source_names():
     for source_definition in settings.sources:
+        if source_definition.type in ("openshift", "rhacs"):
+            continue
         fixture_id = f"{source_definition.name}-{source_definition.type}"
         yield pytest.param(source_definition.name, id=fixture_id)
 

--- a/camayoc/tests/qpc/ui/test_sources.py
+++ b/camayoc/tests/qpc/ui/test_sources.py
@@ -15,6 +15,7 @@ import pytest
 from camayoc.qpc_models import Source
 from camayoc.types.ui import AnsibleSourceFormDTO
 from camayoc.types.ui import NetworkSourceFormDTO
+from camayoc.types.ui import RHACSSourceFormDTO
 from camayoc.types.ui import SatelliteSourceFormDTO
 from camayoc.types.ui import SourceFormDTO
 from camayoc.types.ui import VCenterSourceFormDTO
@@ -35,6 +36,7 @@ SOURCE_DATA_MAP = {
     SatelliteSourceFormDTO: ["127.0.0.1", "examplesatellite.sonar.com"],
     VCenterSourceFormDTO: ["127.0.0.1", "examplevcenter.sonar.com"],
     AnsibleSourceFormDTO: ["127.0.0.1", "exampleansible.sonar.com"],
+    RHACSSourceFormDTO: ["127.0.0.1", "acs.exampleopenshift.sonar.com"],
 }
 
 
@@ -43,6 +45,7 @@ CREDENTIAL_TYPES_MAP = {
     SatelliteSourceFormDTO: "satellite",
     VCenterSourceFormDTO: "vcenter",
     AnsibleSourceFormDTO: "ansible",
+    RHACSSourceFormDTO: "rhacs",
 }
 
 
@@ -51,6 +54,7 @@ SOURCE_TYPES_MAP = {
     SatelliteSourceFormDTO: SourceTypes.SATELLITE,
     VCenterSourceFormDTO: SourceTypes.VCENTER_SERVER,
     AnsibleSourceFormDTO: SourceTypes.ANSIBLE_CONTROLLER,
+    RHACSSourceFormDTO: SourceTypes.RHACS,
 }
 
 

--- a/camayoc/types/settings.py
+++ b/camayoc/types/settings.py
@@ -79,6 +79,12 @@ class VCenterCredentialOptions(BaseModel):
     password: str
 
 
+class RHACSCredentialOptions(BaseModel):
+    name: str
+    type: Literal["rhacs"]
+    auth_token: str
+
+
 class AnsibleCredentialOptions(BaseModel):
     name: str
     type: Literal["ansible"]
@@ -90,6 +96,7 @@ ServicesCredentialOptions = Annotated[
     Union[
         VCenterCredentialOptions,
         SatelliteCredentialOptions,
+        RHACSCredentialOptions,
         AnsibleCredentialOptions,
     ],
     Field(discriminator="type"),

--- a/camayoc/types/ui.py
+++ b/camayoc/types/ui.py
@@ -178,11 +178,22 @@ class AnsibleCredentialFormDTO:
         return cls(credential_name=model.name, username=model.username, password=model.password)
 
 
+@frozen
+class RHACSCredentialFormDTO:
+    credential_name: str
+    token: str
+
+    @classmethod
+    def from_model(cls, model: Credential):
+        return cls(credential_name=model.name, token=model.auth_token)
+
+
 CredentialFormDTO = Union[
     NetworkCredentialFormDTO,
     SatelliteCredentialFormDTO,
     VCenterCredentialFormDTO,
     AnsibleCredentialFormDTO,
+    RHACSCredentialFormDTO,
 ]
 
 
@@ -209,6 +220,9 @@ class AddCredentialDTO:
             case "ansible":
                 credential_type = CredentialTypes.ANSIBLE
                 credential_form_dto = AnsibleCredentialFormDTO.from_model(model)
+            case "rhacs":
+                credential_type = CredentialTypes.RHACS
+                credential_form_dto = RHACSCredentialFormDTO.from_model(model)
             case _:
                 raise ValueError(f"Can't create Credential UI DTO from {model}")
         return cls(credential_type, credential_form_dto)
@@ -291,11 +305,30 @@ class AnsibleSourceFormDTO:
         )
 
 
+@frozen
+class RHACSSourceFormDTO:
+    source_name: str
+    address: str
+    credentials: list[str]
+    connection: Optional[SourceConnectionTypes] = None
+    verify_ssl: Optional[bool] = None
+
+    @classmethod
+    def from_model(cls, model: Source):
+        return cls(
+            source_name=model.name,
+            address=model.hosts[0],
+            credentials=model.credentials,
+            verify_ssl=model.options.get("ssl_cert_verify"),
+        )
+
+
 SourceFormDTO = Union[
     NetworkSourceFormDTO,
     SatelliteSourceFormDTO,
     VCenterSourceFormDTO,
     AnsibleSourceFormDTO,
+    RHACSSourceFormDTO,
 ]
 
 
@@ -319,6 +352,9 @@ class AddSourceDTO:
             case "ansible":
                 source_type = SourceTypes.ANSIBLE_CONTROLLER
                 source_form_dto = AnsibleSourceFormDTO.from_model(model)
+            case "rhacs":
+                source_type = SourceTypes.RHACS
+                source_form_dto = RHACSSourceFormDTO.from_model(model)
             case _:
                 raise ValueError(f"Can't create Source UI DTO from {model}")
         return cls(SelectSourceDTO(source_type), source_form_dto)

--- a/camayoc/ui/enums.py
+++ b/camayoc/ui/enums.py
@@ -31,6 +31,7 @@ class CredentialTypes(StrEnum):
     SATELLITE = auto()
     VCENTER = auto()
     ANSIBLE = auto()
+    RHACS = auto()
 
 
 class NetworkCredentialAuthenticationTypes(StrEnum):
@@ -54,6 +55,7 @@ class SourceTypes(StrEnum):
     SATELLITE = "satellite"
     VCENTER_SERVER = "vcenter"
     ANSIBLE_CONTROLLER = "ansible"
+    RHACS = "rhacs"
 
 
 class SourceConnectionTypes(StrEnum):

--- a/camayoc/ui/models/pages/credentials.py
+++ b/camayoc/ui/models/pages/credentials.py
@@ -5,6 +5,7 @@ from typing import overload
 from camayoc.types.ui import AddCredentialDTO
 from camayoc.types.ui import AnsibleCredentialFormDTO
 from camayoc.types.ui import NetworkCredentialFormDTO
+from camayoc.types.ui import RHACSCredentialFormDTO
 from camayoc.types.ui import SatelliteCredentialFormDTO
 from camayoc.types.ui import VCenterCredentialFormDTO
 from camayoc.ui.decorators import creates_toast
@@ -105,6 +106,21 @@ class AnsibleCredentialForm(CredentialForm):
         return self
 
 
+class RHACSCredentialForm(CredentialForm):
+    class FormDefinition:
+        credential_name = InputField("input[data-ouia-component-id=cred_name]")
+        token = InputField("input[data-ouia-component-id=auth_token]")
+
+    @overload
+    def fill(self, data: RHACSCredentialFormDTO):
+        ...
+
+    @record_action
+    def fill(self, data: RHACSCredentialFormDTO):
+        super().fill(data)
+        return self
+
+
 class CredentialsMainPage(MainPageMixin):
     @service
     def add_credential(self, data: AddCredentialDTO) -> CredentialsMainPage:
@@ -131,6 +147,10 @@ class CredentialsMainPage(MainPageMixin):
             CredentialTypes.ANSIBLE: {
                 "selector": f"{create_credential_button} ~ ul li a[data-value=ansible]",
                 "class": AnsibleCredentialForm,
+            },
+            CredentialTypes.RHACS: {
+                "selector": f"{create_credential_button} ~ ul li a[data-value=rhacs]",
+                "class": RHACSCredentialForm,
             },
         }
 

--- a/camayoc/ui/models/pages/sources.py
+++ b/camayoc/ui/models/pages/sources.py
@@ -6,6 +6,7 @@ from camayoc.types.ui import AddSourceDTO
 from camayoc.types.ui import AnsibleSourceFormDTO
 from camayoc.types.ui import NetworkSourceFormDTO
 from camayoc.types.ui import NewScanFormDTO
+from camayoc.types.ui import RHACSSourceFormDTO
 from camayoc.types.ui import SatelliteSourceFormDTO
 from camayoc.types.ui import SelectSourceDTO
 from camayoc.types.ui import TriggerScanDTO
@@ -59,6 +60,7 @@ class SelectSourceTypeForm(Form, WizardStep, AbstractPage):
             SourceTypes.SATELLITE: SatelliteSourceCredentialsForm,
             SourceTypes.VCENTER_SERVER: VCenterSourceCredentialsForm,
             SourceTypes.ANSIBLE_CONTROLLER: AnsibleSourceCredentialsForm,
+            SourceTypes.RHACS: RHACSSourceCredentialsForm,
         }
         next_step_class = source_type_map.get(data.source_type)
         setattr(self, "NEXT_STEP_RESULT_CLASS", next_step_class)
@@ -157,6 +159,26 @@ class AnsibleSourceCredentialsForm(SourceCredentialsForm):
 
     @record_action
     def fill(self, data: AnsibleSourceFormDTO):
+        super().fill(data)
+        return self
+
+
+class RHACSSourceCredentialsForm(SourceCredentialsForm):
+    class FormDefinition:
+        source_name = InputField("input[data-ouia-component-id=name]")
+        address = InputField("input[data-ouia-component-id=hosts_single]")
+        credentials = MultipleSelectField(
+            "div[data-ouia-component-id=add_credentials_select] > button"
+        )
+        connection = SelectField("div[data-ouia-component-id=options_ssl_protocol] > button")
+        verify_ssl = CheckboxField("input[data-ouia-component-id=options_ssl_cert]")
+
+    @overload
+    def fill(self, data: RHACSSourceFormDTO):
+        ...
+
+    @record_action
+    def fill(self, data: RHACSSourceFormDTO):
         super().fill(data)
         return self
 

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -78,6 +78,9 @@ credentials:
       type: 'satellite'
       password: 'CHANGEME'
       username: 'CHANGEUSERNAME'
+    - name: 'rhacs'
+      type: 'rhacs'
+      auth_token: 'these_tend_to_be_very_long'
 
 # Values in "credentials" field can use names present in "credentials" section
 # above
@@ -102,6 +105,14 @@ sources:
           - 'sat6'
       name: 'sat6'
       type: 'satellite'
+      options:
+          ssl_cert_verify: false
+    - hosts:
+          - 'acs-endpoint.acs.mycluster.com'
+      credentials:
+          - 'rhacs'
+      name: 'RHACS'
+      type: 'rhacs'
       options:
           ssl_cert_verify: false
 


### PR DESCRIPTION
This adds CLI test (modeled after openshift test), and support for UI.

CLI test runs a scan and verifies a details report - checks fields and their values. Test will fail if you try to run it against empty RHACS (technically such test is valid, but I don't think it's very valuable - and I would rather keep stronger tests here). RHACS has a known problem where "max" fields are updated with a delay after cluster was registered, which means that test will likely fail until RHACS data is all processed.

UI test follows the same principles as other UI tests - just create a source, run a scan, download report, verify that report is syntactically correct. No data is validated.

```
$ pytest -v -ra camayoc/tests/qpc/cli/test_rhacs.py camayoc/tests/qpc/ui/test_endtoend.py --tracing retain-on-failure --browser chromium -k rhacs
camayoc/tests/qpc/ui/test_endtoend.py::test_trigger_scan[chromium-rhacs-testing-rhacs] SKIPPED (Skipped due to intermittent failure - DISCOVERY-426)                   [ 33%]
camayoc/tests/qpc/cli/test_rhacs.py::test_rhacs_data[rhacs-testing] PASSED                                                                                             [ 66%]
camayoc/tests/qpc/ui/test_endtoend.py::test_end_to_end[chromium-rhacs-testing-rhacs] PASSED                                                                            [100%]
========================================================== 2 passed, 1 skipped, 10 deselected, 5 warnings in 44.20s ==========================================================
```