### PR TITLE
Prepare Camayoc for CLI smoke tests

### DIFF
--- a/camayoc/tests/qpc/cli/test_openshift.py
+++ b/camayoc/tests/qpc/cli/test_openshift.py
@@ -126,6 +126,7 @@ def openshift_cluster_info(name):
             return scan_info.expected_data[scan_info.name].cluster_info
 
 
+@pytest.mark.runs_scan
 @pytest.mark.parametrize("source_definition", openshift_sources())
 def test_openshift_clusters(qpc_server_config, data_provider, source_definition: SourceOptions):
     """Perform OpenShift inspection and validate results.

--- a/camayoc/tests/qpc/cli/test_reports.py
+++ b/camayoc/tests/qpc/cli/test_reports.py
@@ -365,6 +365,7 @@ def setup_reports_prerequisites(data_provider):
         os.remove(scan["json-file"])
 
 
+@pytest.mark.runs_scan
 @pytest.mark.parametrize("source_option", REPORT_SOURCE_OPTIONS)
 @pytest.mark.parametrize("output_format", REPORT_OUTPUT_FORMATS)
 def test_deployments_report(source_option, output_format, isolated_filesystem, qpc_server_config):
@@ -408,6 +409,7 @@ def test_deployments_report(source_option, output_format, isolated_filesystem, q
             assert_json_report_fields(report_item.keys(), expected_fields)
 
 
+@pytest.mark.runs_scan
 @pytest.mark.parametrize("source_option", REPORT_SOURCE_OPTIONS)
 @pytest.mark.parametrize("output_format", REPORT_OUTPUT_FORMATS)
 def test_detail_report(source_option, output_format, isolated_filesystem, qpc_server_config):
@@ -459,6 +461,7 @@ def test_detail_report(source_option, output_format, isolated_filesystem, qpc_se
             )
 
 
+@pytest.mark.runs_scan
 @pytest.mark.parametrize("merge_by", REPORT_SOURCE_OPTIONS + ("json-file",))
 def test_merge_report(merge_by, isolated_filesystem, qpc_server_config):
     """Ensure can merge reports using report ids, scanjob ids and JSON files.
@@ -506,6 +509,7 @@ def test_merge_report(merge_by, isolated_filesystem, qpc_server_config):
         assert_json_report_fields(report_item.keys())
 
 
+@pytest.mark.runs_scan
 @pytest.mark.parametrize("source_option", REPORT_SOURCE_OPTIONS)
 def test_download_report(source_option, isolated_filesystem, qpc_server_config):
     """Ensure a report can be downloaded and has expected information.

--- a/camayoc/tests/qpc/cli/test_rhacs.py
+++ b/camayoc/tests/qpc/cli/test_rhacs.py
@@ -30,6 +30,7 @@ def rhacs_sources():
         yield pytest.param(source_definition, id=fixture_id)
 
 
+@pytest.mark.runs_scan
 @pytest.mark.parametrize("source_definition", rhacs_sources())
 def test_rhacs_data(qpc_server_config, data_provider, source_definition: SourceOptions):
     """Perform Advanced Cluster Security scan and ensure data is valid and correct.


### PR DESCRIPTION
We are going to run CLI tests on RHELs. For now, I want to do that in addition to standard regression runs we've been doing on Fedora. That means CLI tests on RHELs don't need to be exhaustive. In particular, we can skip running actual scans.

This PR has two commits that prepare us to this effort.

400fe88f44eafd8c35564977221371de6b9e9f90 enables standalone CLI runs. CLI tests had implicit dependency on some API tests that would create specific sources. This was never a problem in standard regression run, because we always run API before CLI.

9bc23c957bd7399cf3123ebfe537b5235fb7e608 adds `runs_scan` marker. This allows us to run only tests without this marker. It's probably a little too much for "smoke" run, but will do for now. All CLI tests took about 15 minutes to complete on my machine, CLI tests without `runs_scan` marker took 7.

I have also run full regression suite against this branch, see discovery standalone job build #40 on Jenkins. 