### PR TITLE
Ensure data known to ScanContainer is in sync with DataProvider

### DIFF
--- a/camayoc/data_provider.py
+++ b/camayoc/data_provider.py
@@ -207,6 +207,7 @@ class ScanContainer:
         return self._get_or_run_scans(scans=wanted_scans, ok_only=True)
 
     def _get_or_run_scans(self, scans: Sequence[str], ok_only=False) -> dict[str, FinishedScan]:
+        self._sync_finished_scans_with_dp()
         self._ensure_wanted_scans_finished(scans)
 
         scans_to_return = [
@@ -223,6 +224,22 @@ class ScanContainer:
         scans_to_return = {scan.definition.name: scan for scan in scans_to_return}
 
         return scans_to_return
+
+    def _sync_finished_scans_with_dp(self) -> None:
+        dp_scans = set(self._dp.scans._created_models.keys())
+        finished_scans = set(self._finished_scans.keys())
+        missing_in_dp = finished_scans - dp_scans
+        if missing_in_dp:
+            logger.warning(
+                (
+                    "Some scans are known to ScanContainer, but not DataProvider. "
+                    "Likely some test called data_provider.cleanup() between two tests using "
+                    "scans fixture. Scans that are missing: %s"
+                ),
+                missing_in_dp,
+            )
+        for extra_scan in missing_in_dp:
+            self._finished_scans.pop(extra_scan)
 
     def _ensure_wanted_scans_finished(self, scans: Sequence[str]):
         finished_scans = set(self._finished_scans.keys())


### PR DESCRIPTION
While working on #523, I found new tests are failing because some other tests are removing data. Since `DataProvider.cleanup()` may remove cache, there's no reason for `ScanContainer` to keep it.

This protects a tests run against a following scenario:

1. Have tests create scans using `scans` fixture
2. Have another test remove data using `data_provider.cleanup()`
3. Have another test try to use `scans` - data is removed and `data_provider` removed references, but `ScanContainer` is not aware of that

Unfortunately, a number of tests remove data using things like `qpc clear --all`, without ever informing DataProvider. So this is not a solution for general problem of test framework getting out of sync with data actually stored in the server. 

In other words, this is theoretically correct thing to do, with minimal pragmatic impact.