### PR TITLE
Add a basic test covering aggregate report

### DIFF
--- a/camayoc/tests/qpc/cli/utils.py
+++ b/camayoc/tests/qpc/cli/utils.py
@@ -196,6 +196,9 @@ report_download = functools.partial(cli_command, "{} -v report download".format(
 report_insights = functools.partial(cli_command, "{} -v report insights".format(client_cmd))
 """Run ``qpc report insights`` with ``options`` and return output."""
 
+report_aggregate = functools.partial(cli_command, "{} -v report aggregate".format(client_cmd))
+"""Run ``qpc report aggregate`` with ``options`` and return output."""
+
 
 def convert_ip_format(ipaddr):
     """Convert IP strings (for generating expected test results)."""


### PR DESCRIPTION
This test only downloads aggregate report and confirms that JSON file comes back.

It depends on https://github.com/quipucords/qpc/pull/341 , so Jenkins is likely to fail until that is merged.