### PR TITLE
Use bulk delete API in cleanup

### DIFF
--- a/camayoc/qpc_models.py
+++ b/camayoc/qpc_models.py
@@ -21,6 +21,29 @@ from camayoc.utils import uuid4
 OPTIONAL_PROD_KEY = "disabled_optional_products"
 
 
+class QPCObjectBulkDeleteMixin(object):
+    """Mixin that provides access to bulk_delete method.
+
+    We can't put that in base model, because not all objects have
+    bulk_delete endpoint; but we don't want to implement that for
+    every object separately, because implementation is exactly the
+    same for objects that do have this endpoint.
+    """
+
+    def bulk_delete(self, ids, **kwargs):
+        """Send POST request to the self.endpoint/bulk_delete/ of this object.
+
+        :param ``**kwargs``: Additional arguments accepted by Requests's
+            `request.request()` method.
+
+        :returns: requests.models.Response. A successful delete has the return
+            code `204`.
+
+        """
+        path = urljoin(self.endpoint, "bulk_delete/")
+        return self.client.post(path, payload={"ids": ids}, **kwargs)
+
+
 class QPCObject(object):
     """A base class for other QPC models."""
 
@@ -146,7 +169,7 @@ class QPCObject(object):
         return self.client.delete(self.path(), **kwargs)
 
 
-class Credential(QPCObject):
+class Credential(QPCObject, QPCObjectBulkDeleteMixin):
     """A class to aid in CRUD tests of Host Credentials on the QPC server.
 
     Host credentials can be created by instantiating a Credential
@@ -272,7 +295,7 @@ class Credential(QPCObject):
         return True
 
 
-class Source(QPCObject):
+class Source(QPCObject, QPCObjectBulkDeleteMixin):
     """A class to aid in CRUD test cases for sources.
 
     Sources can be created on the quipucords server by
@@ -391,7 +414,7 @@ class Source(QPCObject):
         return True
 
 
-class Scan(QPCObject):
+class Scan(QPCObject, QPCObjectBulkDeleteMixin):
     """A class to aid in CRUD test cases for scan jobs.
 
     Scans are named objects on the server that can then be used to generate any

--- a/tests/test_data_provider.py
+++ b/tests/test_data_provider.py
@@ -155,7 +155,7 @@ def test_new_no_match():
 def test_automatic_cleanup():
     dp = DataProvider(credentials=CREDENTIALS, sources=SOURCES, scans=SCANS)
     with mock.patch("camayoc.api.Client"):
-        with mock.patch.object(dp.credentials._model_class, "delete") as mock_delete:
+        with mock.patch.object(dp.credentials._model_class, "bulk_delete") as mock_delete:
             cred = dp.credentials.new_one({"type": "network"}, data_only=False)
             cred._id = 123
             mock_delete.return_value = mock.Mock
@@ -167,7 +167,7 @@ def test_automatic_cleanup():
 def test_mark_for_cleanup():
     dp = DataProvider(credentials=CREDENTIALS, sources=SOURCES, scans=SCANS)
     with mock.patch("camayoc.api.Client"):
-        with mock.patch.object(dp.credentials._model_class, "delete") as mock_delete:
+        with mock.patch.object(dp.credentials._model_class, "bulk_delete") as mock_delete:
             cred = dp.credentials.new_one({"type": "network"}, data_only=True)
             cred._id = 123
             mock_delete.return_value = mock.Mock


### PR DESCRIPTION
Add support for `bulk_delete` and use it in data_provider cleanup code. Hopefully this way we will avoid any problems caused by rate throttling.

This may be merged only after https://github.com/quipucords/quipucords/pull/2609 is merged.

Camayoc tests for this PR are going to fail for this reason. I ran standalone job with this branch against container image from 2609: this is job build #69.