### PR TITLE
Add support to test the Aggregate report

### DIFF
--- a/camayoc/data_provider.py
+++ b/camayoc/data_provider.py
@@ -284,12 +284,14 @@ class ScanContainer:
                 report.retrieve_from_scan_job(scan_job_id=scanjob._id)
                 details_report = report.details().json()
                 deployments_report = report.deployments().json()
+                aggregate_report = report.aggregate().json()
                 finished_scan = evolve(
                     scan,
                     status=ScanSimplifiedStatusEnum.COMPLETED,
                     report_id=report._id,
                     details_report=details_report,
                     deployments_report=deployments_report,
+                    aggregate_report=aggregate_report,
                 )
                 logger.info(
                     "Finished scanjob %s for scan %s", scan.scan_job_id, scan.definition.name

--- a/camayoc/qpc_models.py
+++ b/camayoc/qpc_models.py
@@ -708,3 +708,13 @@ class Report(QPCObject):
         path = urljoin(self.endpoint, "{}/deployments/".format(self._id))
         response = self.client.get(path, **kwargs)
         return response
+
+    def aggregate(self, **kwargs):
+        """Send GET request to self.endpoint/{id}/aggregate/ to view the aggregate report.
+
+        :param ``**kwargs``: Additional arguments accepted by Requests's
+            `request.request()` method.
+        """
+        path = urljoin(self.endpoint, "{}/aggregate/".format(self._id))
+        response = self.client.get(path, **kwargs)
+        return response

--- a/camayoc/tests/qpc/api/v1/reports/test_reports.py
+++ b/camayoc/tests/qpc/api/v1/reports/test_reports.py
@@ -38,7 +38,7 @@ def test_products_found_deployment_report(scans, scan_name):
     :steps:
         1) Request the json report for the scan.
         2) Assert that any products marked as present are expected to be found
-           as is listed in the configuration file for the source.
+           as is listed in the configuration file for the scan.
     :expectedresults: There are inspection results for each source we scanned
         and any products found are correctly identified.
     """
@@ -110,7 +110,7 @@ def test_OS_found_deployment_report(scans, scan_name):
     :steps:
         1) Request the json report for the scan.
         2) Assert that the OS identified is expected to be found
-           as is listed in the configuration file for the source.
+           as is listed in the configuration file for the scan.
     :expectedresults: There are inspection results for each source we scanned
         and the operating system is correctly identified.
     """
@@ -215,7 +215,7 @@ def test_installed_products_deployment_report(scans, scan_name):
     :steps:
         1) Request the json report for the scan.
         2) Assert that the installed products expected to be found,
-           as listed in the configuration file for the source, are present.
+           as listed in the configuration file for the scan, are present.
     :expectedresults: There are inspection results for each source we scanned
         and the installed products are correctly identified.
     """
@@ -280,7 +280,7 @@ def test_raw_facts_details_report(scans, scan_name):
     :steps:
         1) Request the json report for the scan.
         2) Assert that the found raw facts match these listed
-           in the configuration file for the source.
+           in the configuration file for the scan.
     :expectedresults: There are inspection results for each source we scanned
         and the raw facts are matching.
     """
@@ -347,7 +347,7 @@ def test_aggregate_report(scans, scan_name):
     :steps:
         1) Request the aggregate json report for the scan.
         2) Assert that the found aggregate values match these listed
-           in the configuration file for the source.
+           in the configuration file for the scan.
     :expectedresults: There are inspection results for each source we scanned
         and the aggregate values are correctly tallied.
     """

--- a/camayoc/tests/qpc/cli/test_reports.py
+++ b/camayoc/tests/qpc/cli/test_reports.py
@@ -806,6 +806,6 @@ def test_download_aggregate_report(data_provider, scans, isolated_filesystem, qp
         "instances_unknown",
         "instances_virtual",
     )
-    num_instances = sum({k: json_formatted["results"][k] for k in instances_filter}.values())
+    num_instances = sum(json_formatted["results"][k] for k in instances_filter)
     num_success_instances = json_formatted["diagnostics"]["inspect_result_status_success"]
     assert num_instances == num_success_instances

--- a/camayoc/tests/qpc/cli/test_reports.py
+++ b/camayoc/tests/qpc/cli/test_reports.py
@@ -782,7 +782,8 @@ def test_download_aggregate_report(data_provider, scans, isolated_filesystem, qp
         1) Run ``qpc report aggregate --report <report id>``.
         2) Verify that command succeeded.
         3) Verify that downloaded data looks like valid JSON.
-    :expectedresults: Report is downloaded and data is valid JSON.
+        4) Verify if data looks sane.
+    :expectedresults: Report is downloaded and data is valid JSON and sane.
     """
     finished_scan = scan_with_source_type(QPC_SOURCE_TYPES, data_provider, scans)
     output_file = f"aggregate-{uuid4()}.json"
@@ -796,3 +797,15 @@ def test_download_aggregate_report(data_provider, scans, isolated_filesystem, qp
     with open(output_file) as fh:
         json_formatted = json.load(fh)
     assert len(json_formatted)
+    assert json_formatted["diagnostics"]
+    assert json_formatted["results"]
+    instances_filter = (
+        "instances_hypervisor",
+        "instances_not_redhat",
+        "instances_physical",
+        "instances_unknown",
+        "instances_virtual",
+    )
+    num_instances = sum({k: json_formatted["results"][k] for k in instances_filter}.values())
+    num_success_instances = json_formatted["diagnostics"]["inspect_result_status_success"]
+    assert num_instances == num_success_instances

--- a/camayoc/types/scans.py
+++ b/camayoc/types/scans.py
@@ -23,4 +23,6 @@ class FinishedScan:
     report_id: Optional[int] = None
     details_report: Optional[dict] = None
     deployments_report: Optional[dict] = None
+    aggregate_report: Optional[dict] = None
+
     error: Optional[Exception] = None

--- a/camayoc/types/settings.py
+++ b/camayoc/types/settings.py
@@ -144,12 +144,18 @@ class ExpectedOpenShiftData(BaseModel):
     operators: list[str]
 
 
+class ExpectedAggregateData(BaseModel):
+    results: dict[str, Any]
+    diagnostics: dict[str, int]
+
+
 class ExpectedScanData(BaseModel):
     distribution: Optional[ExpectedDistributionData] = None
     products: Optional[list[ExpectedProductData]] = None
     cluster_info: Optional[ExpectedOpenShiftData] = None
     installed_products: Optional[list[str]] = None
     raw_facts: Optional[dict[str, Any]] = None
+    aggregate: Optional[ExpectedAggregateData] = None
 
 
 class ScanOptions(BaseModel):

--- a/camayoc/types/settings.py
+++ b/camayoc/types/settings.py
@@ -155,6 +155,10 @@ class ExpectedScanData(BaseModel):
     cluster_info: Optional[ExpectedOpenShiftData] = None
     installed_products: Optional[list[str]] = None
     raw_facts: Optional[dict[str, Any]] = None
+    # Here this aggregate attribute contains data about the *entire scan* and
+    # it isn't tied to a specific host, like the other attributes are.
+    # When in use in the configuration file, this attribute must be placed
+    # inside any host for the scan, to set the expected aggregate values.
     aggregate: Optional[ExpectedAggregateData] = None
 
 

--- a/tests/test_scan_container.py
+++ b/tests/test_scan_container.py
@@ -64,6 +64,7 @@ def mocked_run_scans(
                 report_id=1,
                 details_report={},
                 deployments_report={},
+                aggregate_report={},
             )
         finished_scans.append(finished_scan)
     return finished_scans


### PR DESCRIPTION
This PR adds support for testing the Aggregate report. It adds data model and settings for the API test and complements the CLI test with some data validation.

```
$ pytest -v -ra -k 'test_download_aggregate_report or test_aggregate_report'
```

```
camayoc/tests/qpc/api/v1/reports/test_reports.py::test_aggregate_report[testlab] PASSED [ 33%]
camayoc/tests/qpc/api/v1/reports/test_reports.py::test_aggregate_report[middleware-testlab] PASSED [ 66%]
camayoc/tests/qpc/cli/test_reports.py::test_download_aggregate_report PASSED [100%]Saved results archive to 72191de6-983f-4e4d-9702-1a2bddad044b.tar.gz
```

Relates to JIRA: DISCOVERY-759                                                                                                                                                                                                              
https://issues.redhat.com/browse/DISCOVERY-759
