### PR TITLE
Updates for create-camayoc-ocp-config script

### DIFF
--- a/scripts/create-camayoc-ocp-config.py
+++ b/scripts/create-camayoc-ocp-config.py
@@ -21,6 +21,9 @@ import sys
 
 import yaml
 
+# Time out limit (in seconds) to log in
+TIMEOUT = 60
+
 
 def has_oc_command():
     cmd = ["command", "-v", "oc"]
@@ -36,9 +39,12 @@ def login(args):
     else:
         cmd = ["oc", "login", url, insecure, "-u", args.username, "-p", args.password]
     try:
-        result = subprocess.run(cmd, capture_output=True, check=False, text=True)
+        result = subprocess.run(cmd, capture_output=True, check=False, text=True, timeout=TIMEOUT)
     except TypeError:
         print("Error: provide a password or authentication token to login!", file=sys.stderr)
+        return False
+    except subprocess.TimeoutExpired:
+        print(f"Error: login timed out after waiting for {TIMEOUT} second(s)", file=sys.stderr)
         return False
     return result.returncode == 0
 

--- a/scripts/create-camayoc-ocp-config.py
+++ b/scripts/create-camayoc-ocp-config.py
@@ -33,11 +33,12 @@ def has_oc_command():
 
 def login(args):
     url = f"https://{args.api_url}:{args.port}"
-    insecure = f"--insecure-skip-tls-verify={args.insecure}"
+    is_insecure_tls = "true" if args.insecure else "false"
+    insecure_tls_option = f"--insecure-skip-tls-verify={is_insecure_tls}"
     if args.auth_token:
-        cmd = ["oc", "login", url, insecure, "--token", args.auth_token]
+        cmd = ["oc", "login", url, insecure_tls_option, "--token", args.auth_token]
     else:
-        cmd = ["oc", "login", url, insecure, "-u", args.username, "-p", args.password]
+        cmd = ["oc", "login", url, insecure_tls_option, "-u", args.username, "-p", args.password]
     try:
         result = subprocess.run(cmd, capture_output=True, check=False, text=True, timeout=TIMEOUT)
     except TypeError:
@@ -141,7 +142,7 @@ def parse_args():
     )
     parser.add_argument("-P", "--port", type=int, default=6443, help="Provide the API port number.")
     parser.add_argument(
-        "-k", "--insecure", action="store_false", help="Skip the SSL verification step."
+        "-k", "--insecure", action="store_true", help="Skip the SSL verification step."
     )
     parser.add_argument(
         "-u", "--username", default="kubeadmin", help="Provide the username to log in."


### PR DESCRIPTION
* Fix: use correct logic to handle the insecure TLS connection option (`--insecure`).
* Feature: login now has a timeout for waiting to complete.

**Why are using timeout only for login?**

Because `oc login` may prompt for input if you don't pass `--insecure` option and you don't have the proper certs stored. The command will display and wait for input:

```
The server uses a certificate signed by an unknown authority.
You can bypass the certificate check, but any data you send to the server could be intercepted by others.
Use insecure connections? (y/n): 
```

and this is going to block forever.
So far, I don't believe the other commands prompts for input.

