### PR TITLE
Add CLI test for insights report

### DIFF
--- a/camayoc/data_provider.py
+++ b/camayoc/data_provider.py
@@ -193,6 +193,10 @@ class ScanContainer:
         all_scans = [scan.name for scan in self._scan_definitions]
         return self._get_or_run_scans(all_scans, ok_only=True)
 
+    def with_name(self, scan_name: str) -> FinishedScan:
+        scans = self._get_or_run_scans([scan_name])
+        return scans[scan_name]
+
     def ok_with_expected_data_attr(self, attr_name) -> dict[str, FinishedScan]:
         wanted_scans = [
             scan.name

--- a/camayoc/tests/qpc/cli/utils.py
+++ b/camayoc/tests/qpc/cli/utils.py
@@ -231,6 +231,9 @@ report_deployments = functools.partial(cli_command, "{} -v report deployments".f
 report_download = functools.partial(cli_command, "{} -v report download".format(client_cmd))
 """Run ``qpc report download`` with ``options`` and return output."""
 
+report_insights = functools.partial(cli_command, "{} -v report insights".format(client_cmd))
+"""Run ``qpc report insights`` with ``options`` and return output."""
+
 
 def convert_ip_format(ipaddr):
     """Convert IP strings (for generating expected test results)."""

--- a/tests/test_scan_container.py
+++ b/tests/test_scan_container.py
@@ -93,6 +93,21 @@ def test_run_ok():
         assert len(scans) == 1
 
 
+def test_run_name():
+    """ScanContainer.with_name() runs only requested scan."""
+    dp = DataProvider(credentials=[], sources=[], scans=SCANS)
+    sc = ScanContainer(data_provider=dp, scans=SCANS)
+    with mock.patch.object(
+        sc, "_run_scans", autospec=True, side_effect=mocked_run_scans
+    ) as mock_run_scans:
+        scan = sc.with_name("networkscan")
+        assert mock_run_scans.call_count == 1
+        assert mock_run_scans.call_args.args == ({"networkscan"},)
+        assert len(sc._finished_scans) == 1
+        assert isinstance(scan, FinishedScan)
+        assert scan.definition.name == "networkscan"
+
+
 def test_expected_attr():
     """ScanContainer.ok_with_expected_data_attr() runs only scans with attr in expected data."""
     dp = DataProvider(credentials=[], sources=[], scans=SCANS)


### PR DESCRIPTION
#495 was incomplete - there was one more container-based test in upstream quipucords, one that verified that Insights report can be downloaded: https://github.com/quipucords/quipucords/pull/2625/files#diff-62b520bb21a93daf2ad93085612171507ac6119d939005e405da8150f975188eL532

This PR functionally ports it to Camayoc. Instead of using API, it uses CLI to obtain the report. It also runs some basic checks of the downloaded file, to verify that output looks like a valid Insights report.

Full Insights report flow is implemented in internal iqe-foreman-rh-cloud-plugin. That test uploads archive through Yuptoo, verifies that hosts appeared in HBI, syncs subscriptions and verifies that data there is correct. However, test executing this flow is not tied to our usual pipelines and is not triggered automatically as we make changes to Quipucords. 