### PR TITLE
Introduce (pr|nightly)_only markers, split out UI tests that can use scans fixture

### DIFF
--- a/camayoc/data_provider.py
+++ b/camayoc/data_provider.py
@@ -178,6 +178,9 @@ class DataProvider:
         )
         sort_and_delete(trash)
 
+        for store in self._stores:
+            getattr(self, store)._created_models.clear()
+
 
 class ScanContainer:
     def __init__(self, data_provider: DataProvider, scans=settings.scans):

--- a/camayoc/tests/conftest.py
+++ b/camayoc/tests/conftest.py
@@ -10,11 +10,18 @@ from camayoc.config import settings
 def pytest_collection_modifyitems(
     session: pytest.Session, items: list[pytest.Item], config: pytest.Config
 ) -> None:
-    for clear_all_idx, node in enumerate(items):
-        if node.nodeid.endswith("test_credentials.py::test_clear_all"):
-            break
-    clear_all_node = items.pop(clear_all_idx)
-    items.insert(0, clear_all_node)
+    cleaning_dp_node_idxs = []
+    for node_idx, node in enumerate(items):
+        if "cleaning_data_provider" in node.fixturenames:
+            cleaning_dp_node_idxs.append(node_idx)
+
+    cleaning_dp_nodes = []
+    for node_idx in sorted(cleaning_dp_node_idxs, reverse=True):
+        node = items.pop(node_idx)
+        cleaning_dp_nodes.append(node)
+
+    for node in reversed(cleaning_dp_nodes):
+        items.insert(0, node)
 
 
 @pytest.fixture

--- a/camayoc/tests/qpc/cli/test_credentials.py
+++ b/camayoc/tests/qpc/cli/test_credentials.py
@@ -632,7 +632,7 @@ def test_clear_negative(isolated_filesystem, qpc_server_config):
     assert qpc_cred_clear.exitstatus == 1
 
 
-def test_clear_all(isolated_filesystem, qpc_server_config):
+def test_clear_all(isolated_filesystem, qpc_server_config, cleaning_data_provider):
     """Clear all auth entries.
 
     :id: 16aa6914-e7ae-400f-b12b-6c9d218c4e0f

--- a/camayoc/tests/qpc/cli/test_scans.py
+++ b/camayoc/tests/qpc/cli/test_scans.py
@@ -394,7 +394,7 @@ def test_clear(isolated_filesystem, qpc_server_config, data_provider, source_nam
     assert match is not None
 
 
-def test_clear_all(isolated_filesystem, qpc_server_config, data_provider):
+def test_clear_all(isolated_filesystem, qpc_server_config, cleaning_data_provider):
     """Clear all scans.
 
     :id: 29e37620-3682-11e8-b467-0ed5f89f718b
@@ -406,7 +406,7 @@ def test_clear_all(isolated_filesystem, qpc_server_config, data_provider):
     :expectedresults: All scans entries are removed.
     """
     # Create scan
-    source = data_provider.sources.defined_one({"type": "network"})
+    source = cleaning_data_provider.sources.defined_one({"type": "network"})
     scan_name = uuid4()
     scan_add_and_check({"name": scan_name, "sources": source.name})
 

--- a/camayoc/tests/qpc/cli/test_sources.py
+++ b/camayoc/tests/qpc/cli/test_sources.py
@@ -1624,7 +1624,7 @@ def test_clear_negative(isolated_filesystem, qpc_server_config):
     assert qpc_source_clear.exitstatus == 1
 
 
-def test_clear_all(isolated_filesystem, qpc_server_config, source_type):
+def test_clear_all(cleaning_data_provider, isolated_filesystem, qpc_server_config, source_type):
     """Clear all sources.
 
     :id: 23234cc2-fb41-4bc4-973a-7c850b998467

--- a/camayoc/tests/qpc/conftest.py
+++ b/camayoc/tests/qpc/conftest.py
@@ -5,7 +5,7 @@ import pytest
 from camayoc import api
 from camayoc.data_provider import DataProvider
 from camayoc.data_provider import ScanContainer
-from camayoc.tests.qpc.utils import sort_and_delete
+from camayoc.tests.qpc.cli.utils import clear_all_entities
 
 
 @pytest.fixture(scope="session")
@@ -17,14 +17,11 @@ def data_provider():
     dp.cleanup()
 
 
-@pytest.fixture(scope="function")
-def cleanup():
-    """Fixture that cleans up any created quipucords objects after a test."""
-    trash = []
-
-    yield trash
-
-    sort_and_delete(trash)
+@pytest.fixture(scope="module")
+def cleaning_data_provider(data_provider):
+    data_provider.cleanup()
+    clear_all_entities()
+    return data_provider
 
 
 @pytest.fixture(scope="session")

--- a/camayoc/tests/qpc/ui/conftest.py
+++ b/camayoc/tests/qpc/ui/conftest.py
@@ -3,7 +3,6 @@
 import pytest
 
 from camayoc.config import settings
-from camayoc.tests.qpc.cli.utils import clear_all_entities
 from camayoc.ui import Client as UIClient
 from camayoc.ui.session import BasicSession
 
@@ -27,13 +26,6 @@ def browser_context_args(browser_context_args):
         extra_context_args["ignore_https_errors"] = True
 
     return {**browser_context_args, **extra_context_args}
-
-
-@pytest.fixture(scope="module")
-def data_provider(data_provider):
-    data_provider.cleanup()
-    clear_all_entities()
-    return data_provider
 
 
 @pytest.fixture

--- a/camayoc/tests/qpc/ui/test_endtoend.py
+++ b/camayoc/tests/qpc/ui/test_endtoend.py
@@ -64,7 +64,7 @@ def source_names():
 
 
 @pytest.mark.parametrize("source_name", source_names())
-def test_end_to_end(data_provider, ui_client: Client, source_name):
+def test_end_to_end(cleaning_data_provider, ui_client: Client, source_name):
     """End-to-end test using web user interface.
 
     :id: f187fbd0-021c-4563-9691-61e54eb272bf
@@ -80,7 +80,9 @@ def test_end_to_end(data_provider, ui_client: Client, source_name):
     :expectedresults: Credential and Source are created. Scan is completed.
         Report is downloaded. User is logged out.
     """
-    credential_dto, source_dto, trigger_scan_dto = create_endtoend_dtos(source_name, data_provider)
+    credential_dto, source_dto, trigger_scan_dto = create_endtoend_dtos(
+        source_name, cleaning_data_provider
+    )
     (
         ui_client.begin()
         .login(data_factories.LoginFormDTOFactory())
@@ -127,7 +129,7 @@ def test_end_to_end(data_provider, ui_client: Client, source_name):
 
 @pytest.mark.skip("Skipped due to intermittent failure - DISCOVERY-426")
 @pytest.mark.parametrize("source_name", source_names())
-def test_trigger_scan(data_provider, ui_client: Client, source_name):
+def test_trigger_scan(cleaning_data_provider, ui_client: Client, source_name):
     """Mostly end-to-end test using web user interface (without downloading scan results).
 
     :id: ae8b2d7d-8ac2-4957-a67a-6dedd80f4f31
@@ -144,7 +146,9 @@ def test_trigger_scan(data_provider, ui_client: Client, source_name):
     :expectedresults: Credential and Source are created. Scan has started.
         User is logged out.
     """
-    credential_dto, source_dto, trigger_scan_dto = create_endtoend_dtos(source_name, data_provider)
+    credential_dto, source_dto, trigger_scan_dto = create_endtoend_dtos(
+        source_name, cleaning_data_provider
+    )
     scans_page = (
         ui_client.begin()
         .login(data_factories.LoginFormDTOFactory())

--- a/camayoc/tests/qpc/ui/test_scans.py
+++ b/camayoc/tests/qpc/ui/test_scans.py
@@ -1,0 +1,66 @@
+"""Web user interface scan tests.
+
+:caseautomation: automated
+:casecomponent: ui
+:caseimportance: medium
+:caselevel: integration
+:testtype: functional
+"""
+
+import tarfile
+
+import pytest
+
+from camayoc.config import settings
+from camayoc.tests.qpc.utils import assert_ansible_logs
+from camayoc.tests.qpc.utils import assert_sha256sums
+from camayoc.ui import Client
+from camayoc.ui import data_factories
+from camayoc.ui.enums import MainMenuPages
+
+
+def has_network_source(scan_name):
+    network_sources = set([source.name for source in settings.sources if source.type == "network"])
+    for scan_definition in settings.scans:
+        if scan_definition.name != scan_name:
+            continue
+        scan_sources = set(scan_definition.sources)
+        return bool(network_sources.intersection(scan_sources))
+
+
+def scan_names():
+    for scan_definition in settings.scans:
+        yield pytest.param(scan_definition.name)
+
+
+@pytest.mark.pr_only
+@pytest.mark.parametrize("scan_name", scan_names())
+def test_download_scan(tmp_path, scans, ui_client: Client, scan_name):
+    """Download finished scan and verify basic content properties.
+
+    :id: 66abf967-24f1-43cb-9375-c1a5e519a0e6
+    :description: This is the last part of end-to-end user journey through web
+        user interface. It is split out from end_to_end test to allow usage of
+        cached scans results.
+    :steps:
+        1) Log into the UI.
+        2) Download finished scan report.
+        3) Verify downloaded file looks like a valid scan.
+        4) Log out.
+    :expectedresults: Report is downloaded. User is logged out.
+    """
+    finished_scan = scans.with_name(scan_name)
+    (
+        ui_client.begin()
+        .login(data_factories.LoginFormDTOFactory())
+        .navigate_to(MainMenuPages.SCANS)
+        .download_scan(finished_scan.definition.name)
+        .logout()
+    )
+
+    is_network_scan = has_network_source(scan_name)
+    downloaded_report = ui_client.downloaded_files[-1]
+
+    tarfile.open(downloaded_report.path()).extractall(tmp_path)
+    assert_sha256sums(tmp_path)
+    assert_ansible_logs(tmp_path, is_network_scan)

--- a/camayoc/tests/qpc/ui/test_sources.py
+++ b/camayoc/tests/qpc/ui/test_sources.py
@@ -107,7 +107,7 @@ def create_source_dto(source_type, data_provider):
 
 # FIXME: this never actually deletes in UI
 @pytest.mark.parametrize("source_type", get_args(SourceFormDTO))
-def test_create_delete_source(data_provider, ui_client: Client, source_type):
+def test_create_delete_source(cleaning_data_provider, ui_client: Client, source_type):
     """Create and then delete a source through the UI.
 
     :id: b1f64fd6-0421-4650-aa6d-149cb3099012
@@ -119,7 +119,7 @@ def test_create_delete_source(data_provider, ui_client: Client, source_type):
     :expectedresults: A new source is created with the provided information,
         then it is deleted.
     """
-    source_dto = create_source_dto(source_type, data_provider)
+    source_dto = create_source_dto(source_type, cleaning_data_provider)
     (
         ui_client.begin()
         .login(data_factories.LoginFormDTOFactory())

--- a/camayoc/tests/qpc/utils.py
+++ b/camayoc/tests/qpc/utils.py
@@ -61,6 +61,36 @@ def get_expected_sha256sums(directory):
     return parsed_shasums
 
 
+def assert_sha256sums(directory: Path):
+    """Verify SHA256 sums of files match. Tests helper."""
+    actual_shasums = calculate_sha256sums(directory)
+    expected_shasums = get_expected_sha256sums(directory)
+
+    for filename, expected_shasum in expected_shasums.items():
+        actual_shasum = actual_shasums.get(filename)
+        assert actual_shasum == expected_shasum
+
+
+def assert_ansible_logs(directory: Path, is_network_scan: bool):
+    """Verify that ansible log files exist (or not). Tests helper."""
+    has_ansible_logs = False
+    for file in directory.rglob("*"):
+        if not file.is_file():
+            continue
+
+        # Ansible STDERR may or may not be empty, no point in asserting size
+        if "ansible-stderr" in file.name:
+            has_ansible_logs = True
+            continue
+
+        if "ansible-stdout" in file.name:
+            has_ansible_logs = True
+
+        assert file.stat().st_size > 0
+
+    assert is_network_scan == has_ansible_logs
+
+
 def get_object_id(obj):
     """Get id of object whose name is known."""
     if obj._id:

--- a/camayoc/ui/models/components/items_list.py
+++ b/camayoc/ui/models/components/items_list.py
@@ -21,7 +21,9 @@ class ItemsList(UIPage):
 
     def _get_item_from_current_list(self, name: str):
         default_timeout = 5000  # 5s
-        item_elem = self._driver.locator("css=strong").filter(has_text=name)
+        item_elem = self._driver.locator("css=strong").filter(
+            has=self._driver.get_by_text(name, exact=True)
+        )
         item_elem_locator = "xpath=./ancestor::tr[contains(@class, 'quipucords-table__tr')]"
         item_elem = item_elem.locator(item_elem_locator)
         item_elem.hover(timeout=default_timeout, trial=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,8 @@ filterwarnings = "ignore::urllib3.exceptions.InsecureRequestWarning"
 markers = [
     "ssh_keyfile_path: mark test with SSH key file path mapped to /sshkeys/ on the server (deselect with '-m \"not ssh_keyfile_path\"')",
     "runs_scan: tests that run scans (might be slow!)",
+    "nightly_only: tests to execute only during nightly (or full) run, i.e. not during PR check; note that actual selection is implemented in discovery-ci",
+    "pr_only: tests to execute only during PR check run, i.e. not during nightly run; note that actual selection is implemented in discovery-ci",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
Introduce `pr_only` and `nightly_only` pytest markers, which allows tests to be marked for execution on PR job or nightly job. Tests not marked with either will be run in both.

With that as a foundation, split out UI end to end test into UI scan test that takes advantage of `scans` fixture and downloads a scan result created earlier for API/CLI report tests. These new scan tests are marked for PR job execution only. This should speed up PR test execution by few minutes.

UI tests used their own `data_provider` fixture that cleaned things up before running a test, to work around DISCOVERY-162. Since new scan tests depend on data being kept around, introduce new `cleaning_data_provider` that does the same thing. All tests using that fixture are moved to the beginning of test run. Changed few other tests running `qpc clear --all` to use this new fixture, or they would end up removing data that scan UI tests depended on.

Actual filtering out of tests marked with new markers is implemented in discovery-ci PR 85.