### PR TITLE
Add username/password authentication to OpenShift credentials

### DIFF
--- a/camayoc/types/settings.py
+++ b/camayoc/types/settings.py
@@ -74,6 +74,13 @@ class OpenShiftCredentialOptions(BaseModel):
     auth_token: str
 
 
+class PlainOpenShiftCredentialOptions(BaseModel):
+    name: str
+    type: Literal["openshift"]
+    username: str
+    password: str
+
+
 class RHACSCredentialOptions(BaseModel):
     name: str
     type: Literal["rhacs"]
@@ -102,6 +109,7 @@ ServicesCredentialOptions = Annotated[
 CredentialOptions = Union[
     PlainNetworkCredentialOptions,
     SSHNetworkCredentialOptions,
+    PlainOpenShiftCredentialOptions,
     ServicesCredentialOptions,
 ]
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -92,7 +92,7 @@ def test_invalid_source_credential_type_mismatch(tmp_path, faker, example_config
         ]
     )
     credential["type"] = new_type
-    if new_type in ("satellite", "vcenter") and not credential.get("password"):
+    if new_type in ("satellite", "vcenter", "openshift") and not credential.get("password"):
         credential["password"] = faker.password()
     with open(config_file, "w") as fh:
         yaml.dump(data=example_config, stream=fh)


### PR DESCRIPTION
We can have now username/password and token authentication to OpenShift credentials.

Examples:

```
  - name: 'ruda-plain'
    type: 'openshift'
    username: 'kubeadmin'
    password: 'xyz'

  - name: 'ruda-token'
    type: 'openshift'
    auth_token: sha256~...
```


Related to JIRA: DISCOVERY-401
https://issues.redhat.com/browse/DISCOVERY-401