### PR TITLE
Add support for scan_timeout configuration

### DIFF
--- a/camayoc/config.py
+++ b/camayoc/config.py
@@ -18,6 +18,7 @@ from camayoc.types.settings import Configuration
 
 default_dynaconf_validators = [
     Validator("camayoc.run_scans", default=False),
+    Validator("camayoc.scan_timeout", default=600),
     Validator("quipucords_server.hostname", default=""),
     Validator("quipucords_server.https", default=False),
     Validator("quipucords_server.port", default=8000),

--- a/camayoc/types/settings.py
+++ b/camayoc/types/settings.py
@@ -11,6 +11,7 @@ from typing_extensions import Annotated
 
 class CamayocOptions(BaseModel):
     run_scans: Optional[bool] = False
+    scan_timeout: Optional[int] = 600
 
 
 class QuipucordsServerOptions(BaseModel):

--- a/camayoc/ui/models/pages/scans.py
+++ b/camayoc/ui/models/pages/scans.py
@@ -18,7 +18,8 @@ class ScanListElem(AbstractListItem):
     def download_scan(self) -> Download:
         scan_locator = "td[class*=-c-table__action] button[data-ouia-component-id=download]"
         timeout_start = time.monotonic()
-        while 10 * 60 > (time.monotonic() - timeout_start):
+        timeout = self._client._camayoc_config.camayoc.scan_timeout
+        while timeout > (time.monotonic() - timeout_start):
             try:
                 with self.locator.page.expect_download() as download_info:
                     self.locator.locator(scan_locator).click(timeout=10_000)


### PR DESCRIPTION
This PR makes possible to configure the timeout for the test waiting for a scan to be available. At first it focus on UI tests.

Here is how to customize timeout for 30 minutes (60*30 = 1800). Set in Camayoc config file:

```yaml
camayoc:
  scan_timeout: 1800
```