### PR TITLE
fix: expect new `created_at` and `updated_at` fields

### DIFF
--- a/camayoc/tests/qpc/cli/test_reports.py
+++ b/camayoc/tests/qpc/cli/test_reports.py
@@ -44,6 +44,8 @@ REPORT_SOURCE_OPTIONS = ("report", "scan-job")
 """Options to generate reports from."""
 
 DEPLOYMENTS_REPORT_FIELDS = (
+    "created_at",
+    "updated_at",
     "architecture",
     "bios_uuid",
     "cloud_provider",


### PR DESCRIPTION
I believe this should fix the tests that are failing in camayoc as of https://github.com/quipucords/quipucords/pull/2639

Running locally on just the test that fails that PR:
```
poetry run pytest --verbose camayoc/tests/qpc/cli/test_reports.py::test_deployments_report
========================================================================== test session starts ==========================================================================
platform darwin -- Python 3.11.3, pytest-7.4.4, pluggy-1.4.0 -- /Users/brasmith/Library/Caches/pypoetry/virtualenvs/camayoc-uSBjm9lI-py3.11/bin/python
cachedir: .pytest_cache
rootdir: /Users/brasmith/projects/camayoc
configfile: pyproject.toml
plugins: ibutsu-2.2.4, Faker-20.1.0, cov-4.1.0, playwright-0.4.4, base-url-2.1.0
collected 4 items

camayoc/tests/qpc/cli/test_reports.py::test_deployments_report[json-scan-job] PASSED                                                                              [ 25%]
camayoc/tests/qpc/cli/test_reports.py::test_deployments_report[csv-report] PASSED                                                                                 [ 50%]
camayoc/tests/qpc/cli/test_reports.py::test_deployments_report[csv-scan-job] PASSED                                                                               [ 75%]
camayoc/tests/qpc/cli/test_reports.py::test_deployments_report[json-report] PASSED                                                                                [100%]

===================================================================== 4 passed in 124.48s (0:02:04) =====================================================================
```

Internal Jenkins job `discovery-standalone/86/` should use this `quipucords-pull-2639` camayoc branch with the image `quay.io/quipucords/quipucords:pr-2639` built for https://github.com/quipucords/quipucords/pull/2639.