### PR TITLE
Run test_scanjob_cancel on network sources only

### DIFF
--- a/camayoc/tests/qpc/cli/test_scanjobs.py
+++ b/camayoc/tests/qpc/cli/test_scanjobs.py
@@ -289,9 +289,7 @@ def test_scanjob_cancel(qpc_server_config, data_provider):
     # In our environment, they tend to finish too quickly, largely
     # increasing a risk of test failing because job finished before
     # we checked if it started.
-    source = data_provider.sources.new_one(
-        {"type": Table.is_in(("network", "vcenter"))}, data_only=False
-    )
+    source = data_provider.sources.new_one({"type": Table.eq("network")}, data_only=False)
     scan_name = uuid4()
     scan_add_and_check({"name": scan_name, "sources": source.name})
     data_provider.mark_for_cleanup(Scan(name=scan_name))


### PR DESCRIPTION
See 9894ffd52517bf0c22a0b8442f6a1651b25ad8d5 and 47129b013f3b0fc48fc3a40d523da6d80c5c121c for previous attempts at stabilizing the test. Currently only network sources take long enough for us to reliably cancel them before they finish.

```
$ pytest -s -v camayoc/tests/qpc/cli/test_scanjobs.py::test_scanjob_cancel
camayoc/tests/qpc/cli/test_scanjobs.py::test_scanjob_cancel PASSED

============================================================================= 1 passed in 8.74s ==============================================================================
```