### PR TITLE
Fix to call the 'dsc' command properly in tests

### DIFF
--- a/camayoc/config.py
+++ b/camayoc/config.py
@@ -26,7 +26,6 @@ default_dynaconf_validators = [
     Validator("quipucords_server.password", default=""),
     Validator("quipucords_server.ssh_keyfile_path", default=""),
     Validator("quipucords_cli.executable", default="qpc"),
-    Validator("quipucords_cli.display_name", default="qpc"),
     Validator("credentials", default=[]),
     Validator("sources", default=[]),
     Validator("scans", default=[]),

--- a/camayoc/tests/qpc/cli/test_scans.py
+++ b/camayoc/tests/qpc/cli/test_scans.py
@@ -14,7 +14,7 @@ import re
 import pytest
 
 from camayoc.tests.qpc.utils import all_source_names
-from camayoc.utils import client_cmd_name
+from camayoc.utils import client_cmd
 from camayoc.utils import uuid4
 
 from .utils import scan_add_and_check
@@ -308,7 +308,7 @@ def test_edit_scan_negative(isolated_filesystem, qpc_server_config, data_provide
     # Edit scan options
     scan_edit_and_check(
         {"name": scan_name, "sources": ""},
-        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd_name),
+        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd),
         exitstatus=2,
     )
 
@@ -322,7 +322,7 @@ def test_edit_scan_negative(isolated_filesystem, qpc_server_config, data_provide
     # Edit scan options
     scan_edit_and_check(
         {"name": scan_name, "sources": source.name, "max-concurrency": "abc"},
-        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd_name),
+        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd),
         exitstatus=2,
     )
 
@@ -333,7 +333,7 @@ def test_edit_scan_negative(isolated_filesystem, qpc_server_config, data_provide
             "sources": "",
             "disabled-optional-products": "not_a_real_product",
         },
-        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd_name),
+        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd),
         exitstatus=2,
     )
 
@@ -344,14 +344,14 @@ def test_edit_scan_negative(isolated_filesystem, qpc_server_config, data_provide
             "sources": "",
             "enabled-ext-product-search": "not_a_real_product",
         },
-        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd_name),
+        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd),
         exitstatus=2,
     )
 
     # Edit ext-product-search-dirs
     scan_edit_and_check(
         {"name": scan_name, "sources": "", "ext-product-search-dirs": "not-a-dir"},
-        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd_name),
+        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd),
         exitstatus=2,
     )
 

--- a/camayoc/tests/qpc/cli/test_sources.py
+++ b/camayoc/tests/qpc/cli/test_sources.py
@@ -30,7 +30,6 @@ from camayoc.tests.qpc.cli.utils import source_add_and_check
 from camayoc.tests.qpc.cli.utils import source_edit_and_check
 from camayoc.tests.qpc.cli.utils import source_show_and_check
 from camayoc.utils import client_cmd
-from camayoc.utils import client_cmd_name
 
 ISSUE_449_MARK = pytest.mark.xfail(
     reason="https://github.com/quipucords/quipucords/issues/449", strict=True
@@ -342,7 +341,7 @@ def test_add_with_ssl_cert_verify_negative(isolated_filesystem, qpc_server_confi
     qpc_source_add = pexpect.spawn(
         "{} source add --name {} --cred {} --hosts {} --port {} "
         "--ssl-cert-verify {} --type {}".format(
-            client_cmd_name, name, cred_name, hosts, port, ssl_cert_verify, source_type
+            client_cmd, name, cred_name, hosts, port, ssl_cert_verify, source_type
         )
     )
     assert qpc_source_add.expect(expected_error) == 0

--- a/camayoc/types/settings.py
+++ b/camayoc/types/settings.py
@@ -27,7 +27,6 @@ class QuipucordsServerOptions(BaseModel):
 
 class QuipucordsCLIOptions(BaseModel):
     executable: Optional[str] = "qpc"
-    display_name: Optional[str] = "qpc"
 
 
 class PlainNetworkCredentialOptions(BaseModel):

--- a/camayoc/utils.py
+++ b/camayoc/utils.py
@@ -19,10 +19,6 @@ _XDG_ENV_VARS = ("XDG_DATA_HOME", "XDG_CONFIG_HOME", "XDG_CACHE_HOME")
 client_cmd = settings.quipucords_cli.executable
 """Client command to use during tests. Defaults to `qpc`."""
 
-client_cmd_name = settings.quipucords_cli.display_name
-"""Client name displayed on help texts. Defaults to `qpc`."""
-# this is useful when client_cmd is set to an absolute path, has extra arguments like -v
-
 
 def get_qpc_url():
     """Return the base url for the qpc server."""


### PR DESCRIPTION
When I installed the `dsc` CLI from RPM, I've discovered that some tests were failing because they're using `qpc` as the discovery command line name instead of `dsc`. This PR fix this misbehavior.