### PR TITLE
Introduce UIv2 support

### DIFF
--- a/camayoc/config.py
+++ b/camayoc/config.py
@@ -19,6 +19,7 @@ from camayoc.types.settings import Configuration
 default_dynaconf_validators = [
     Validator("camayoc.run_scans", default=False),
     Validator("camayoc.scan_timeout", default=600),
+    Validator("camayoc.use_uiv2", default=False),
     Validator("quipucords_server.hostname", default=""),
     Validator("quipucords_server.https", default=False),
     Validator("quipucords_server.port", default=8000),

--- a/camayoc/types/settings.py
+++ b/camayoc/types/settings.py
@@ -12,6 +12,7 @@ from typing_extensions import Annotated
 class CamayocOptions(BaseModel):
     run_scans: Optional[bool] = False
     scan_timeout: Optional[int] = 600
+    use_uiv2: Optional[bool] = False
 
 
 class QuipucordsServerOptions(BaseModel):

--- a/camayoc/types/ui.py
+++ b/camayoc/types/ui.py
@@ -14,6 +14,7 @@ from attrs import frozen
 from playwright.sync_api import Locator
 from playwright.sync_api import Page
 
+from camayoc.config import settings
 from camayoc.qpc_models import Credential
 from camayoc.qpc_models import Source
 from camayoc.ui.enums import CredentialTypes
@@ -324,19 +325,24 @@ class SatelliteSourceFormDTO:
     source_name: str
     address: str
     credentials: list[str]
+    port_v2: Optional[str] = None
     connection: Optional[SourceConnectionTypes] = None
     verify_ssl: Optional[bool] = None
 
     @classmethod
     def from_model(cls, model: Source):
         address = model.hosts[0]
+        address_port = {"address": address}
         if hasattr(model, "port") and model.port:
-            address = f"{address}:{model.port}"
+            if settings.camayoc.use_uiv2:
+                address_port["port_v2"] = str(model.port)
+            else:
+                address_port["address"] = f"{address}:{model.port}"
         return cls(
             source_name=model.name,
-            address=address,
             credentials=model.credentials,
             verify_ssl=model.options.get("ssl_cert_verify"),
+            **address_port,
         )
 
 
@@ -345,19 +351,24 @@ class VCenterSourceFormDTO:
     source_name: str
     address: str
     credentials: list[str]
+    port_v2: Optional[str] = None
     connection: Optional[SourceConnectionTypes] = None
     verify_ssl: Optional[bool] = None
 
     @classmethod
     def from_model(cls, model: Source):
         address = model.hosts[0]
+        address_port = {"address": address}
         if hasattr(model, "port") and model.port:
-            address = f"{address}:{model.port}"
+            if settings.camayoc.use_uiv2:
+                address_port["port_v2"] = str(model.port)
+            else:
+                address_port["address"] = f"{address}:{model.port}"
         return cls(
             source_name=model.name,
-            address=address,
             credentials=model.credentials,
             verify_ssl=model.options.get("ssl_cert_verify"),
+            **address_port,
         )
 
 
@@ -366,19 +377,24 @@ class OpenShiftSourceFormDTO:
     source_name: str
     address: str
     credentials: list[str]
+    port_v2: Optional[str] = None
     connection: Optional[SourceConnectionTypes] = None
     verify_ssl: Optional[bool] = None
 
     @classmethod
     def from_model(cls, model: Source):
         address = model.hosts[0]
+        address_port = {"address": address}
         if hasattr(model, "port") and model.port:
-            address = f"{address}:{model.port}"
+            if settings.camayoc.use_uiv2:
+                address_port["port_v2"] = str(model.port)
+            else:
+                address_port["address"] = f"{address}:{model.port}"
         return cls(
             source_name=model.name,
-            address=address,
             credentials=model.credentials,
             verify_ssl=model.options.get("ssl_cert_verify"),
+            **address_port,
         )
 
 
@@ -387,19 +403,24 @@ class AnsibleSourceFormDTO:
     source_name: str
     address: str
     credentials: list[str]
+    port_v2: Optional[str] = None
     connection: Optional[SourceConnectionTypes] = None
     verify_ssl: Optional[bool] = None
 
     @classmethod
     def from_model(cls, model: Source):
         address = model.hosts[0]
+        address_port = {"address": address}
         if hasattr(model, "port") and model.port:
-            address = f"{address}:{model.port}"
+            if settings.camayoc.use_uiv2:
+                address_port["port_v2"] = str(model.port)
+            else:
+                address_port["address"] = f"{address}:{model.port}"
         return cls(
             source_name=model.name,
-            address=address,
             credentials=model.credentials,
             verify_ssl=model.options.get("ssl_cert_verify"),
+            **address_port,
         )
 
 
@@ -408,19 +429,24 @@ class RHACSSourceFormDTO:
     source_name: str
     address: str
     credentials: list[str]
+    port_v2: Optional[str] = None
     connection: Optional[SourceConnectionTypes] = None
     verify_ssl: Optional[bool] = None
 
     @classmethod
     def from_model(cls, model: Source):
         address = model.hosts[0]
+        address_port = {"address": address}
         if hasattr(model, "port") and model.port:
-            address = f"{address}:{model.port}"
+            if settings.camayoc.use_uiv2:
+                address_port["port_v2"] = str(model.port)
+            else:
+                address_port["address"] = f"{address}:{model.port}"
         return cls(
             source_name=model.name,
-            address=address,
             credentials=model.credentials,
             verify_ssl=model.options.get("ssl_cert_verify"),
+            **address_port,
         )
 
 

--- a/camayoc/types/ui.py
+++ b/camayoc/types/ui.py
@@ -48,6 +48,7 @@ class Session(Protocol):
 class UIPage(Protocol):
     _client: Client
     _driver: Page
+    _use_uiv2: bool
 
     def _new_page(self, class_or_page) -> UIPage: ...
 

--- a/camayoc/ui/models/components/form.py
+++ b/camayoc/ui/models/components/form.py
@@ -4,6 +4,7 @@ import logging
 
 from attrs import fields
 
+from camayoc.config import settings
 from camayoc.exceptions import MisconfiguredWidgetException
 from camayoc.types.ui import UIField
 from camayoc.types.ui import UIPage
@@ -25,7 +26,11 @@ class Form(UIPage):
         ordered_field_names = [f for f in form_fields if f in field_names]
 
         for field_name in ordered_field_names:
+            field_name_v2 = f"{field_name}_v2"
             field: UIField = getattr(form_definition, field_name)
+            if settings.camayoc.use_uiv2:
+                field: UIField = getattr(form_definition, field_name_v2, field)
+
             if not isinstance(field, Field):
                 logger.debug(
                     "%s.FormDefinition.%s is not instance of Field, skipping",
@@ -36,6 +41,9 @@ class Form(UIPage):
 
             field.bind(parent=self, name=field_name, driver=self._driver)
             value = getattr(data, field_name, None)
+            if settings.camayoc.use_uiv2:
+                value = getattr(data, field_name_v2, value)
+
             if value is None:
                 logger.debug(
                     "%s field %s is None, skipping",

--- a/camayoc/ui/models/components/items_list.py
+++ b/camayoc/ui/models/components/items_list.py
@@ -21,19 +21,26 @@ class ItemsList(UIPage):
 
     def _get_item_from_current_list(self, name: str):
         default_timeout = 5000  # 5s
-        item_elem = self._driver.locator("css=strong").filter(
+        item_label_locator = "css=strong"
+        item_elem_locator = "xpath=./ancestor::tr[contains(@class, 'quipucords-table__tr')]"
+
+        if self._use_uiv2:
+            item_label_locator = "td[data-label=Name]"
+            item_elem_locator = "xpath=./ancestor::tr[contains(@class, 'table__tr')]"
+
+        item_elem = self._driver.locator(item_label_locator).filter(
             has=self._driver.get_by_text(name, exact=True)
         )
-        item_elem_locator = "xpath=./ancestor::tr[contains(@class, 'quipucords-table__tr')]"
         item_elem = item_elem.locator(item_elem_locator)
         item_elem.hover(timeout=default_timeout, trial=True)
         return item_elem
 
     # We probably should have separate component for filters
     # that exposes wider array of actions (filtering by any field,
-    # by multiple fileds, clearing filters, sorting?).
+    # by multiple fields, clearing filters, sorting?).
     # But YAGNI tells us this will do for now
     def _search_for_item_by_name(self, name: str):
+        # FIXME: implement for v2
         filter_field_button = self._driver.locator(
             "div[class*=-c-toolbar__content] button[id]:has(span[class*=-c-select__toggle-arrow])"
         ).locator("nth=0")

--- a/camayoc/ui/models/components/logged_in.py
+++ b/camayoc/ui/models/components/logged_in.py
@@ -11,9 +11,21 @@ if TYPE_CHECKING:
 
 class LoggedIn(UIPage):
     def logout(self) -> Login:
+        if self._use_uiv2:
+            return self._logout_uiv2()
+
         app_user_dropdown = "div[data-ouia-component-id=user_dropdown]:visible"
         app_user_dropdown_button = f"{app_user_dropdown} > button"
         logout_link = f"{app_user_dropdown} > ul a[data-ouia-component-id=logout]"
+
+        self._driver.click(app_user_dropdown_button)
+        self._driver.click(logout_link)
+
+        return self._new_page(Pages.LOGIN)
+
+    def _logout_uiv2(self) -> Login:
+        app_user_dropdown_button = "button[data-ouia-component-id=user_dropdown_button]:visible"
+        logout_link = f"{app_user_dropdown_button} ~ div li[data-ouia-component-id=logout]"
 
         self._driver.click(app_user_dropdown_button)
         self._driver.click(logout_link)

--- a/camayoc/ui/models/components/popup.py
+++ b/camayoc/ui/models/components/popup.py
@@ -31,6 +31,9 @@ class PopUp(UIPage):
         result_cls_name = "SAVE_RESULT_CLASS"
         if self._use_uiv2:
             locator_cls_name = "SAVE_LOCATOR_V2"
+            result_cls_name_v2 = "SAVE_RESULT_CLASS_V2"
+            if hasattr(self, result_cls_name_v2):
+                result_cls_name = result_cls_name_v2
 
         return self._click_button(locator_cls_name, result_cls_name)
 

--- a/camayoc/ui/models/components/popup.py
+++ b/camayoc/ui/models/components/popup.py
@@ -10,6 +10,9 @@ class PopUp(UIPage):
     SAVE_RESULT_CLASS = None
     CANCEL_RESULT_CLASS = None
 
+    SAVE_LOCATOR_V2 = "*[class*=-c-modal-box__body] button.pf-m-primary"
+    CANCEL_LOCATOR_V2 = "*[class*=-c-modal-box__body] button.pf-m-link"
+
     def _get_result_class_name(self, class_name_id) -> str:
         class_name = getattr(self, class_name_id)
         if class_name is None:
@@ -24,7 +27,12 @@ class PopUp(UIPage):
         return self._new_page(result_class)
 
     def confirm(self):
-        return self._click_button("SAVE_LOCATOR", "SAVE_RESULT_CLASS")
+        locator_cls_name = "SAVE_LOCATOR"
+        result_cls_name = "SAVE_RESULT_CLASS"
+        if self._use_uiv2:
+            locator_cls_name = "SAVE_LOCATOR_V2"
+
+        return self._click_button(locator_cls_name, result_cls_name)
 
     def cancel(self):
         return self._click_button("CANCEL_LOCATOR", "CANCEL_RESULT_CLASS")

--- a/camayoc/ui/models/fields.py
+++ b/camayoc/ui/models/fields.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 from playwright.sync_api import Page
 
+from camayoc.config import settings
 from camayoc.types.ui import UIField
 
 
@@ -70,9 +71,13 @@ class RadioGroupField(Field):
 
 class SelectField(Field):
     def do_fill(self, value):
+        values_list_locator = "xpath=following-sibling::ul"
+        if settings.camayoc.use_uiv2:
+            values_list_locator = "xpath=following-sibling::div//ul"
+
         if isinstance(value, Enum) and (enum_value := getattr(value, "value")):
             value = enum_value
 
         self.driver.click(self.locator)
-        values_list = self.driver.locator(self.locator).locator("xpath=following-sibling::ul")
+        values_list = self.driver.locator(self.locator).locator(values_list_locator)
         values_list.locator(f"text='{value}'").click()

--- a/camayoc/ui/models/fields.py
+++ b/camayoc/ui/models/fields.py
@@ -44,6 +44,26 @@ class CheckboxField(Field):
             elem.uncheck()
 
 
+class FilteredMultipleSelectField(Field):
+    def do_fill(self, value: list[str]):
+        filter_input = ' div[data-ouia-component-id="credentials_list_input"] input'
+
+        # First click opens the list. Second hides it and enables us to type.
+        for _ in range(2):
+            self.driver.locator(self.locator).locator(filter_input).click()
+
+        for actual_value in value:
+            self.driver.locator(self.locator).locator(filter_input).fill(actual_value)
+            values_list = self.driver.locator(self.locator).locator(
+                "xpath=following-sibling::div//ul[contains(@id, 'select')]"
+            )
+            values_list.locator(f"text='{actual_value}'").click()
+            self.driver.locator(self.locator).locator(filter_input).clear()
+
+        if values_list.is_visible():
+            self.driver.locator(self.locator).locator(filter_input).click()
+
+
 class InputField(Field):
     def do_fill(self, value):
         self.driver.fill(self.locator, value)

--- a/camayoc/ui/models/pages/abstract_page.py
+++ b/camayoc/ui/models/pages/abstract_page.py
@@ -18,6 +18,7 @@ class AbstractPage(UIPage):
     def __init__(self, client: camayoc.ui.client.Client):
         self._client = client
         self._driver = client.driver
+        self._use_uiv2 = bool(self._client._camayoc_config.camayoc.use_uiv2)
 
     def _new_page(self, class_or_page: ClassOrPage) -> UIPage:
         cls = None

--- a/camayoc/ui/models/pages/credentials.py
+++ b/camayoc/ui/models/pages/credentials.py
@@ -40,12 +40,14 @@ class CredentialForm(Form, PopUp, AbstractPage):
 class NetworkCredentialForm(CredentialForm):
     class FormDefinition:
         authentication_type = SelectField("div[data-ouia-component-id=auth_type] > button")
+        authentication_type_v2 = SelectField("button[data-ouia-component-id=auth_type]")
         credential_name = InputField("input[data-ouia-component-id=cred_name]")
         username = InputField("input[data-ouia-component-id=username]")
         password = InputField("input[data-ouia-component-id=password]")
         ssh_key_file = InputField("input[data-ouia-component-id=ssh_keyfile]")
         passphrase = InputField("input[data-ouia-component-id=ssh_passphrase]")
         become_method = SelectField("div[data-ouia-component-id=become_method] > button")
+        become_method_v2 = SelectField("button[data-ouia-component-id=become_method]")
         become_user = InputField("input[data-ouia-component-id=become_user]")
         become_password = InputField("input[data-ouia-component-id=become_password]")
 
@@ -167,6 +169,40 @@ class CredentialsMainPage(MainPageMixin):
                 "class": RHACSCredentialForm,
             },
         }
+
+        # these selectors get few characters over allowed line length limit,
+        # in part due to indentation caused by conditional. Temporarily
+        # disable ruff rule for a file - we'll introduce correct solution when
+        # we remove old UI support
+        # ruff: noqa: E501
+        if self._use_uiv2:
+            create_credential_button = "button[data-ouia-component-id=add_credential_button]"
+            source_type_map = {
+                CredentialTypes.NETWORK: {
+                    "selector": f"{create_credential_button} ~ div ul li[data-ouia-component-id=network]",
+                    "class": NetworkCredentialForm,
+                },
+                CredentialTypes.SATELLITE: {
+                    "selector": f"{create_credential_button} ~ div ul li[data-ouia-component-id=satellite]",
+                    "class": SatelliteCredentialForm,
+                },
+                CredentialTypes.VCENTER: {
+                    "selector": f"{create_credential_button} ~ div ul li[data-ouia-component-id=vcenter]",
+                    "class": VCenterCredentialForm,
+                },
+                CredentialTypes.OPENSHIFT: {
+                    "selector": f"{create_credential_button} ~ div ul li[data-ouia-component-id=openshift]",
+                    "class": OpenShiftCredentialForm,
+                },
+                CredentialTypes.ANSIBLE: {
+                    "selector": f"{create_credential_button} ~ div ul li[data-ouia-component-id=ansible]",
+                    "class": AnsibleCredentialForm,
+                },
+                CredentialTypes.RHACS: {
+                    "selector": f"{create_credential_button} ~ div ul li[data-ouia-component-id=rhacs]",
+                    "class": RHACSCredentialForm,
+                },
+            }
 
         selector, cls = source_type_map.get(source_type).values()
 

--- a/camayoc/ui/models/pages/login.py
+++ b/camayoc/ui/models/pages/login.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from camayoc.types.ui import LoginFormDTO
 from camayoc.ui.decorators import record_action
+from camayoc.ui.enums import MainMenuPages
 from camayoc.ui.enums import Pages
 
 from .abstract_page import AbstractPage
@@ -15,6 +16,9 @@ if TYPE_CHECKING:
 class Login(AbstractPage):
     @record_action
     def login(self, data: LoginFormDTO) -> SourcesMainPage:
+        if self._use_uiv2:
+            return self._login_uiv2(data)
+
         login_page_indicator = "html.login-pf"
         username_input = "input[name=username]"
         password_input = "input[name=password]"
@@ -26,3 +30,22 @@ class Login(AbstractPage):
             self._driver.click(submit_button)
 
         return self._new_page(Pages.SOURCES)
+
+    def _login_uiv2(self, data: LoginFormDTO) -> SourcesMainPage:
+        login_page_indicator = "main[class$=login__main]"
+        username_input = "input[name=pf-login-username-id]"
+        password_input = "input[name=pf-login-password-id]"
+        submit_button = "button[type=submit]"
+
+        if self._driver.locator(login_page_indicator).is_visible():
+            self._driver.fill(username_input, data.username)
+            self._driver.fill(password_input, data.password)
+            self._driver.click(submit_button)
+
+        # The new UI opens Credentials page right after login,
+        # but we need to navigate to Sources to keep interface
+        # compatibility. In most cases it means that we log in,
+        # click Sources in menu and immediately go back to Credentials.
+        # Oh well...
+        credentials_page = self._new_page(Pages.CREDENTIALS)
+        return credentials_page.navigate_to(MainMenuPages.SOURCES)

--- a/camayoc/ui/models/pages/scans.py
+++ b/camayoc/ui/models/pages/scans.py
@@ -5,17 +5,42 @@ import time
 from playwright.sync_api import Download
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
+from camayoc.config import settings
 from camayoc.exceptions import FailedScanException
 from camayoc.ui.decorators import creates_toast
 from camayoc.ui.decorators import record_action
 from camayoc.ui.decorators import service
+from camayoc.ui.enums import Pages
 
 from ..components.items_list import AbstractListItem
+from ..components.popup import PopUp
 from ..mixins import MainPageMixin
+from .abstract_page import AbstractPage
+
+
+class ScanHistoryPopup(PopUp, AbstractPage):
+    SAVE_LOCATOR = None
+    CANCEL_LOCATOR = "*[class$='modal-box__close'] button"
+    SAVE_RESULT_CLASS = None
+    CANCEL_RESULT_CLASS = Pages.SCANS
+
+    def get_last_download(self) -> Download:
+        table_row_locator = "table[data-ouia-component-id=scan_jobs_table] tbody tr"
+        download_button_locator = "td[data-label=Download] button"
+
+        last_download = self._driver.locator(table_row_locator).last
+        with self._driver.expect_download() as download_info:
+            last_download.locator(download_button_locator).click(timeout=10_000)
+        download = download_info.value
+        download.path()  # blocks the script while file is downloaded
+        return download
 
 
 class ScanListElem(AbstractListItem):
     def download_scan(self) -> Download:
+        if settings.camayoc.use_uiv2:
+            return self._download_scan_v2()
+
         scan_locator = "td[class*=-c-table__action] button[data-ouia-component-id=download]"
         timeout_start = time.monotonic()
         timeout = self._client._camayoc_config.camayoc.scan_timeout
@@ -31,6 +56,27 @@ class ScanListElem(AbstractListItem):
                     "div[class*=-c-toolbar] button[data-ouia-component-id=refresh]"
                 ).click()
         raise FailedScanException("Scan could not be downloaded")
+
+    def _download_scan_v2(self) -> Download:
+        timeout_start = time.monotonic()
+        timeout = self._client._camayoc_config.camayoc.scan_timeout
+        while timeout > (time.monotonic() - timeout_start):
+            try:
+                scans_popup = self._open_scans()
+                download = scans_popup.get_last_download()
+                scans_popup.cancel()
+                return download
+            except PlaywrightTimeoutError:
+                scans_popup.cancel()
+                self._client.driver.locator(
+                    "div[class*=-c-toolbar] button[data-ouia-component-id=refresh]"
+                ).click()
+        raise FailedScanException("Scan could not be downloaded")
+
+    def _open_scans(self) -> ScanHistoryPopup:
+        last_scanned_locator = "td[data-label='Last scanned'] button"
+        self.locator.locator(last_scanned_locator).click()
+        return ScanHistoryPopup(client=self._client)
 
 
 class ScansMainPage(MainPageMixin):

--- a/camayoc/ui/models/pages/sources.py
+++ b/camayoc/ui/models/pages/sources.py
@@ -119,6 +119,7 @@ class SatelliteSourceCredentialsForm(SourceCredentialsForm):
     class FormDefinition:
         source_name = InputField("input[data-ouia-component-id=name]")
         address = InputField("input[data-ouia-component-id=hosts_single]")
+        port_v2 = InputField("input[data-ouia-component-id=port]")
         credentials = MultipleSelectField(
             "div[data-ouia-component-id=add_credentials_select] > button"
         )
@@ -142,6 +143,7 @@ class VCenterSourceCredentialsForm(SourceCredentialsForm):
     class FormDefinition:
         source_name = InputField("input[data-ouia-component-id=name]")
         address = InputField("input[data-ouia-component-id=hosts_single]")
+        port_v2 = InputField("input[data-ouia-component-id=port]")
         credentials = MultipleSelectField(
             "div[data-ouia-component-id=add_credentials_select] > button"
         )
@@ -165,6 +167,7 @@ class OpenShiftSourceCredentialsForm(SourceCredentialsForm):
     class FormDefinition:
         source_name = InputField("input[data-ouia-component-id=name]")
         address = InputField("input[data-ouia-component-id=hosts_single]")
+        port_v2 = InputField("input[data-ouia-component-id=port]")
         credentials = MultipleSelectField(
             "div[data-ouia-component-id=add_credentials_select] > button"
         )
@@ -188,6 +191,7 @@ class AnsibleSourceCredentialsForm(SourceCredentialsForm):
     class FormDefinition:
         source_name = InputField("input[data-ouia-component-id=name]")
         address = InputField("input[data-ouia-component-id=hosts_single]")
+        port_v2 = InputField("input[data-ouia-component-id=port]")
         credentials = MultipleSelectField(
             "div[data-ouia-component-id=add_credentials_select] > button"
         )
@@ -211,6 +215,7 @@ class RHACSSourceCredentialsForm(SourceCredentialsForm):
     class FormDefinition:
         source_name = InputField("input[data-ouia-component-id=name]")
         address = InputField("input[data-ouia-component-id=hosts_single]")
+        port_v2 = InputField("input[data-ouia-component-id=port]")
         credentials = MultipleSelectField(
             "div[data-ouia-component-id=add_credentials_select] > button"
         )
@@ -248,11 +253,17 @@ class ScanForm(Form, PopUp, AbstractPage):
 
     class FormDefinition:
         scan_name = InputField("input[name=scanName]")
+        scan_name_v2 = InputField("input[data-ouia-component-id=name][id=scan-name]")
         max_concurrent_scans = InputField("input#scanConcurrency")
+        max_concurrent_scans_v2 = InputField("div[data-ouia-component-id=scan_concurrency] input")
         jboss_eap = CheckboxField("input[name=jbossEap]")
+        jboss_eap_v2 = CheckboxField("input[data-ouia-component-id=options_jboss_eap]")
         fuse = CheckboxField("input[name=jbossFuse]")
+        fuse_v2 = CheckboxField("input[data-ouia-component-id=options_jboss_fuse]")
         jboss_web_server = CheckboxField("input[name=jbossWs]")
+        jboss_web_server_v2 = CheckboxField("input[data-ouia-component-id=options_jboss_ws]")
         alternate_dirs = InputField("textarea[name=displayScanDirectories]")
+        alternate_dirs_v2 = InputField("textarea[data-ouia-component-id=scan_alt_dirs]")
 
     @overload
     def fill(self, data: NewScanFormDTO): ...

--- a/camayoc/ui/models/pages/sources.py
+++ b/camayoc/ui/models/pages/sources.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import overload
 
+from camayoc.config import settings
 from camayoc.types.ui import AddSourceDTO
 from camayoc.types.ui import AnsibleSourceFormDTO
 from camayoc.types.ui import NetworkSourceFormDTO
@@ -265,6 +266,8 @@ class ScanForm(Form, PopUp, AbstractPage):
 class SourceListElem(AbstractListItem):
     def open_scan(self) -> ScanForm:
         scan_locator = 'td.quipucords-table__td-action button:has-text("Scan")'
+        if settings.camayoc.use_uiv2:
+            scan_locator = 'button[data-ouia-component-id="scan_button"]'
         self.locator.locator(scan_locator).click()
         return ScanForm(client=self._client)
 


### PR DESCRIPTION
Changes needed in Camayoc to tun tests against UIv2.

This is being developed against https://github.com/quipucords/quipucords-ui/pull/463 , which is in draft state. The current plan is:

1. Have enough changes in Camayoc to have at least one of each UI tests passing when running against new UI. That should identify most of changes needed in quipucords-ui for Camayoc to find elements in ergonomic way.
2. Merge quipucords-ui PR. Open this PR for merging
3. Merge this PR
4. Create nightly pipeline that executes Camayoc with UIv2 enabled against quipucords-ui `main`. There are going to be failures, which will be tackled in future PRs.
5. ???
6. Profit. I mean, release new UI. Assuming pipeline is green.

There are multiple commits, as I try to have one commit per area of interest. We can squash later if that is desired.

## How to run:

1. Obtain the quipucords-ui container image with https://github.com/quipucords/quipucords-ui/pull/463 . You might need to build it locally
2. Start quipucords server, using above container image for `quipucords-app`. Make sure that Quipucords is using UIv2.
3. Modify Camayoc config to enable `use_uiv2` setting. Or run `export DYNACONF_camayoc__use_uiv2=True`.
4. Start UI tests:
    ```
    pytest -v -s 'camayoc/tests/qpc/ui/test_login.py' --tracing retain-on-failure --browser chromium
    ```