### PR TITLE
Fix exceptions in failure handling

### DIFF
--- a/camayoc/tests/qpc/api/v1/reports/test_reports.py
+++ b/camayoc/tests/qpc/api/v1/reports/test_reports.py
@@ -138,7 +138,7 @@ def test_products_found_deployment_report(data_provider, scan_info: ScanOptions)
             continue
         if not found_hosts.get(hostname):
             errors_found.append(
-                f"Host '{hostname}' was expected for scan {scan_info.get('name')}, but not found"
+                f"Host '{hostname}' was expected for scan {scan_info.name}, but not found"
             )
         for fingerprint in system_fingerprints:
             present_product_names = {
@@ -222,7 +222,7 @@ def test_OS_found_deployment_report(data_provider, scan_info: ScanOptions):
         actual_data = found_hosts.get(hostname)
         if not actual_data:
             errors_found.append(
-                f"Host '{hostname}' was expected for scan {scan_info.get('name')}, but not found"
+                f"Host '{hostname}' was expected for scan {scan_info.name}, but not found"
             )
 
         found_release = actual_data.get("os_release", "")


### PR DESCRIPTION
A branch of test failure handling was not ported to pydantic objects back when we introduced them. If test would be failing, it would issue new exception ('ScanOptions' object has no attribute 'get') instead of printing what went wrong.

We did not catch that earlier because tests were stable, until they randomly failed (and exposed the issue) last night.