### PR TITLE
Workaround DISCOVERY-531

### DIFF
--- a/camayoc/ui/client.py
+++ b/camayoc/ui/client.py
@@ -41,6 +41,11 @@ def requestfinished_handler_factory(ui_client):
         # we are only interested in client and server errors
         if 400 > response_status:
             return
+
+        # workaround for DISCOVERY-531
+        if "/reports/" in request.url and response_status == 424:
+            return
+
         error_msg = f"{request.method} {request.url} returned {response_status}"
         ui_client._log_page_error(error_msg)
 
@@ -88,6 +93,10 @@ class Client:
         self._base_url = urlunparse((scheme, netloc, "", "", "", ""))
 
     def _log_page_error(self, error: str):
+        # workaround for DISCOVERY-531
+        if "detected" in error and self.driver.url.endswith("client/scans"):
+            return
+
         context_msg = f"[issued by {self.driver.url}]"
         error_msg = f"{error} {context_msg}"
         self.page_errors.append(error_msg)


### PR DESCRIPTION
This introduces a workaround for DISCOVERY-531: 424 errors in response to `/reports/` endpoint, and JavaScript console errors on scans page are not going to be logged. This should prevent test teardown phase from erroring out.

This issue is related to timing, so it's hard to say if it will never happen again. I had another workaround prepared and I needed about 20 local runs of all e2e UI tests to encounter this problem once. I have run the same set of tests over 30 times with this patch on, and didn't have a single failure or error. That gives me confidence we should not see these pipelines failures again, but who knows.