### PR TITLE
Mark more tests as nightly_only

### DIFF
--- a/camayoc/tests/qpc/cli/test_scanjobs.py
+++ b/camayoc/tests/qpc/cli/test_scanjobs.py
@@ -55,6 +55,7 @@ def test_scanjob(data_provider, scans, qpc_server_config):
         assert report.get("sources")
 
 
+@pytest.mark.nightly_only
 @pytest.mark.runs_scan
 def test_scanjob_with_multiple_sources(qpc_server_config, data_provider):
     """Scan multiple source types.
@@ -101,6 +102,7 @@ def test_scanjob_with_multiple_sources(qpc_server_config, data_provider):
         assert report.get("sources", []) != []
 
 
+@pytest.mark.nightly_only
 @pytest.mark.runs_scan
 def test_scanjob_with_disabled_products(isolated_filesystem, qpc_server_config, data_provider):
     """Perform a scan with optional products disabled.
@@ -159,6 +161,7 @@ def test_scanjob_with_disabled_products(isolated_filesystem, qpc_server_config, 
     assert len(errors_found) == 0, "\n================\n".join(errors_found)
 
 
+@pytest.mark.nightly_only
 @pytest.mark.runs_scan
 def test_scanjob_with_enabled_extended_products(qpc_server_config, data_provider):
     """Perform a scan with extended products enabled.


### PR DESCRIPTION
These three tests cover parts that are very rarely modified, while taking about 3 minutes to complete. Hence a proposal to move them to nightly pipeline, to save some time in PR checks.

The drawback is obvious - they won't run even for PRs that actually modify extended/disabled products, so there's a risk of merging breaking change. We should run standalone job for these PRs, but I bet we won't remember. Hopefully pipeline will still be stable then, so we will notice some failures in nightly run, which should prompt us to investigate.