### PR TITLE
Add Jenkinsfile for internal CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,23 @@
+@Library("smqe-shared-lib@master") _
+
+def agents = [:]
+agents["failFast"] = false
+
+["fedora", "rhel8", "rhel9"].each { distro_label ->
+    agents[distro_label] = {
+        node("discovery_ci && ${distro_label}") {
+            stage("[${distro_label}] Setup test environment") {
+                echo "Setting up Quipucords PR tests"
+                discoveryLib.setupCIEnv()
+            }
+            stage("[${distro_label}] Run tests") {
+                discoveryLib.runTests()
+            }
+            stage("[${distro_label}] Archive artifacts") {
+                discoveryLib.archiveArtifacts()
+            }
+        }
+    }
+}
+
+parallel agents


### PR DESCRIPTION
Add the same Jenkinsfile as we have in quipucords, so Camayoc PRs won't break other pipelines.

This also requires a change in Jenkins configuration, there will be a PR in swatch-ci repo.