### PR TITLE
Change CLI tests to use client_cmd instead of client_cmd_name

### DIFF
--- a/camayoc/tests/qpc/cli/test_scans.py
+++ b/camayoc/tests/qpc/cli/test_scans.py
@@ -14,7 +14,7 @@ import re
 import pytest
 
 from camayoc.tests.qpc.utils import all_source_names
-from camayoc.utils import client_cmd_name
+from camayoc.utils import client_cmd
 from camayoc.utils import uuid4
 
 from .utils import scan_add_and_check
@@ -308,7 +308,7 @@ def test_edit_scan_negative(isolated_filesystem, qpc_server_config, data_provide
     # Edit scan options
     scan_edit_and_check(
         {"name": scan_name, "sources": ""},
-        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd_name),
+        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd),
         exitstatus=2,
     )
 
@@ -322,7 +322,7 @@ def test_edit_scan_negative(isolated_filesystem, qpc_server_config, data_provide
     # Edit scan options
     scan_edit_and_check(
         {"name": scan_name, "sources": source.name, "max-concurrency": "abc"},
-        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd_name),
+        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd),
         exitstatus=2,
     )
 
@@ -333,7 +333,7 @@ def test_edit_scan_negative(isolated_filesystem, qpc_server_config, data_provide
             "sources": "",
             "disabled-optional-products": "not_a_real_product",
         },
-        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd_name),
+        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd),
         exitstatus=2,
     )
 
@@ -344,14 +344,14 @@ def test_edit_scan_negative(isolated_filesystem, qpc_server_config, data_provide
             "sources": "",
             "enabled-ext-product-search": "not_a_real_product",
         },
-        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd_name),
+        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd),
         exitstatus=2,
     )
 
     # Edit ext-product-search-dirs
     scan_edit_and_check(
         {"name": scan_name, "sources": "", "ext-product-search-dirs": "not-a-dir"},
-        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd_name),
+        r"usage: {} scan edit(.|[\r\n])*".format(client_cmd),
         exitstatus=2,
     )
 

--- a/camayoc/tests/qpc/cli/test_sources.py
+++ b/camayoc/tests/qpc/cli/test_sources.py
@@ -30,7 +30,6 @@ from camayoc.tests.qpc.cli.utils import source_add_and_check
 from camayoc.tests.qpc.cli.utils import source_edit_and_check
 from camayoc.tests.qpc.cli.utils import source_show_and_check
 from camayoc.utils import client_cmd
-from camayoc.utils import client_cmd_name
 
 ISSUE_449_MARK = pytest.mark.xfail(
     reason="https://github.com/quipucords/quipucords/issues/449", strict=True
@@ -342,7 +341,7 @@ def test_add_with_ssl_cert_verify_negative(isolated_filesystem, qpc_server_confi
     qpc_source_add = pexpect.spawn(
         "{} source add --name {} --cred {} --hosts {} --port {} "
         "--ssl-cert-verify {} --type {}".format(
-            client_cmd_name, name, cred_name, hosts, port, ssl_cert_verify, source_type
+            client_cmd, name, cred_name, hosts, port, ssl_cert_verify, source_type
         )
     )
     assert qpc_source_add.expect(expected_error) == 0


### PR DESCRIPTION
Note: this is an alternative to PR #512 . This MR just change the tests and nothing more than this.

Camayoc has two places to get the discovery cli command,

```
camayoc/utils.py:client_cmd = settings.quipucords_cli.executable
camayoc/utils.py:client_cmd_name = settings.quipucords_cli.display_name
```

Some of CLI tests for sources and scans are using client_cmd_name and unfortunally if you set Camayoc to use 'dsc' for the CLI, then client_cmd sets to dsc and client_cmd_name takes the default value 'qpc'. This setup will make the tests to fail.

Let's use client_cmd like any other CLI tests do.