### PR TITLE
Stop depending on openshift source and scan having the same name

### DIFF
--- a/camayoc/tests/qpc/cli/test_openshift.py
+++ b/camayoc/tests/qpc/cli/test_openshift.py
@@ -123,7 +123,7 @@ def openshift_sources():
 
 def openshift_cluster_info(name):
     for scan_info in settings.scans:
-        if name == scan_info.name:
+        if name in scan_info.sources:
             return scan_info.expected_data[scan_info.name].cluster_info
 
 


### PR DESCRIPTION
openshift_cluster_info receives source name as an argument. While in about every single instance it is the same as scan name (especially since `./scripts/create-camayoc-ocp-config.py` has been introduced), technically they can be different.

This partly resolves DISCOVERY-492