### PR TITLE
DISCOVERY-621: Mark slow tests

### DIFF
--- a/camayoc/tests/qpc/api/v1/reports/test_reports.py
+++ b/camayoc/tests/qpc/api/v1/reports/test_reports.py
@@ -25,6 +25,7 @@ has_installed_products = partial(expected_data_has_attribute, attr_name="install
 has_raw_facts = partial(expected_data_has_attribute, attr_name="raw_facts")
 
 
+@pytest.mark.slow
 @pytest.mark.runs_scan
 @pytest.mark.parametrize("scan_name", scan_names(has_product))
 def test_products_found_deployment_report(scans, scan_name):
@@ -96,6 +97,7 @@ def test_products_found_deployment_report(scans, scan_name):
     )
 
 
+@pytest.mark.slow
 @pytest.mark.runs_scan
 @pytest.mark.parametrize("scan_name", scan_names(has_distribution))
 def test_OS_found_deployment_report(scans, scan_name):

--- a/camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py
+++ b/camayoc/tests/qpc/api/v1/scanjobs/test_run_scanjobs.py
@@ -16,6 +16,7 @@ from camayoc.tests.qpc.utils import all_scan_names
 from camayoc.types.scans import ScanSimplifiedStatusEnum
 
 
+@pytest.mark.slow
 @pytest.mark.runs_scan
 @pytest.mark.parametrize("scan_name", all_scan_names())
 def test_scan_complete(scans, scan_name):

--- a/camayoc/tests/qpc/cli/test_reports.py
+++ b/camayoc/tests/qpc/cli/test_reports.py
@@ -336,6 +336,7 @@ def source_option_attr(source_option, finished_scan):
     return getattr(finished_scan, attr_name)
 
 
+@pytest.mark.slow
 @pytest.mark.runs_scan
 @pytest.mark.parametrize("source_option", REPORT_SOURCE_OPTIONS)
 @pytest.mark.parametrize("output_format", REPORT_OUTPUT_FORMATS)

--- a/camayoc/tests/qpc/cli/test_scanjobs.py
+++ b/camayoc/tests/qpc/cli/test_scanjobs.py
@@ -55,6 +55,7 @@ def test_scanjob(data_provider, scans, qpc_server_config):
 
 
 @pytest.mark.nightly_only
+@pytest.mark.slow
 @pytest.mark.runs_scan
 def test_scanjob_with_multiple_sources(qpc_server_config, data_provider):
     """Scan multiple source types.
@@ -103,6 +104,7 @@ def test_scanjob_with_multiple_sources(qpc_server_config, data_provider):
 
 
 @pytest.mark.nightly_only
+@pytest.mark.slow
 @pytest.mark.runs_scan
 def test_scanjob_with_disabled_products(isolated_filesystem, qpc_server_config, data_provider):
     """Perform a scan with optional products disabled.
@@ -162,6 +164,7 @@ def test_scanjob_with_disabled_products(isolated_filesystem, qpc_server_config, 
 
 
 @pytest.mark.nightly_only
+@pytest.mark.slow
 @pytest.mark.runs_scan
 def test_scanjob_with_enabled_extended_products(qpc_server_config, data_provider):
     """Perform a scan with extended products enabled.

--- a/camayoc/tests/qpc/ui/test_endtoend.py
+++ b/camayoc/tests/qpc/ui/test_endtoend.py
@@ -60,6 +60,7 @@ def source_names():
         yield pytest.param(source_definition.name, id=fixture_id)
 
 
+@pytest.mark.slow
 @pytest.mark.nightly_only
 @pytest.mark.parametrize("source_name", source_names())
 def test_end_to_end(tmp_path, cleaning_data_provider, ui_client: Client, source_name):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ filterwarnings = "ignore::urllib3.exceptions.InsecureRequestWarning"
 markers = [
     "ssh_keyfile_path: mark test with SSH key file path mapped to /sshkeys/ on the server (deselect with '-m \"not ssh_keyfile_path\"')",
     "runs_scan: tests that run scans (might be slow!)",
+    "slow: tests that take a long time to run (on average, more than 30 seconds)",
     "nightly_only: tests to execute only during nightly (or full) run, i.e. not during PR check; note that actual selection is implemented in discovery-ci",
     "pr_only: tests to execute only during PR check run, i.e. not during nightly run; note that actual selection is implemented in discovery-ci",
 ]


### PR DESCRIPTION
Using data from Jenkins, add `slow` marker to all tests that on average take at least 30 seconds to complete. There are 11 tests like that. If we put threshold at 15 seconds, there would be 18 tests marked.

It's important to remember that data is obtained from complete test suite runs, and so it differs from times we would obtain when running tests individually. Good example is `camayoc/tests/qpc/api/v1/reports/test_reports.py` - only first two tests gets marked, because all subsequent tests would use results cached in `scans` fixture, and finish much faster. But if you were to run `camayoc/tests/qpc/api/v1/reports/test_reports.py::test_installed_products_deployment_report` individually, it would likely take long time to finish, as it would have to wait for scan to complete.

Another approach we might take is just adding `slow` marker automatically to tests that use `scans` fixture, leaving explicit mark to few tests that are slow due to other reasons.