### PR TITLE
Add script to create OCP configs

### DIFF
--- a/scripts/create-camayoc-ocp-config.py
+++ b/scripts/create-camayoc-ocp-config.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+
+"""Create an OpenShift configuration for Camayoc.
+
+Given an OpenShift instance with credentials and URL to login,
+this program will create a Openshift configuration for Camayoc.
+
+Example:
+./create-camayoc-ocp-config.py \
+   --name shocp4upi415ovn \
+   --api-url api.shrocp4upi415ovn.lab \
+   --insecure \
+   --auth-token sha256~... \
+   --output config.local.yaml
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+import yaml
+
+
+def has_oc_command():
+    cmd = ["command", "-v", "oc"]
+    result = subprocess.run(cmd, capture_output=True, check=False, text=True)
+    return result.returncode == 0
+
+
+def login(args):
+    url = f"https://{args.api_url}:{args.port}"
+    insecure = f"--insecure-skip-tls-verify={args.insecure}"
+    if args.auth_token:
+        cmd = ["oc", "login", url, insecure, "--token", args.auth_token]
+    else:
+        cmd = ["oc", "login", url, insecure, "-u", args.username, "-p", args.password]
+    result = subprocess.run(cmd, capture_output=True, check=False, text=True)
+    return result.returncode == 0
+
+
+def get_auth_token():
+    cmd = ["oc", "whoami", "-t"]
+    result = subprocess.run(cmd, capture_output=True, check=True, text=True)
+    return result.stdout
+
+
+def get_cluster_id():
+    jsonpath = "{$.items[].spec.clusterID}"
+    cmd = ["oc", "get", "clusterversion", "-o", f"jsonpath={jsonpath}"]
+    result = subprocess.run(cmd, capture_output=True, check=True, text=True)
+    return result.stdout
+
+
+def get_cluster_version():
+    cmd = ["oc", "version", "-o", "json"]
+    result = subprocess.run(cmd, capture_output=True, check=True, text=True)
+    version = json.loads(result.stdout)
+    return version["openshiftVersion"]
+
+
+def get_cluster_nodes():
+    jsonpath = "{$.items[*].metadata.name}"
+    cmd = ["oc", "get", "nodes", "-o", f"jsonpath={jsonpath}"]
+    result = subprocess.run(cmd, capture_output=True, check=True, text=True)
+    nodes = result.stdout.split()
+    return nodes
+
+
+def get_cluster_operators():
+    jsonpath = "{$.items[*].metadata.name}"
+    cmd = ["oc", "get", "clusteroperators.config.openshift.io", "-o", f"jsonpath={jsonpath}"]
+    result = subprocess.run(cmd, capture_output=True, check=True, text=True)
+    operators = result.stdout.split()
+    return operators
+
+
+def create_ocp_configuration(args, cluster):
+    name_and_type = {"name": args.name, "type": "openshift"}
+    if args.auth_token:
+        auth_method = {"auth_token": args.auth_token}
+    else:
+        auth_method = {"username": args.username, "password": args.password}
+    credential = name_and_type | auth_method
+    source = name_and_type | {
+        "hosts": [args.api_url],
+        "credentials": [args.name],
+        "options": {"ssl_cert_verify": args.insecure},
+    }
+    scan = {
+        "name": args.name,
+        "sources": [args.name],
+        "expected_data": {args.name: {"cluster_info": cluster}},
+    }
+    config = {"credentials": [credential], "sources": [source], "scans": [scan]}
+    return yaml.dump(config, sort_keys=False)
+
+
+def create_configuration(args, cluster):
+    yaml_dynaconf_merge = f"dynaconf_merge: {'true' if args.dynaconf_merge else 'false'}"
+    ocp_output = create_ocp_configuration(args, cluster)
+    output = f"{yaml_dynaconf_merge}\n{ocp_output}"
+    with args.output as fd:
+        fd.write(output)
+
+
+def get_cluster_information():
+    cluster = {
+        "cluster_id": get_cluster_id(),
+        "version": get_cluster_version(),
+        "nodes": get_cluster_nodes(),
+        "operators": get_cluster_operators(),
+    }
+    return cluster
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Create an OpenShift configuration for Camayoc.",
+    )
+    parser.add_argument("-n", "--name", help="The common name for credentials, sources and scans.")
+    parser.add_argument("-a", "--api-url", required=True, help="Provide the API URL to log in.")
+    parser.add_argument("-P", "--port", type=int, default=6443, help="Provide the API port number.")
+    parser.add_argument(
+        "-k", "--insecure", action="store_false", help="Skip the SSL verification step."
+    )
+    parser.add_argument(
+        "-u", "--username", default="kubeadmin", help="Provide the username to log in."
+    )
+    parser.add_argument("-p", "--password", help="Provide the password to log in.")
+    parser.add_argument("-t", "--auth-token", help="Provide the token to log in.")
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=argparse.FileType("w", encoding="UTF-8"),
+        default=sys.stdout,
+        help="Write to file instead of stdout.",
+    )
+    parser.add_argument(
+        "-m",
+        "--dynaconf-merge",
+        action="store_true",
+        help="Merge configurations, otherwise overwrite. See also https://www.dynaconf.com/merging/",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Perform a trial run without connecting."
+    )
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    cluster_info = {}
+    args = parse_args()
+    if not args.dry_run:
+        if not has_oc_command():
+            print("Could not find the 'oc' command", file=sys.stderr)
+            return 1
+        if not login(args):
+            print(f"Could not log in to '{args.api_url}:{args.port}'", file=sys.stderr)
+            return 1
+        cluster_info = get_cluster_information()
+    create_configuration(args, cluster_info)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
"""Create an OpenShift configuration for Camayoc.                                                                                                                                
                                                                                                                                                                                 
Given an OpenShift instance with credentials and URL to login,                                                                                                                   
this program will create a Openshift configuration for Camayoc.                                                                                                                  
                                                                                                                                                                                 
Example:

Running...

```bash                                                                                                                                                             
./create-camayoc-ocp-config.py \                                                                                                                                                 
   --name shocp4upi415ovn \                                                                                                                                                      
   --api-url api.shrocp4upi415ovn.lab \                                                                                                                                                                                                                                                                                                  
   --password *********                                                                                                                                             
```

will display:

```
dynaconf_merge: false                                                                                                                                                            
credentials:                                                                                                                                                                     
- name: shrocp4upi415ovn                                                                                                                                                         
  type: openshift                                                                                                                                                                
  username: kubeadmin                                                                                                                                                            
  password: *********                                                                                                                                              
sources:                                                                                                                                                                         
- name: shrocp4upi415ovn                                                                                                                                                         
  type: openshift                                                                                                                                                                
  hosts:                                                                                                                                                                         
  - api.shrocp4upi415ovn.lab                                                                                                                             
  credentials:                                                                                                                                                                   
  - shrocp4upi415ovn                                                                                                                                                             
  options:                                                                                                                                                                       
    ssl_cert_verify: true                                       
scans:                                                                                                                                                                           
- name: shrocp4upi415ovn                                                                                                                                                         
  sources:                                                                                                                                                                       
  - shrocp4upi415ovn                                                                                                                                                             
  expected_data:      
    shrocp4upi415ovn:
      cluster_info:
        cluster_id: 7e4fd7d1-57a0-4e06-9e78-e4e085ec2a0e
        version: 4.15.0
        nodes:
        - master-0.shrocp4upi415ovn.lab
        - master-1.shrocp4upi415ovn.lab
        - master-2.shrocp4upi415ovn.lab
        - worker-0.shrocp4upi415ovn.lab
        - worker-1.shrocp4upi415ovn.lab
        - worker-2.shrocp4upi415ovn.lab
        operators:
        - authentication
        - baremetal
        - cloud-controller-manager
        - cloud-credential
        - cluster-autoscaler
        - config-operator
        - console
        - control-plane-machine-set
        - csi-snapshot-controller
        - dns
        - etcd
        - image-registry
        - ingress
        - insights
        - kube-apiserver
        - kube-controller-manager
        - kube-scheduler
        - kube-storage-version-migrator
        - machine-api
        - machine-approver
        - machine-config
        - marketplace
        - monitoring
        - network
        - node-tuning
        - openshift-apiserver
        - openshift-controller-manager
        - openshift-samples
        - operator-lifecycle-manager
        - operator-lifecycle-manager-catalog
        - operator-lifecycle-manager-packageserver
        - service-ca
        - storage
```