### PR TITLE
Drop config.get_config backwards compatibility shim

### DIFF
--- a/camayoc/config.py
+++ b/camayoc/config.py
@@ -93,11 +93,3 @@ def get_settings(path=None) -> Configuration:
 
 
 settings = get_settings()
-
-
-def get_config():
-    """Backwards compatibility shim. Returns global config object."""
-    shim_settings = settings.model_dump(by_alias=True)
-    qpc_options = shim_settings.pop("quipucords_server")
-    shim_settings["qpc"] = qpc_options
-    return shim_settings

--- a/camayoc/tests/conftest.py
+++ b/camayoc/tests/conftest.py
@@ -4,7 +4,7 @@
 import pytest
 
 from camayoc import utils
-from camayoc.config import get_config
+from camayoc.config import settings
 
 
 def pytest_collection_modifyitems(
@@ -29,9 +29,8 @@ def isolated_filesystem(request):
     mark = request.node.get_closest_marker("ssh_keyfile_path")
     ssh_keyfile_path = None
     if mark:
-        cfg = get_config().get("qpc", {})
-        ssh_keyfile_path = cfg.get("ssh_keyfile_path")
+        ssh_keyfile_path = settings.quipucords_server.ssh_keyfile_path
         if not ssh_keyfile_path:
-            pytest.fail("QPC configuration 'ssh_keyfile_path' not provided or " "found")
+            pytest.fail("QPC configuration 'ssh_keyfile_path' not provided or found")
     with utils.isolated_filesystem(ssh_keyfile_path) as path:
         yield path

--- a/camayoc/tests/qpc/api/v1/authentication/test_login.py
+++ b/camayoc/tests/qpc/api/v1/authentication/test_login.py
@@ -11,7 +11,7 @@ import pytest
 import requests
 
 from camayoc import api
-from camayoc import config
+from camayoc.config import settings
 from camayoc.constants import QPC_CREDENTIALS_PATH
 from camayoc.constants import QPC_SCAN_PATH
 from camayoc.constants import QPC_SOURCE_PATH
@@ -80,5 +80,5 @@ def test_user():
     :expectedresults: The server correctly reports our username.
     """
     client = api.Client()
-    qpc_user = config.get_config().get("qpc", {}).get("username")
+    qpc_user = settings.quipucords_server.username
     assert client.get_user().json()["username"] == qpc_user

--- a/camayoc/tests/qpc/api/v1/utils.py
+++ b/camayoc/tests/qpc/api/v1/utils.py
@@ -3,14 +3,11 @@
 import pprint
 import time
 
-from camayoc import config
 from camayoc.constants import QPC_SCAN_STATES
 from camayoc.constants import QPC_SCAN_TERMINAL_STATES
 from camayoc.exceptions import StoppedScanException
 from camayoc.exceptions import WaitTimeError
-from camayoc.qpc_models import Credential
 from camayoc.qpc_models import Scan
-from camayoc.qpc_models import Source
 
 
 def get_source(source_type, cleanup):
@@ -50,44 +47,10 @@ def get_source(source_type, cleanup):
         on server and has all credentials listed in config file created and
         associtated with it.
     """
-    cfg = config.get_config()
-    cred_list = cfg.get("credentials", [])
-    src_list = cfg.get("qpc", {}).get("sources", [])
-    config_src = {}
-    if not (src_list and cred_list):
-        return
-    for src in src_list:
-        if src.get("type") == source_type:
-            config_src = src
-    if config_src:
-        config_src.setdefault("credential_ids", [])
-        src_creds = config_src.get("credentials")
-        for cred in src_creds:
-            for config_cred in cred_list:
-                if cred == config_cred["name"]:
-                    server_cred = Credential(
-                        cred_type=source_type, username=config_cred["username"]
-                    )
-                    if config_cred.get("password"):
-                        server_cred.password = config_cred["password"]
-                    else:
-                        server_cred.ssh_keyfile = config_cred["sshkeyfile"]
-
-                    server_cred.create()
-                    cleanup.append(server_cred)
-                    config_src["credential_ids"].append(server_cred._id)
-        server_src = Source(
-            hosts=config_src["hosts"],
-            credential_ids=config_src["credential_ids"],
-            source_type=source_type,
-        )
-
-        if config_src.get("options"):
-            server_src.options = config_src.get("options")
-
-        server_src.create()
-        cleanup.append(server_src)
-        return server_src
+    # FIXME: Taking some debt here. This function is only used by prepare_scan, which in
+    # turn is only used by 2 tests that are skipped. These tests should be rewritten to
+    # data_provider, which fundamentally does exactly the same thing.
+    return None
 
 
 def prepare_scan(source_type, cleanup):

--- a/camayoc/tests/qpc/cli/test_reports.py
+++ b/camayoc/tests/qpc/cli/test_reports.py
@@ -331,7 +331,7 @@ def setup_reports_prerequisites(data_provider):
     and store the information about it on the global ``_SCANS`` list.
     """
     setup_qpc()
-    network_sources = [source for source in config_sources() if source["type"] == "network"]
+    network_sources = [source for source in config_sources() if source.type == "network"]
     random.shuffle(network_sources)
     network_sources = network_sources[:2]
     if len(network_sources) < 2:
@@ -341,7 +341,7 @@ def setup_reports_prerequisites(data_provider):
         )
 
     for source in network_sources:
-        real_source = data_provider.sources.new_one({"name": source["name"]}, data_only=False)
+        real_source = data_provider.sources.new_one({"name": source.name}, data_only=False)
         scan = {"name": uuid4(), "sources": [real_source]}
         scan_add_and_check({"name": scan["name"], "sources": real_source.name})
         data_provider.mark_for_cleanup(Scan(name=scan["name"]))

--- a/camayoc/tests/qpc/cli/test_scanjobs.py
+++ b/camayoc/tests/qpc/cli/test_scanjobs.py
@@ -251,7 +251,7 @@ def test_scanjob_restart(isolated_filesystem, qpc_server_config):
         should be available.
     """
     scan_name = uuid4()
-    scan_add_and_check({"name": scan_name, "sources": config_sources()[0]["name"]})
+    scan_add_and_check({"name": scan_name, "sources": config_sources()[0].name})
     result = scan_start({"name": scan_name})
     match = re.match(r'Scan "(\d+)" started.', result)
     assert match is not None
@@ -322,7 +322,7 @@ def test_scanjob_cancel_paused(isolated_filesystem, qpc_server_config):
     :expectedresults: The scan must be canceled and can't not be restarted.
     """
     scan_name = uuid4()
-    scan_add_and_check({"name": scan_name, "sources": config_sources()[0]["name"]})
+    scan_add_and_check({"name": scan_name, "sources": config_sources()[0].name})
     result = scan_start({"name": scan_name})
     match = re.match(r'Scan "(\d+)" started.', result)
     assert match is not None

--- a/camayoc/tests/qpc/cli/test_scans.py
+++ b/camayoc/tests/qpc/cli/test_scans.py
@@ -32,7 +32,7 @@ def test_create_scan(isolated_filesystem, qpc_server_config, data_provider, sour
     :steps: Run ``qpc scan add --sources <source>``
     :expectedresults: The created scan matches default for options.
     """
-    source = data_provider.sources.defined_one({"name": source["name"]})
+    source = data_provider.sources.defined_one({"name": source.name})
     scan_name = uuid4()
     scan_add_and_check({"name": scan_name, "sources": source.name})
 
@@ -373,7 +373,7 @@ def test_clear(isolated_filesystem, qpc_server_config, data_provider, source):
     :expectedresults: Scan is deleted.
     """
     # Create scan
-    source = data_provider.sources.defined_one({"name": source["name"]})
+    source = data_provider.sources.defined_one({"name": source.name})
     scan_name = uuid4()
     scan_add_and_check({"name": scan_name, "sources": source.name})
 

--- a/camayoc/tests/qpc/ui/conftest.py
+++ b/camayoc/tests/qpc/ui/conftest.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from camayoc import config
+from camayoc.config import settings
 from camayoc.tests.qpc.cli.utils import clear_all_entities
 from camayoc.ui import Client as UIClient
 from camayoc.ui.session import BasicSession
@@ -22,7 +22,7 @@ def pytest_exception_interact(node, call, report):
 @pytest.fixture(scope="session")
 def browser_context_args(browser_context_args):
     extra_context_args = {}
-    verify_ssl = config.get_config().get("qpc", {}).get("ssl-verify", False)
+    verify_ssl = settings.quipucords_server.ssl_verify
     if not verify_ssl:
         extra_context_args["ignore_https_errors"] = True
 

--- a/camayoc/types/settings.py
+++ b/camayoc/types/settings.py
@@ -17,7 +17,9 @@ class QuipucordsServerOptions(BaseModel):
     hostname: str
     https: Optional[bool] = False
     port: Optional[int] = 8000
-    ssl_verify: Optional[bool] = Field(False, alias="ssl-verify")
+    # FIXME: this is thin layer around requests.adapters.BaseAdapter.send() `verify`
+    # param, which can be a boolean OR string (representing local path to CA bundle)
+    ssl_verify: Optional[bool] = False
     username: str
     password: str
     ssh_keyfile_path: str

--- a/camayoc/ui/client.py
+++ b/camayoc/ui/client.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 from typing import Optional
 from urllib.parse import urlunparse
 
-from camayoc import exceptions
 from camayoc.config import settings
 from camayoc.types.settings import Configuration
 from camayoc.types.ui import Session
@@ -83,14 +82,6 @@ class Client:
             return
 
         hostname = self._camayoc_config.quipucords_server.hostname
-
-        if not hostname:
-            msg = (
-                "\n'quipucords_server' section specified in camayoc config file, "
-                "but no 'hostname' key found."
-            )
-            raise exceptions.QPCBaseUrlNotFound(msg)
-
         scheme = "https" if self._camayoc_config.quipucords_server.https else "http"
         port = str(self._camayoc_config.quipucords_server.port)
         netloc = hostname + ":{}".format(port) if port else hostname

--- a/camayoc/utils.py
+++ b/camayoc/utils.py
@@ -9,8 +9,6 @@ import tempfile
 import uuid
 from urllib.parse import urlunparse
 
-from camayoc import exceptions
-from camayoc.config import get_config
 from camayoc.config import settings
 
 _XDG_ENV_VARS = ("XDG_DATA_HOME", "XDG_CONFIG_HOME", "XDG_CACHE_HOME")
@@ -33,22 +31,13 @@ client_cmd = settings.quipucords_cli.executable
 client_cmd_name = settings.quipucords_cli.display_name
 """Client name displayed on help texts. Defaults to `qpc`."""
 # this is useful when client_cmd is set to an absolute path, has extra arguments like -v
-# or even when we finally support running tests with proper dsc.
 
 
 def get_qpc_url():
     """Return the base url for the qpc server."""
-    cfg = get_config().get("qpc", {})
-    hostname = cfg.get("hostname")
-
-    if not hostname:
-        raise exceptions.QPCBaseUrlNotFound(
-            'Make sure you have a "qpc" section and `hostname`is specified in '
-            "the camayoc config file"
-        )
-
-    scheme = "https" if cfg.get("https", False) else "http"
-    port = str(cfg.get("port", ""))
+    hostname = settings.quipucords_server.hostname
+    scheme = "https" if settings.quipucords_server.https else "http"
+    port = str(settings.quipucords_server.port)
     netloc = hostname + ":{}".format(port) if port else hostname
     return urlunparse((scheme, netloc, "", "", "", ""))
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,30 +7,18 @@ from unittest.mock import MagicMock
 from urllib.parse import urljoin
 
 import requests
-import yaml
 
 from camayoc import api
-from camayoc import config
-from camayoc import exceptions
 from camayoc.qpc_models import Credential
 from camayoc.qpc_models import Scan
 from camayoc.qpc_models import ScanJob
 from camayoc.qpc_models import Source
+from camayoc.types.settings import QuipucordsServerOptions
 from camayoc.utils import uuid4
 
-CAMAYOC_CONFIG = """
-qpc:
-    hostname: example.com
-    https: false
-    username: admin
-    password: pass
-"""
-
-INVALID_HOST_CONFIG = """
-qpc:
-    port: 8000
-    https: true
-"""
+CAMAYOC_CONFIG = QuipucordsServerOptions(
+    hostname="example.com", https=False, username="admin", password="pass", ssh_keyfile_path="/tmp/"
+)
 
 MOCK_CREDENTIAL = {
     "id": 34,
@@ -61,7 +49,6 @@ MOCK_SAT6_SOURCE = {
     "options": {"satellite_version": "6.2", "ssl_cert_verify": False},
 }
 
-
 MOCK_SCAN = {
     "id": 21,
     "name": "testscan",
@@ -75,246 +62,180 @@ MOCK_SCAN = {
 class APIClientTestCase(unittest.TestCase):
     """Test :mod:camayoc.api."""
 
-    @classmethod
-    def setUpClass(cls):
-        """Create a parsed configuraton dictionary."""
-        cls.config = yaml.load(CAMAYOC_CONFIG, Loader=yaml.FullLoader)
-        cls.invalid_config = yaml.load(INVALID_HOST_CONFIG, Loader=yaml.FullLoader)
-
     def test_create_with_config(self):
         """If a hostname is specified in the config file, we use it."""
-        with mock.patch.object(config, "get_config", return_value=self.config):
-            self.assertEqual(config.get_config(), self.config)
-            client = api.Client(authenticate=False)
-            self.assertEqual(client.url, "http://example.com/api/v1/")
+        client = api.Client(authenticate=False, config=CAMAYOC_CONFIG)
+        self.assertEqual(client.url, "http://example.com:8000/api/v1/")
 
-    def test_create_no_config(self):
+    def test_create_specific_url(self):
         """If a base url is specified we use it."""
-        with mock.patch.object(config, "get_config", return_value={}):
-            self.assertEqual(config.get_config(), {})
-            other_host = "http://hostname.com"
-            client = api.Client(url=other_host, authenticate=False)
-            self.assertNotEqual("http://example.com/api/v1/", client.url)
-            self.assertEqual(other_host, client.url)
-
-    def test_create_override_config(self):
-        """If a base url is specified, we use that instead of config file."""
-        with mock.patch.object(config, "get_config", return_value=self.config):
-            other_host = "http://hostname.com"
-            client = api.Client(url=other_host, authenticate=False)
-            cfg_host = self.config["qpc"]["hostname"]
-            self.assertNotEqual(cfg_host, client.url)
-            self.assertEqual(other_host, client.url)
-
-    def test_negative_create(self):
-        """Raise an error if no config entry is found and no url specified."""
-        with mock.patch.object(config, "get_config", return_value={}):
-            self.assertEqual(config.get_config(), {})
-            with self.assertRaises(exceptions.QPCBaseUrlNotFound):
-                api.Client(authenticate=False)
-
-    def test_invalid_hostname(self):
-        """Raise an error if no config entry is found and no url specified."""
-        with mock.patch.object(config, "get_config", return_value=self.invalid_config):
-            self.assertEqual(config.get_config(), self.invalid_config)
-            with self.assertRaises(exceptions.QPCBaseUrlNotFound):
-                api.Client(authenticate=False)
+        other_host = "http://hostname.com"
+        client = api.Client(url=other_host, authenticate=False)
+        self.assertNotEqual("http://example.com:8000/api/v1/", client.url)
+        self.assertEqual(other_host, client.url)
 
     def test_login(self):
         """Test that when a client is created, it logs in just once."""
-        with mock.patch.object(config, "get_config", return_value=self.config):
-            self.assertEqual(config.get_config(), self.config)
-            client = api.Client
-            client.login = MagicMock()
-            cl = client()
-            assert client.login.call_count == 1
-            cl.token = uuid4()
-            assert cl.default_headers() != {}
+        client = api.Client
+        client.login = MagicMock()
+        cl = client(config=CAMAYOC_CONFIG)
+        assert client.login.call_count == 1
+        cl.token = uuid4()
+        assert cl.default_headers() != {}
 
     def test_get_user(self):
         """Test that when a client is created, it logs in just once."""
-        with mock.patch.object(config, "get_config", return_value=self.config):
-            self.assertEqual(config.get_config(), self.config)
-            client = api.Client
-            client.login = MagicMock()
-            response = MagicMock(json=MagicMock(return_value={"username": "admin"}))
-            client.request = MagicMock(return_value=response)
-            cl = client()
-            u = cl.get_user().json()["username"]
-            assert u == config.get_config()["qpc"]["username"]
-            client.request.assert_called_once_with("GET", urljoin(cl.url, "users/current/"))
+        client = api.Client
+        client.login = MagicMock()
+        response = MagicMock(json=MagicMock(return_value={"username": "admin"}))
+        client.request = MagicMock(return_value=response)
+        cl = client(config=CAMAYOC_CONFIG)
+        u = cl.get_user().json()["username"]
+        assert u == CAMAYOC_CONFIG.username
+        client.request.assert_called_once_with("GET", urljoin(cl.url, "users/current/"))
 
     def test_logout(self):
         """Test that when we log out, all credentials are cleared."""
-        with mock.patch.object(config, "get_config", return_value=self.config):
-            self.assertEqual(config.get_config(), self.config)
-            client = api.Client
-            client.login = MagicMock()
-            cl = client()
-            assert client.login.call_count == 1
-            cl.token = uuid4()
-            assert cl.default_headers() is not {}
-            client.request = MagicMock()
-            cl.logout()
-            assert client.request.call_count == 1
-            assert cl.token is None
-            assert cl.default_headers() == {}
+        client = api.Client
+        client.login = MagicMock()
+        cl = client(config=CAMAYOC_CONFIG)
+        assert client.login.call_count == 1
+        cl.token = uuid4()
+        assert cl.default_headers() is not {}
+        client.request = MagicMock()
+        cl.logout()
+        assert client.request.call_count == 1
+        assert cl.token is None
+        assert cl.default_headers() == {}
 
     def test_response_handler(self):
         """Test that when we get a 4xx or 5xx response, an error is raised."""
-        with mock.patch.object(config, "get_config", return_value=self.config):
-            self.assertEqual(config.get_config(), self.config)
-            client = api.Client(authenticate=False)
-            mock_request = mock.Mock(
-                body='{"Test Body"}',
-                path_url="/example/path/",
-                headers='{"Test Header"}',
-                text="Some text",
-            )
-            mock_response = mock.Mock(status_code=404)
-            mock_response.request = mock_request
-            mock_response.json = MagicMock(
-                return_value=json.dumps('{"The resource you requested was not found"}')
-            )
-            with self.subTest(msg="Test code handler"):
-                client.response_handler = api.code_handler
-                with self.assertRaises(requests.exceptions.HTTPError):
-                    client.response_handler(mock_response)
-
-            with self.subTest(msg="Test json handler"):
-                client.response_handler = api.json_handler
-                with self.assertRaises(requests.exceptions.HTTPError):
-                    client.response_handler(mock_response)
-
-            with self.subTest(msg="Test echo handler"):
-                client.response_handler = api.echo_handler
-                # no error should be raised with the echo handler
+        client = api.Client(authenticate=False, config=CAMAYOC_CONFIG)
+        mock_request = mock.Mock(
+            body='{"Test Body"}',
+            path_url="/example/path/",
+            headers='{"Test Header"}',
+            text="Some text",
+        )
+        mock_response = mock.Mock(status_code=404)
+        mock_response.request = mock_request
+        mock_response.json = MagicMock(
+            return_value=json.dumps('{"The resource you requested was not found"}')
+        )
+        with self.subTest(msg="Test code handler"):
+            client.response_handler = api.code_handler
+            with self.assertRaises(requests.exceptions.HTTPError):
                 client.response_handler(mock_response)
 
-            # not all responses have valid json
-            mock_response.json = MagicMock(return_value="Not valid json")
-
-            with self.subTest(msg="Test code handler without json available"):
-                client.response_handler = api.code_handler
-                with self.assertRaises(requests.exceptions.HTTPError):
-                    client.response_handler(mock_response)
-
-            with self.subTest(msg="Test json handler without json available"):
-                client.response_handler = api.json_handler
-                with self.assertRaises(requests.exceptions.HTTPError):
-                    client.response_handler(mock_response)
-
-            with self.subTest(msg="Test echo handler without json available"):
-                client.response_handler = api.echo_handler
-                # no error should be raised with the echo handler
+        with self.subTest(msg="Test json handler"):
+            client.response_handler = api.json_handler
+            with self.assertRaises(requests.exceptions.HTTPError):
                 client.response_handler(mock_response)
+
+        with self.subTest(msg="Test echo handler"):
+            client.response_handler = api.echo_handler
+            # no error should be raised with the echo handler
+            client.response_handler(mock_response)
+
+        # not all responses have valid json
+        mock_response.json = MagicMock(return_value="Not valid json")
+
+        with self.subTest(msg="Test code handler without json available"):
+            client.response_handler = api.code_handler
+            with self.assertRaises(requests.exceptions.HTTPError):
+                client.response_handler(mock_response)
+
+        with self.subTest(msg="Test json handler without json available"):
+            client.response_handler = api.json_handler
+            with self.assertRaises(requests.exceptions.HTTPError):
+                client.response_handler(mock_response)
+
+        with self.subTest(msg="Test echo handler without json available"):
+            client.response_handler = api.echo_handler
+            # no error should be raised with the echo handler
+            client.response_handler(mock_response)
 
 
 class CredentialTestCase(unittest.TestCase):
     """Test :mod:camayoc.api."""
 
-    @classmethod
-    def setUpClass(cls):
-        """Create a parsed configuraton dictionary."""
-        cls.config = yaml.load(CAMAYOC_CONFIG, Loader=yaml.FullLoader)
-        cls.invalid_config = yaml.load(INVALID_HOST_CONFIG, Loader=yaml.FullLoader)
-
     def test_equivalent(self):
         """If a hostname is specified in the config file, we use it."""
-        with mock.patch.object(config, "get_config", return_value=self.config):
-            client = api.Client(authenticate=False)
-            h = Credential(
-                cred_type="network",
-                username=MOCK_CREDENTIAL["username"],
-                name=MOCK_CREDENTIAL["name"],
-                client=client,
-            )
-            h._id = MOCK_CREDENTIAL["id"]
-            self.assertTrue(h.equivalent(MOCK_CREDENTIAL))
-            self.assertTrue(h.equivalent(h))
-            with self.assertRaises(TypeError):
-                h.equivalent([])
+        client = api.Client(authenticate=False, config=CAMAYOC_CONFIG)
+        h = Credential(
+            cred_type="network",
+            username=MOCK_CREDENTIAL["username"],
+            name=MOCK_CREDENTIAL["name"],
+            client=client,
+        )
+        h._id = MOCK_CREDENTIAL["id"]
+        self.assertTrue(h.equivalent(MOCK_CREDENTIAL))
+        self.assertTrue(h.equivalent(h))
+        with self.assertRaises(TypeError):
+            h.equivalent([])
 
 
 class SourceTestCase(unittest.TestCase):
     """Test :mod:camayoc.api."""
 
-    @classmethod
-    def setUpClass(cls):
-        """Create a parsed configuraton dictionary."""
-        cls.config = yaml.load(CAMAYOC_CONFIG, Loader=yaml.FullLoader)
-        cls.invalid_config = yaml.load(INVALID_HOST_CONFIG, Loader=yaml.FullLoader)
-
     def test_equivalent_network(self):
         """If a hostname is specified in the config file, we use it."""
-        with mock.patch.object(config, "get_config", return_value=self.config):
-            client = api.Client(authenticate=False)
-            src = Source(
-                source_type="network",
-                name=MOCK_SOURCE["name"],
-                hosts=MOCK_SOURCE["hosts"],
-                credential_ids=[MOCK_SOURCE["credentials"][0]["id"]],
-                client=client,
-            )
-            src._id = MOCK_SOURCE["id"]
-            self.assertTrue(src.equivalent(MOCK_SOURCE))
-            self.assertTrue(src.equivalent(src))
-            with self.assertRaises(TypeError):
-                src.equivalent([])
+        client = api.Client(authenticate=False, config=CAMAYOC_CONFIG)
+        src = Source(
+            source_type="network",
+            name=MOCK_SOURCE["name"],
+            hosts=MOCK_SOURCE["hosts"],
+            credential_ids=[MOCK_SOURCE["credentials"][0]["id"]],
+            client=client,
+        )
+        src._id = MOCK_SOURCE["id"]
+        self.assertTrue(src.equivalent(MOCK_SOURCE))
+        self.assertTrue(src.equivalent(src))
+        with self.assertRaises(TypeError):
+            src.equivalent([])
 
     def test_equivalent_satellite(self):
         """If a hostname is specified in the config file, we use it."""
-        with mock.patch.object(config, "get_config", return_value=self.config):
-            client = api.Client(authenticate=False)
-            p = Source(
-                source_type="satellite",
-                name=MOCK_SAT6_SOURCE["name"],
-                hosts=MOCK_SAT6_SOURCE["hosts"],
-                credential_ids=[MOCK_SAT6_SOURCE["credentials"][0]["id"]],
-                options=MOCK_SAT6_SOURCE["options"],
-                port=443,
-                client=client,
-            )
-            p._id = MOCK_SAT6_SOURCE["id"]
-            self.assertTrue(p.equivalent(MOCK_SAT6_SOURCE))
-            self.assertTrue(p.equivalent(p))
-            with self.assertRaises(TypeError):
-                p.equivalent([])
+        client = api.Client(authenticate=False, config=CAMAYOC_CONFIG)
+        p = Source(
+            source_type="satellite",
+            name=MOCK_SAT6_SOURCE["name"],
+            hosts=MOCK_SAT6_SOURCE["hosts"],
+            credential_ids=[MOCK_SAT6_SOURCE["credentials"][0]["id"]],
+            options=MOCK_SAT6_SOURCE["options"],
+            port=443,
+            client=client,
+        )
+        p._id = MOCK_SAT6_SOURCE["id"]
+        self.assertTrue(p.equivalent(MOCK_SAT6_SOURCE))
+        self.assertTrue(p.equivalent(p))
+        with self.assertRaises(TypeError):
+            p.equivalent([])
 
 
 class ScanTestCase(unittest.TestCase):
     """Test :mod:camayoc.api."""
 
-    @classmethod
-    def setUpClass(cls):
-        """Create a parsed configuraton dictionary."""
-        cls.config = yaml.load(CAMAYOC_CONFIG, Loader=yaml.FullLoader)
-
     def test_equivalent(self):
         """If a hostname is specified in the config file, we use it."""
-        with mock.patch.object(config, "get_config", return_value=self.config):
-            scn = Scan(source_ids=[153], scan_type="connect", name=MOCK_SCAN["name"])
-            scn._id = MOCK_SCAN["id"]
-            self.assertTrue(scn.equivalent(MOCK_SCAN))
-            self.assertTrue(scn.equivalent(scn))
-            with self.assertRaises(TypeError):
-                scn.equivalent([])
+        client = api.Client(authenticate=False, config=CAMAYOC_CONFIG)
+        scn = Scan(source_ids=[153], scan_type="connect", name=MOCK_SCAN["name"], client=client)
+        scn._id = MOCK_SCAN["id"]
+        self.assertTrue(scn.equivalent(MOCK_SCAN))
+        self.assertTrue(scn.equivalent(scn))
+        with self.assertRaises(TypeError):
+            scn.equivalent([])
 
 
 class ScanJobTestCase(unittest.TestCase):
     """Test :mod:camayoc.api."""
 
-    @classmethod
-    def setUpClass(cls):
-        """Create a parsed configuraton dictionary."""
-        cls.config = yaml.load(CAMAYOC_CONFIG, Loader=yaml.FullLoader)
-
     def test_create(self):
         """If a hostname is specified in the config file, we use it."""
-        with mock.patch.object(config, "get_config", return_value=self.config):
-            job = ScanJob(scan_id=1)
-            job._id = 1
-            correct_payload = {"scan_id": 1}
-            self.assertEqual(job.payload(), correct_payload)
-            with self.assertRaises(NotImplementedError):
-                job.equivalent({})
+        client = api.Client(authenticate=False, config=CAMAYOC_CONFIG)
+        job = ScanJob(scan_id=1, client=client)
+        job._id = 1
+        correct_payload = {"scan_id": 1}
+        self.assertEqual(job.payload(), correct_payload)
+        with self.assertRaises(NotImplementedError):
+            job.equivalent({})

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,13 +1,10 @@
 from copy import deepcopy
 from pathlib import Path
-from unittest import mock
 
 import pytest
 import yaml
 from pydantic import ValidationError
 
-import camayoc.config
-from camayoc.config import get_config
 from camayoc.config import get_settings
 
 EXAMPLE_CONFIG_PATH = Path(__file__).parent / "../example_config.yaml"
@@ -99,11 +96,3 @@ def test_invalid_source_credential_type_mismatch(tmp_path, faker, example_config
 
     with pytest.raises(ValidationError):
         get_settings(config_file)
-
-
-def test_get_config_backward_compatibility():
-    global_settings = get_settings(path=EXAMPLE_CONFIG_PATH)
-    with mock.patch.object(camayoc.config, "settings", global_settings):
-        settings = get_config()
-        assert "qpc" in settings
-        assert "quipucords_server" not in settings

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,39 +3,31 @@
 from tempfile import mkdtemp
 from unittest import mock
 
-import pytest
-
-from camayoc import exceptions
 from camayoc import utils
+from camayoc.types.settings import QuipucordsServerOptions
 
 
 def test_get_qpc_url():
     """Test ``camayoc.utils.get_qpc_url``."""
-    with mock.patch("camayoc.utils.get_config") as get_config:
-        get_config.return_value = {
-            "qpc": {"hostname": "server.example.com", "https": True, "port": 443}
-        }
+    config = QuipucordsServerOptions(
+        hostname="server.example.com",
+        https=True,
+        port=443,
+        username="admin",
+        password="pass",
+        ssh_keyfile_path="/tmp/",
+    )
+    with mock.patch.object(utils, "settings") as get_config:
+        get_config.quipucords_server = config
         assert utils.get_qpc_url() == "https://server.example.com:443"
-
-
-def test_get_qpc_url_no_hostname():
-    """Test ``camayoc.utils.get_qpc_url`` when no hostname is present."""
-    with mock.patch("camayoc.utils.get_config") as get_config:
-        get_config.return_value = {"qpc": {"https": True, "port": 443}}
-        with pytest.raises(exceptions.QPCBaseUrlNotFound) as err:
-            utils.get_qpc_url()
-        assert (
-            'Make sure you have a "qpc" section and `hostname`is specified in '
-            "the camayoc config file"
-        ) in str(err.value)
 
 
 def test_isolated_filesystem():
     """Test default ``camayoc.utils.isolated_filesystem``."""
     with utils.isolated_filesystem() as path:
-        assert path.startswith("/tmp/") or path.startswith("/var/folders/"), (
-            "Make sure default isolated_filesystem " "creates the temp dir at '/tmp/'."
-        )
+        assert path.startswith("/tmp/") or path.startswith(
+            "/var/folders/"
+        ), "Make sure default isolated_filesystem creates the temp dir at '/tmp/'."
 
 
 def test_isolated_filesystem_w_path():


### PR DESCRIPTION
Remove old backwards compatibility shim and using configuration as dictionary, embrace strongly-typed `settings`.

The main change is that API client can be provided settings objects as parameter. This greatly simplifies unit tests.

Also - configuration fields like `hostname` are required and this condition is checked by pydantic when creating the object. We don't need to check if `hostname` is available when constructing the client - if we get that far, it means we do have `hostname`.

I took a bit of debt in `camayoc/tests/qpc/api/v1/utils.py` - the function in question is effectively replaced by data provider, but is never invoked for now as tests that use it are marked as skipped.