### PR TITLE
get-version.py: Make RPM case more robust

### DIFF
--- a/scripts/get-version.py
+++ b/scripts/get-version.py
@@ -43,6 +43,8 @@ def get_cli_version():
         ]
         rpm_qa_result = subprocess.run(cmd, capture_output=True, check=True, text=True)
         for pkg_line in rpm_qa_result.stdout.split("\n"):
+            if not pkg_line:
+                continue
             pkg_name, pkg_version = pkg_line.split(":", maxsplit=1)
             if pkg_name in ("qpc", "discovery-cli"):
                 return pkg_version


### PR DESCRIPTION
Since rpm command output is split on new line, and every single package line ends with it, at the very end of split there will be an empty string. Trying to split it again on colon raises ValueError.

Let loop skip empty values and gracefully continue to git case.