### PR TITLE
Fix runs when there's no sight of RHACS in config

### DIFF
--- a/camayoc/types/ui.py
+++ b/camayoc/types/ui.py
@@ -138,6 +138,19 @@ class SSHNetworkCredentialFormDTO(_NetworkCredentialFormDTO):
             become_password=getattr(model, "become_password", None),
         )
 
+    def to_model(self):
+        model = Credential(
+            cred_type="network",
+            name=self.credential_name,
+            username=self.username,
+            ssh_keyfile=self.ssh_key_file,
+            auth_token=self.passphrase,
+            become_method=self.become_method.value,
+            become_user=self.become_user,
+            become_password=self.become_password,
+        )
+        return model
+
 
 NetworkCredentialFormDTO = Union[
     PlainNetworkCredentialFormDTO,
@@ -155,6 +168,15 @@ class SatelliteCredentialFormDTO:
     def from_model(cls, model: Credential):
         return cls(credential_name=model.name, username=model.username, password=model.password)
 
+    def to_model(self):
+        model = Credential(
+            cred_type="satellite",
+            name=self.credential_name,
+            username=self.username,
+            password=self.password,
+        )
+        return model
+
 
 @frozen
 class VCenterCredentialFormDTO:
@@ -166,6 +188,15 @@ class VCenterCredentialFormDTO:
     def from_model(cls, model: Credential):
         return cls(credential_name=model.name, username=model.username, password=model.password)
 
+    def to_model(self):
+        model = Credential(
+            cred_type="vcenter",
+            name=self.credential_name,
+            username=self.username,
+            password=self.password,
+        )
+        return model
+
 
 @frozen
 class OpenShiftCredentialFormDTO:
@@ -175,6 +206,14 @@ class OpenShiftCredentialFormDTO:
     @classmethod
     def from_model(cls, model: Credential):
         return cls(credential_name=model.name, token=model.auth_token)
+
+    def to_model(self):
+        model = Credential(
+            cred_type="openshift",
+            name=self.credential_name,
+            auth_token=self.token,
+        )
+        return model
 
 
 @frozen
@@ -187,6 +226,15 @@ class AnsibleCredentialFormDTO:
     def from_model(cls, model: Credential):
         return cls(credential_name=model.name, username=model.username, password=model.password)
 
+    def to_model(self):
+        model = Credential(
+            cred_type="ansible",
+            name=self.credential_name,
+            username=self.username,
+            password=self.password,
+        )
+        return model
+
 
 @frozen
 class RHACSCredentialFormDTO:
@@ -196,6 +244,14 @@ class RHACSCredentialFormDTO:
     @classmethod
     def from_model(cls, model: Credential):
         return cls(credential_name=model.name, token=model.auth_token)
+
+    def to_model(self):
+        model = Credential(
+            cred_type="rhacs",
+            name=self.credential_name,
+            auth_token=self.token,
+        )
+        return model
 
 
 CredentialFormDTO = Union[


### PR DESCRIPTION
A follow up to #461 - this contains changes necessary for pipeline to pass even if there's no RHACS in config file.

That should be a part of #461, because the problem was identified during review, but since that PR is already merged, I created new one.

```
$ pytest -v -ra camayoc/tests/qpc/ui/ --tracing retain-on-failure --browser chromium
camayoc/tests/qpc/ui/test_credentials.py::test_create_delete_credential[chromium-RHACSCredentialFormDTO] PASSED                                                        [  4%]
camayoc/tests/qpc/ui/test_credentials.py::test_create_delete_credential[chromium-PlainNetworkCredentialFormDTO] PASSED                                                 [  8%]
camayoc/tests/qpc/ui/test_endtoend.py::test_end_to_end[chromium-testlab-A-network] PASSED                                                                              [ 12%]
camayoc/tests/qpc/ui/test_endtoend.py::test_trigger_scan[chromium-testlab-A-network] SKIPPED (Skipped due to intermittent failure - DISCOVERY-426)                     [ 16%]
camayoc/tests/qpc/ui/test_login.py::test_login_logout[chromium] PASSED                                                                                                 [ 20%]
camayoc/tests/qpc/ui/test_long_running.py::test_long_running[chromium] SKIPPED (Not intended for CI run)                                                               [ 24%]
camayoc/tests/qpc/ui/test_sources.py::test_create_delete_source[chromium-NetworkSourceFormDTO] PASSED                                                                  [ 28%]
camayoc/tests/qpc/ui/test_credentials.py::test_create_delete_credential[chromium-SSHNetworkCredentialFormDTO] PASSED                                                   [ 32%]
camayoc/tests/qpc/ui/test_endtoend.py::test_end_to_end[chromium-testlab-B-network] PASSED                                                                              [ 36%]
camayoc/tests/qpc/ui/test_endtoend.py::test_trigger_scan[chromium-testlab-B-network] SKIPPED (Skipped due to intermittent failure - DISCOVERY-426)                     [ 40%]
camayoc/tests/qpc/ui/test_sources.py::test_create_delete_source[chromium-SatelliteSourceFormDTO] PASSED                                                                [ 44%]
camayoc/tests/qpc/ui/test_credentials.py::test_create_delete_credential[chromium-SatelliteCredentialFormDTO] PASSED                                                    [ 48%]
camayoc/tests/qpc/ui/test_endtoend.py::test_end_to_end[chromium-vcenter-vcenter] PASSED                                                                                [ 52%]
camayoc/tests/qpc/ui/test_endtoend.py::test_trigger_scan[chromium-vcenter-vcenter] SKIPPED (Skipped due to intermittent failure - DISCOVERY-426)                       [ 56%]
camayoc/tests/qpc/ui/test_sources.py::test_create_delete_source[chromium-VCenterSourceFormDTO] PASSED                                                                  [ 60%]
camayoc/tests/qpc/ui/test_credentials.py::test_create_delete_credential[chromium-VCenterCredentialFormDTO] PASSED                                                      [ 64%]
camayoc/tests/qpc/ui/test_endtoend.py::test_end_to_end[chromium-satellite-satellite] PASSED                                                                            [ 68%]
camayoc/tests/qpc/ui/test_endtoend.py::test_trigger_scan[chromium-satellite-satellite] SKIPPED (Skipped due to intermittent failure - DISCOVERY-426)                   [ 72%]
camayoc/tests/qpc/ui/test_sources.py::test_create_delete_source[chromium-OpenShiftSourceFormDTO] PASSED                                                                [ 76%]
camayoc/tests/qpc/ui/test_credentials.py::test_create_delete_credential[chromium-OpenShiftCredentialFormDTO] PASSED                                                    [ 80%]
camayoc/tests/qpc/ui/test_endtoend.py::test_end_to_end[chromium-ansible-testlab-ansible] PASSED                                                                        [ 84%]
camayoc/tests/qpc/ui/test_endtoend.py::test_trigger_scan[chromium-ansible-testlab-ansible] SKIPPED (Skipped due to intermittent failure - DISCOVERY-426)               [ 88%]
camayoc/tests/qpc/ui/test_sources.py::test_create_delete_source[chromium-AnsibleSourceFormDTO] PASSED                                                                  [ 92%]
camayoc/tests/qpc/ui/test_credentials.py::test_create_delete_credential[chromium-AnsibleCredentialFormDTO] PASSED                                                      [ 96%]
camayoc/tests/qpc/ui/test_sources.py::test_create_delete_source[chromium-RHACSSourceFormDTO] PASSED                                                                    [100%]
=========================================================== 19 passed, 6 skipped, 5 warnings in 308.13s (0:05:08) ============================================================
```