### PR TITLE
Move pytest-ibutsu out of Jenkins dependency group

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1133,6 +1133,7 @@ develop = true
 
 [package.dependencies]
 cryptography = ">=37.0.4"
+faker = "^20.0.3"
 packaging = "^23.1"
 requests = ">=2.28.1"
 setuptools = "^67.8.0"
@@ -1321,4 +1322,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "4cbe155fe1f71b972925d9f7eff0e9c3b881739303ec172071901e90025ff489"
+content-hash = "9bb151b3e0be6e956adeae3e74f6ea3ee3ef56f45c9ef6a25fb45e14b613894d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ pexpect = "^4.8.0"
 playwright = "1.39.0"
 pydantic = "^1.10.7"
 pytest = "^7.4.3"
+pytest-ibutsu = "^2.2.4"
 pytest-playwright = "^0.4.3"
 pyxdg = "^0.28"
 pyyaml = "^6.0"
@@ -57,7 +58,6 @@ ruff = "^0.0.270"
 optional = true
 
 [tool.poetry.group.jenkins.dependencies]
-pytest-ibutsu = "^2.2.4"
 qpc = {path = "../qpc", develop = true}
 koji = "^1.33.0"
 


### PR DESCRIPTION
The pipeline will soon switch to installing qpc from RPM. For this switch to happen in phases, pipeline will first drop `--with jenkins` argument when installing camayoc, and then we can remove jenkins dependency group here.

However, right now jenkins dependency group contains one package we don't want (qpc from git), and one we do want (pytest-ibutsu). To allow for switch to happen, let's promote pytest-ibutsu to standard dependency - it's technically not required for normal camayoc usage, but it's only one package. Once we install from RPM in pipeline, we can think about moving pytest-ibutsu back to separate dependency group and installing it.