### PR TITLE
Remove ruff warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ pre-commit:
 	poetry run pre-commit run --all-files
 
 lint:
-	poetry run ruff .
+	poetry run ruff check .
 	poetry run ruff format --check .
 
 test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,14 @@ markers = [
 ]
 
 [tool.ruff]
+src = [
+    "camayoc",
+    "tests",
+]
+target-version = "py311"
+line-length = 100
+
+[tool.ruff.lint]
 select = [
     "C90", # mccabe complexity
     "D",   # pydocstyle
@@ -92,14 +100,8 @@ ignore = [
     "D106",
     "D107",
 ]
-src = [
-    "camayoc",
-    "tests",
-]
-target-version = "py311"
-line-length = 100
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "D104"]
 "**/test_*.py" = [
     "PLC1901",
@@ -112,15 +114,14 @@ line-length = 100
 "camayoc/tests/qpc/utils.py" = ["PLW2901"]
 "tests/test_command.py" = ["F401"]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 force-single-line = true
 known-first-party = [
     "camayoc",
 ]
 
-
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 10
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "pep257"


### PR DESCRIPTION
#504 introduced a new version of ruff, which complains about our `pyproject.toml` and the way we invoke `ruff`. Our way still works, but issues warnings, and it's obvious it will stop working at some point in the future.

This PR makes changes recommended by ruff, so `make lint` finishes without warnings.