### PR TITLE
DISCOVERY-481: Gather browser-issued errors during UI testing

### DIFF
--- a/camayoc/tests/qpc/ui/conftest.py
+++ b/camayoc/tests/qpc/ui/conftest.py
@@ -41,3 +41,8 @@ def ui_client(page):
     client_session = BasicSession()
     client = UIClient(driver=page, session=client_session)
     yield client
+    if client.page_errors:
+        fail_msg = ["Browser encountered errors during test execution:"]
+        page_errors = [f"- {err}" for err in client.page_errors]
+        fail_msg = "\n".join(fail_msg + page_errors)
+        pytest.fail(fail_msg)

--- a/camayoc/ui/client.py
+++ b/camayoc/ui/client.py
@@ -14,7 +14,46 @@ from .session import DummySession
 
 if TYPE_CHECKING:
     from playwright.sync_api import Download
+    from playwright.sync_api import Error
     from playwright.sync_api import Page
+    from playwright.sync_api import Request
+
+
+def requestfailed_handler_factory(ui_client):
+    def inner(request: Request):
+        error_msg = f"{request.method} {request.url} failed: {request.failure}"
+        ui_client._log_page_error(error_msg)
+
+    return inner
+
+
+def requestfinished_handler_factory(ui_client):
+    def inner(request: Request):
+        request_response = request.response()
+        # if we did not receive a response, then "requestfailed" event should
+        # be fired instead of "requestfinished", but Request.response() may
+        # return None - so better safe than sorry
+        if not request_response:
+            error_msg = f"{request.method} {request.url} did not receive a response"
+            ui_client._log_page_error(error_msg)
+            return
+
+        response_status = request_response.status
+        # we are only interested in client and server errors
+        if 400 > response_status:
+            return
+        error_msg = f"{request.method} {request.url} returned {response_status}"
+        ui_client._log_page_error(error_msg)
+
+    return inner
+
+
+def pageerror_handler_factory(ui_client):
+    def inner(error: Error):
+        error_msg = f"{error.name} {error.message} detected"
+        ui_client._log_page_error(error_msg)
+
+    return inner
 
 
 class Client:
@@ -33,6 +72,11 @@ class Client:
         self.session = session or DummySession()
         self.downloaded_files: list[Download] = []
         self.driver = driver
+        self.page_errors = []
+
+        self.driver.on("requestfailed", requestfailed_handler_factory(self))
+        self.driver.on("requestfinished", requestfinished_handler_factory(self))
+        self.driver.on("pageerror", pageerror_handler_factory(self))
 
     def _set_url(self):
         if self._base_url:
@@ -51,6 +95,11 @@ class Client:
         port = str(self._camayoc_config.quipucords_server.port)
         netloc = hostname + ":{}".format(port) if port else hostname
         self._base_url = urlunparse((scheme, netloc, "", "", "", ""))
+
+    def _log_page_error(self, error: str):
+        context_msg = f"[issued by {self.driver.url}]"
+        error_msg = f"{error} {context_msg}"
+        self.page_errors.append(error_msg)
 
     def begin(self) -> Login:
         """Start browser and open Quipucords UI login page."""


### PR DESCRIPTION
During UI testing, gather errors that browser saw and fail a test if there were any.

Issues gathered:

- failed HTTP requests (time outs, broken pipes, network issues in the middle of reading response and other problems that prevented browser from receiving the whole response)
- HTTP responses with 4xx and 5xx status codes
- JavaScript errors (syntax errors, uncaught exceptions, but NOT console.error() messages)

This allows us to remove one of integration tests from quipucords.

This is implemented by gathering interesting events during test execution and calling `pytest.fail()` in function-scoped fixture teardown. pytest in command line shows that funny - for each test, it will be reported as pass and then as error (because technically test did pass - fixture teardown is executed after the test). Ibutsu and Jenkins show test as errored instead of failed, but this difference is irrelevant.

See https://url.corp.redhat.com/ibutsu-runs-43032926-7ccf-471a-942a-2e79ee36b4ee for sample test session with some tests failing due to injected errors.