### PR TITLE
Restrict Python to 3.11.z in pyproject.toml

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ A GPL-licensed Python library that facilitates functional testing of quipucords_
 Installation
 ^^^^^^^^^^^^
 
-Camayoc supports Python 3.11 and above. It uses `Poetry <https://python-poetry.org/>`_
+Camayoc supports Python 3.11. It uses `Poetry <https://python-poetry.org/>`_
 for dependency and virtual environment management. See Poetry documentation for
 installation instructions - one of the easier paths is to install it through
 `pipx <https://pypa.github.io/pipx/>`_ , which you can get from your distribution.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ build-backend = "poetry.core.masonry.api"
 requires = ["poetry-core"]
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = "~3.11"
 attrs = "^23.1.0"
 dynaconf = "^3.1.12"
 factory_boy = "^3.2.1"


### PR DESCRIPTION
Pin Python to version 3.11 because the greenlet 2.0.2 module is not building in Python 3.12.


```
Package operations: 31 installs, 0 updates, 0 removals

  • Installing greenlet (2.0.2): Failed
...
  gcc -fno-strict-overflow -Wsign-compare -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -fcf-protection -fexceptions -fcf-protection -fexceptions -fcf-protection -fexceptions -fPIC -I/tmp/tmpk10kzdgn/.venv/include -I/usr/include/python3.12 -c src/greenlet/greenlet.cpp -o build/temp.linux-x86_64-cpython-312/src/greenlet/greenlet.o
  In file included from src/greenlet/greenlet_internal.hpp:20,
                   from src/greenlet/greenlet.cpp:19:
  src/greenlet/greenlet_greenlet.hpp: In member function ‘void greenlet::PythonState::operator<<(const PyThreadState*)’:
  src/greenlet/greenlet_greenlet.hpp:831:41: error: ‘_PyCFrame’ {aka ‘struct _PyCFrame’} has no member named ‘use_tracing’
    831 |     this->use_tracing = tstate->cframe->use_tracing;
        |                                         ^~~~~~~~~~~
...
```

In Fedora 39 you have to install Python 3.11 with

```sudo dnf install python3.11-devel```

and select this version in poetry with

```poetry env use python3.11```