### PR TITLE
Support new PatternFly version in UI

### DIFF
--- a/camayoc/ui/models/components/items_list.py
+++ b/camayoc/ui/models/components/items_list.py
@@ -33,7 +33,7 @@ class ItemsList(UIPage):
     # But YAGNI tells us this will do for now
     def _search_for_item_by_name(self, name: str):
         filter_field_button = self._driver.locator(
-            "div.pf-c-toolbar__content button[id]:has(span.pf-c-select__toggle-arrow)"
+            "div.pf-v5-c-toolbar__content button[id]:has(span.pf-v5-c-select__toggle-arrow)"
         ).locator("nth=0")
         if filter_field_button.text_content() != "Name":
             filter_field_button.click()

--- a/camayoc/ui/models/components/items_list.py
+++ b/camayoc/ui/models/components/items_list.py
@@ -33,7 +33,7 @@ class ItemsList(UIPage):
     # But YAGNI tells us this will do for now
     def _search_for_item_by_name(self, name: str):
         filter_field_button = self._driver.locator(
-            "div.pf-v5-c-toolbar__content button[id]:has(span.pf-v5-c-select__toggle-arrow)"
+            "div[class*=-c-toolbar__content] button[id]:has(span[class*=-c-select__toggle-arrow])"
         ).locator("nth=0")
         if filter_field_button.text_content() != "Name":
             filter_field_button.click()

--- a/camayoc/ui/models/components/popup.py
+++ b/camayoc/ui/models/components/popup.py
@@ -5,8 +5,8 @@ from camayoc.types.ui import UIPage
 
 
 class PopUp(UIPage):
-    SAVE_LOCATOR = ".pf-v5-c-modal-box__footer button.pf-m-primary"
-    CANCEL_LOCATOR = ".pf-v5-c-modal-box__footer button.pf-m-secondary"
+    SAVE_LOCATOR = "*[class*=-c-modal-box__footer] button.pf-m-primary"
+    CANCEL_LOCATOR = "*[class*=-c-modal-box__footer] button.pf-m-secondary"
     SAVE_RESULT_CLASS = None
     CANCEL_RESULT_CLASS = None
 

--- a/camayoc/ui/models/components/popup.py
+++ b/camayoc/ui/models/components/popup.py
@@ -5,8 +5,8 @@ from camayoc.types.ui import UIPage
 
 
 class PopUp(UIPage):
-    SAVE_LOCATOR = ".pf-c-modal-box__footer button.pf-m-primary"
-    CANCEL_LOCATOR = ".pf-c-modal-box__footer button.pf-m-secondary"
+    SAVE_LOCATOR = ".pf-v5-c-modal-box__footer button.pf-m-primary"
+    CANCEL_LOCATOR = ".pf-v5-c-modal-box__footer button.pf-m-secondary"
     SAVE_RESULT_CLASS = None
     CANCEL_RESULT_CLASS = None
 

--- a/camayoc/ui/models/components/toasts.py
+++ b/camayoc/ui/models/components/toasts.py
@@ -9,7 +9,7 @@ class ToastNotifications(UIPage):
     def _dismiss_notifications(self, ensure_notifications_appeared=False):
         default_timeout = 100  # milliseconds!
         current_timeout = 5000 if ensure_notifications_appeared else default_timeout
-        notifications_selector = ".pf-m-toast > li > .pf-v5-c-alert"
+        notifications_selector = ".pf-m-toast > li > *[class*=-c-alert]"
 
         notifications = self._driver.locator(notifications_selector)
         while True:

--- a/camayoc/ui/models/components/toasts.py
+++ b/camayoc/ui/models/components/toasts.py
@@ -9,7 +9,7 @@ class ToastNotifications(UIPage):
     def _dismiss_notifications(self, ensure_notifications_appeared=False):
         default_timeout = 100  # milliseconds!
         current_timeout = 5000 if ensure_notifications_appeared else default_timeout
-        notifications_selector = ".pf-m-toast > li > .pf-c-alert"
+        notifications_selector = ".pf-m-toast > li > .pf-v5-c-alert"
 
         notifications = self._driver.locator(notifications_selector)
         while True:

--- a/camayoc/ui/models/components/vertical_navigation.py
+++ b/camayoc/ui/models/components/vertical_navigation.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
     NavigateToPage = Union[CredentialsMainPage, ScansMainPage, SourcesMainPage]
 
-LEFT_NAV = "nav.pf-v5-c-nav"
+LEFT_NAV = "nav[class*=-c-nav]"
 
 
 class VerticalNavigation(UIPage):

--- a/camayoc/ui/models/components/vertical_navigation.py
+++ b/camayoc/ui/models/components/vertical_navigation.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
     NavigateToPage = Union[CredentialsMainPage, ScansMainPage, SourcesMainPage]
 
-LEFT_NAV = "nav.pf-c-nav"
+LEFT_NAV = "nav.pf-v5-c-nav"
 
 
 class VerticalNavigation(UIPage):

--- a/camayoc/ui/models/components/wizard.py
+++ b/camayoc/ui/models/components/wizard.py
@@ -6,9 +6,9 @@ from .popup import PopUp
 
 
 class WizardStep(PopUp, UIPage):
-    NEXT_STEP_LOCATOR = '.pf-c-wizard__footer button:has-text("Next")'
-    PREV_STEP_LOCATOR = '.pf-c-wizard__footer button:has-text("Back")'
-    CANCEL_LOCATOR = ".pf-c-wizard__footer .pf-c-wizard__footer-cancel button"
+    NEXT_STEP_LOCATOR = '.pf-v5-c-wizard__footer button:has-text("Next")'
+    PREV_STEP_LOCATOR = '.pf-v5-c-wizard__footer button:has-text("Back")'
+    CANCEL_LOCATOR = ".pf-v5-c-wizard__footer .pf-v5-c-wizard__footer-cancel button"
     NEXT_STEP_RESULT_CLASS = None
     PREV_STEP_RESULT_CLASS = None
     CANCEL_RESULT_CLASS = None

--- a/camayoc/ui/models/components/wizard.py
+++ b/camayoc/ui/models/components/wizard.py
@@ -6,9 +6,9 @@ from .popup import PopUp
 
 
 class WizardStep(PopUp, UIPage):
-    NEXT_STEP_LOCATOR = '.pf-v5-c-wizard__footer button:has-text("Next")'
-    PREV_STEP_LOCATOR = '.pf-v5-c-wizard__footer button:has-text("Back")'
-    CANCEL_LOCATOR = ".pf-v5-c-wizard__footer .pf-v5-c-wizard__footer-cancel button"
+    NEXT_STEP_LOCATOR = '*[class*=-c-wizard__footer] button:has-text("Next")'
+    PREV_STEP_LOCATOR = '*[class*=-c-wizard__footer] button:has-text("Back")'
+    CANCEL_LOCATOR = "*[class*=-c-wizard__footer] *[class*=-c-wizard__footer-cancel] button"
     NEXT_STEP_RESULT_CLASS = None
     PREV_STEP_RESULT_CLASS = None
     CANCEL_RESULT_CLASS = None

--- a/camayoc/ui/models/pages/scans.py
+++ b/camayoc/ui/models/pages/scans.py
@@ -16,7 +16,7 @@ from ..mixins import MainPageMixin
 
 class ScanListElem(AbstractListItem):
     def download_scan(self) -> Download:
-        scan_locator = "td.pf-v5-c-table__action button[data-ouia-component-id=download]"
+        scan_locator = "td[class*=-c-table__action] button[data-ouia-component-id=download]"
         timeout_start = time.monotonic()
         while 10 * 60 > (time.monotonic() - timeout_start):
             try:
@@ -27,7 +27,7 @@ class ScanListElem(AbstractListItem):
                 return download
             except PlaywrightTimeoutError:
                 self._client.driver.locator(
-                    "div.pf-v5-c-toolbar button[data-ouia-component-id=refresh]"
+                    "div[class*=-c-toolbar] button[data-ouia-component-id=refresh]"
                 ).click()
         raise FailedScanException("Scan could not be downloaded")
 

--- a/camayoc/ui/models/pages/scans.py
+++ b/camayoc/ui/models/pages/scans.py
@@ -16,7 +16,7 @@ from ..mixins import MainPageMixin
 
 class ScanListElem(AbstractListItem):
     def download_scan(self) -> Download:
-        scan_locator = "td.pf-c-table__action button[data-ouia-component-id=download]"
+        scan_locator = "td.pf-v5-c-table__action button[data-ouia-component-id=download]"
         timeout_start = time.monotonic()
         while 10 * 60 > (time.monotonic() - timeout_start):
             try:
@@ -27,7 +27,7 @@ class ScanListElem(AbstractListItem):
                 return download
             except PlaywrightTimeoutError:
                 self._client.driver.locator(
-                    "div.pf-c-toolbar button[data-ouia-component-id=refresh]"
+                    "div.pf-v5-c-toolbar button[data-ouia-component-id=refresh]"
                 ).click()
         raise FailedScanException("Scan could not be downloaded")
 

--- a/camayoc/ui/models/pages/sources.py
+++ b/camayoc/ui/models/pages/sources.py
@@ -32,8 +32,8 @@ from .abstract_page import AbstractPage
 
 
 class CancelWizardPopup(PopUp, AbstractPage):
-    SAVE_LOCATOR = ".pf-v5-c-modal-box__footer button.pf-m-primary:text-is('Yes')"
-    CANCEL_LOCATOR = ".pf-v5-c-modal-box__footer button.pf-m-secondary:text-is('No')"
+    SAVE_LOCATOR = "*[class*=-c-modal-box__footer] button.pf-m-primary:text-is('Yes')"
+    CANCEL_LOCATOR = "*[class*=-c-modal-box__footer] button.pf-m-secondary:text-is('No')"
     SAVE_RESULT_CLASS = Pages.SOURCES
     CANCEL_RESULT_CLASS = None
 
@@ -44,7 +44,7 @@ class SelectSourceTypeForm(Form, WizardStep, AbstractPage):
     CANCEL_RESULT_CLASS = CancelWizardPopup
 
     class FormDefinition:
-        source_type = RadioGroupField("div.pf-v5-c-wizard__main-body:not(.hidden)")
+        source_type = RadioGroupField("div[class*=-c-wizard__main-body]:not(.hidden)")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -71,7 +71,7 @@ class SelectSourceTypeForm(Form, WizardStep, AbstractPage):
 
 
 class SourceCredentialsForm(Form, WizardStep, AbstractPage):
-    NEXT_STEP_LOCATOR = '.pf-v5-c-wizard__footer button:has-text("Save")'
+    NEXT_STEP_LOCATOR = '*[class*=-c-wizard__footer] button:has-text("Save")'
     NEXT_STEP_RESULT_CLASS = Pages.SOURCES_RESULTS_PAGE
     PREV_STEP_RESULT_CLASS = SelectSourceTypeForm
     CANCEL_RESULT_CLASS = CancelWizardPopup
@@ -200,11 +200,11 @@ class RHACSSourceCredentialsForm(SourceCredentialsForm):
 
 
 class ResultForm(WizardStep, AbstractPage):
-    NEXT_STEP_LOCATOR = ".pf-v5-c-wizard__footer button.pf-m-primary"
+    NEXT_STEP_LOCATOR = "*[class*=-c-wizard__footer] button.pf-m-primary"
     NEXT_STEP_RESULT_CLASS = Pages.SOURCES
 
     def confirm(self):
-        locator_template = ".pf-v5-c-wizard svg[data-test-state={state}]"
+        locator_template = "*[class*=-c-wizard] svg[data-test-state={state}]"
         fulfilled_elem = self._driver.locator(locator_template.format(state="fulfilled"))
         error_elem = self._driver.locator(locator_template.format(state="error"))
         fulfilled_elem.or_(error_elem).hover(trial=True)

--- a/camayoc/ui/models/pages/sources.py
+++ b/camayoc/ui/models/pages/sources.py
@@ -32,8 +32,8 @@ from .abstract_page import AbstractPage
 
 
 class CancelWizardPopup(PopUp, AbstractPage):
-    SAVE_LOCATOR = ".pf-c-modal-box__footer button.pf-m-primary:text-is('Yes')"
-    CANCEL_LOCATOR = ".pf-c-modal-box__footer button.pf-m-secondary:text-is('No')"
+    SAVE_LOCATOR = ".pf-v5-c-modal-box__footer button.pf-m-primary:text-is('Yes')"
+    CANCEL_LOCATOR = ".pf-v5-c-modal-box__footer button.pf-m-secondary:text-is('No')"
     SAVE_RESULT_CLASS = Pages.SOURCES
     CANCEL_RESULT_CLASS = None
 
@@ -44,7 +44,7 @@ class SelectSourceTypeForm(Form, WizardStep, AbstractPage):
     CANCEL_RESULT_CLASS = CancelWizardPopup
 
     class FormDefinition:
-        source_type = RadioGroupField("div.pf-c-wizard__main-body:not(.hidden)")
+        source_type = RadioGroupField("div.pf-v5-c-wizard__main-body:not(.hidden)")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -71,7 +71,7 @@ class SelectSourceTypeForm(Form, WizardStep, AbstractPage):
 
 
 class SourceCredentialsForm(Form, WizardStep, AbstractPage):
-    NEXT_STEP_LOCATOR = '.pf-c-wizard__footer button:has-text("Save")'
+    NEXT_STEP_LOCATOR = '.pf-v5-c-wizard__footer button:has-text("Save")'
     NEXT_STEP_RESULT_CLASS = Pages.SOURCES_RESULTS_PAGE
     PREV_STEP_RESULT_CLASS = SelectSourceTypeForm
     CANCEL_RESULT_CLASS = CancelWizardPopup
@@ -200,11 +200,11 @@ class RHACSSourceCredentialsForm(SourceCredentialsForm):
 
 
 class ResultForm(WizardStep, AbstractPage):
-    NEXT_STEP_LOCATOR = ".pf-c-wizard__footer button.pf-m-primary"
+    NEXT_STEP_LOCATOR = ".pf-v5-c-wizard__footer button.pf-m-primary"
     NEXT_STEP_RESULT_CLASS = Pages.SOURCES
 
     def confirm(self):
-        locator_template = ".pf-c-wizard svg[data-test-state={state}]"
+        locator_template = ".pf-v5-c-wizard svg[data-test-state={state}]"
         fulfilled_elem = self._driver.locator(locator_template.format(state="fulfilled"))
         error_elem = self._driver.locator(locator_template.format(state="error"))
         fulfilled_elem.or_(error_elem).hover(trial=True)


### PR DESCRIPTION
This is Camayoc counterpart work for https://github.com/quipucords/quipucords-ui/pull/349 (updating old UI to PatternFly 5). If we release new UI version before this is merged, pipelines will break.

Commit 14fe8367998cbdc4065672d4c324444f58c01bff introduces changes needed for Camayoc to work with PatternFly 5, but at the expense of PatternFly 4 (i.e. on that commit Camayoc will pass against unreleased UI, but will fail when run against older UI versions).

Commit 522cebf7e7022f31d7f5c532e2191726454bca8d changes it further in a way that Camayoc can work against either PatternFly 4 or 5. Possibly it will also work against future versions of PatternFly.

I send this as 2 commits so we can discuss the best way to move forward. We can squash both commits and have Camayoc working against both older and newer PatternFly in UI. Or we can drop second commit and have Camayoc working only against PatternFly 5. In that case, we need to coordinate merge of that PR with UI version tagging.