### PR TITLE
Refactor OpenShift CLI tests

### DIFF
--- a/camayoc/config.py
+++ b/camayoc/config.py
@@ -26,7 +26,6 @@ default_dynaconf_validators = [
     Validator("quipucords_server.ssh_keyfile_path", default=""),
     Validator("quipucords_cli.executable", default="qpc"),
     Validator("quipucords_cli.display_name", default="qpc"),
-    Validator("openshift", default=[]),
     Validator("vcenter.hostname", default=""),
     Validator("vcenter.username", default=""),
     Validator("vcenter.password", default=""),

--- a/camayoc/tests/qpc/cli/utils.py
+++ b/camayoc/tests/qpc/cli/utils.py
@@ -67,15 +67,6 @@ def config_sources():
     return [source for source in config_sources if source["name"] in scan_sources]
 
 
-def config_openshift():
-    """Return all OpenShift sources available on configuration file for CLI scans."""
-    try:
-        cfg = get_config().get("openshift", [])
-    except ConfigFileNotFoundError:
-        cfg = []
-    return cfg
-
-
 def config_scans():
     """Return all CLI scans available on the configuration file."""
     try:

--- a/camayoc/types/settings.py
+++ b/camayoc/types/settings.py
@@ -27,17 +27,6 @@ class QuipucordsCLIOptions(BaseModel):
     display_name: Optional[str] = "qpc"
 
 
-class OpenShiftOptions(BaseModel):
-    hostname: str
-    port: int
-    token: str
-    skip_tls_verify: bool
-    cluster_id: str
-    version: str
-    nodes: list[str]
-    operators: list[str]
-
-
 class VCenterOptions(BaseModel):
     hostname: str
     password: str
@@ -140,9 +129,17 @@ class ExpectedProductData(BaseModel):
     presence: str
 
 
+class ExpectedOpenShiftData(BaseModel):
+    cluster_id: str
+    version: str
+    nodes: list[str]
+    operators: list[str]
+
+
 class ExpectedScanData(BaseModel):
     distribution: Optional[ExpectedDistributionData]
     products: Optional[list[ExpectedProductData]]
+    cluster_info: Optional[ExpectedOpenShiftData]
 
 
 class ScanOptions(BaseModel):
@@ -155,7 +152,6 @@ class Configuration(BaseModel):
     camayoc: CamayocOptions
     quipucords_server: QuipucordsServerOptions
     quipucords_cli: QuipucordsCLIOptions
-    openshift: list[OpenShiftOptions]
     vcenter: VCenterOptions
     credentials: list[CredentialOptions]
     sources: list[SourceOptions]

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -25,26 +25,6 @@ quipucords_server:
 quipucords_cli:
     executable: qpc
 
-# OpenShift (OCP) cluster
-openshift:
-    - hostname: api.example.com
-      port: 6443
-      token: sha256~...
-      skip_tls_verify: true
-      cluster_id: '00000000-1111-2222-3333-123456789abc'
-      version: '4.11.32'
-      nodes:
-          - 'master-0.example.com'
-          - 'master-1.example.com'
-          - 'master-2.example.com'
-          - 'worker-0.example.com'
-          - 'worker-1.example.com'
-          - 'worker-2.example.com'
-          - 'worker-3.example.com'
-      operators:
-          - 'abc-operator'
-          - 'xyz-operator'
-
 # We host most of our test machines on a VCenter instance
 # and this section contains its URL and the credentials
 # needed to log in to it
@@ -78,7 +58,7 @@ credentials:
       type: 'satellite'
       password: 'CHANGEME'
       username: 'CHANGEUSERNAME'
-    - name: 'openshift'
+    - name: 'OpenShift'
       type: 'openshift'
       auth_token: 'sha256~XYZabc...'
     - name: 'rhacs'
@@ -108,6 +88,14 @@ sources:
           - 'sat6'
       name: 'sat6'
       type: 'satellite'
+      options:
+          ssl_cert_verify: false
+    - hosts:
+          - 'api.example.com'
+      credentials:
+          - 'OpenShift'
+      name: 'OpenShift'
+      type: 'openshift'
       options:
           ssl_cert_verify: false
     - hosts:
@@ -144,3 +132,21 @@ scans:
                   name: 'Red Hat Enterprise Linux'
                   version: '6.9'
                   release: ''
+    - name: OpenShift
+      sources:
+          - 'OpenShift'
+      expected_data:
+          OpenShift:
+              cluster_id: '00000000-1111-2222-3333-123456789abc'
+              version: '4.11.32'
+              nodes:
+                  - 'master-0.example.com'
+                  - 'master-1.example.com'
+                  - 'master-2.example.com'
+                  - 'worker-0.example.com'
+                  - 'worker-1.example.com'
+                  - 'worker-2.example.com'
+                  - 'worker-3.example.com'
+              operators:
+                  - 'abc-operator'
+                  - 'xyz-operator'


### PR DESCRIPTION
This refactor will make the OpenShift CLI tests behaves just like any other Camayoc test.
This change will drop the **top level openshift configuration** in Camayoc in favor of common  credential, source, scan, expected data places in Camayoc config.

I wish to refactor the way that we get the expected data from the configuration, it's fragile but it works. We can do it better later, because I prefer to merge as it is.

Relates to JIRA: DISCOVERY-401
https://issues.redhat.com/browse/DISCOVERY-401