### PR TITLE
Fix UI tests using network credentials with SSH key when running UIv2

### DIFF
--- a/camayoc/tests/qpc/ui/test_credentials.py
+++ b/camayoc/tests/qpc/ui/test_credentials.py
@@ -14,6 +14,7 @@ from typing import get_args
 import pytest
 from littletable import Table
 
+from camayoc.config import settings
 from camayoc.qpc_models import Credential
 from camayoc.types.ui import AnsibleCredentialFormDTO
 from camayoc.types.ui import CredentialFormDTO
@@ -29,6 +30,7 @@ from camayoc.ui import data_factories
 from camayoc.ui.enums import CredentialTypes
 from camayoc.ui.enums import MainMenuPages
 from camayoc.ui.enums import NetworkCredentialBecomeMethods
+from camayoc.utils import server_container_ssh_key_content
 
 CREDENTIAL_TYPE_MAP = {
     SatelliteCredentialFormDTO: CredentialTypes.SATELLITE,
@@ -61,6 +63,10 @@ def create_credential_dto(credential_type, data_provider):
                 "ssh_key_file": ssh_network_credential.ssh_keyfile,
                 "passphrase": "123456",
             }
+            if settings.camayoc.use_uiv2:
+                ssh_factory_kwargs["ssh_key_file_v2"] = server_container_ssh_key_content(
+                    ssh_network_credential.ssh_keyfile
+                )
             factory_kwargs.update(ssh_factory_kwargs)
         credential_form = form_factory_cls(**factory_kwargs)
         credential = data_factories.AddCredentialDTOFactory(

--- a/camayoc/types/ui.py
+++ b/camayoc/types/ui.py
@@ -22,6 +22,7 @@ from camayoc.ui.enums import NetworkCredentialAuthenticationTypes
 from camayoc.ui.enums import NetworkCredentialBecomeMethods
 from camayoc.ui.enums import SourceConnectionTypes
 from camayoc.ui.enums import SourceTypes
+from camayoc.utils import server_container_ssh_key_content
 
 if TYPE_CHECKING:
     from camayoc.ui import Client
@@ -117,6 +118,7 @@ class SSHNetworkCredentialFormDTO(_NetworkCredentialFormDTO):
         NetworkCredentialAuthenticationTypes.SSH_KEY
     )
     ssh_key_file: str = field(kw_only=True)
+    ssh_key_file_v2: Optional[str] = field(default=None, kw_only=True)
     passphrase: Optional[str] = None
 
     @classmethod
@@ -127,10 +129,16 @@ class SSHNetworkCredentialFormDTO(_NetworkCredentialFormDTO):
         except AttributeError:
             become_method = next(iter(NetworkCredentialBecomeMethods))
 
+        ssh_key = {
+            "ssh_key_file": model.ssh_keyfile,
+        }
+        if settings.camayoc.use_uiv2:
+            ssh_key["ssh_key_file_v2"] = server_container_ssh_key_content(model.ssh_keyfile)
+
         return cls(
             credential_name=model.name,
             username=model.username,
-            ssh_key_file=model.ssh_keyfile,
+            **ssh_key,
             passphrase=model.auth_token,
             become_method=become_method,
             become_user=getattr(model, "become_user", None),

--- a/camayoc/ui/models/components/form.py
+++ b/camayoc/ui/models/components/form.py
@@ -22,6 +22,11 @@ class Form(UIPage):
             raise MisconfiguredWidgetException(msg.format(type(self).__name__, self))
 
         field_names = [f.name for f in fields(type(data))]
+        # we can't filter out _v2 fields every time because there are
+        # cases where new UI introduces completely new field, and we can't
+        # find them if we only look for oldfield_v2
+        if not settings.camayoc.use_uiv2:
+            field_names = [fname for fname in field_names if not fname.endswith("_v2")]
         form_fields = [f for f in form_definition.__dict__ if not f.startswith("_")]
         ordered_field_names = [f for f in form_fields if f in field_names]
 

--- a/camayoc/ui/models/pages/credentials.py
+++ b/camayoc/ui/models/pages/credentials.py
@@ -45,6 +45,9 @@ class NetworkCredentialForm(CredentialForm):
         username = InputField("input[data-ouia-component-id=username]")
         password = InputField("input[data-ouia-component-id=password]")
         ssh_key_file = InputField("input[data-ouia-component-id=ssh_keyfile]")
+        # FIXME: this should be called `ssh_key_v2`, but using v1 field name
+        # makes things easier during transition period
+        ssh_key_file_v2 = InputField("textarea[data-ouia-component-id=ssh_key]")
         passphrase = InputField("input[data-ouia-component-id=ssh_passphrase]")
         become_method = SelectField("div[data-ouia-component-id=become_method] > button")
         become_method_v2 = SelectField("button[data-ouia-component-id=become_method]")

--- a/camayoc/utils.py
+++ b/camayoc/utils.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import tempfile
 import uuid
+from pathlib import Path
 from urllib.parse import urlunparse
 
 from camayoc.config import settings
@@ -68,3 +69,17 @@ def expected_data_has_attribute(scan_definition: ScanOptions, attr_name: str) ->
         if getattr(expected_data, attr_name, None):
             return True
     return False
+
+
+def server_container_ssh_key_content(container_path: str):
+    ssh_key_filename = Path(container_path).relative_to("/sshkeys/")
+    for product_name in ("quipucords", "discovery"):
+        # FIXME: could/should we re-purpose settings.quipucords_server.ssh_keyfile_path ?
+        ssh_dir = f"~/.local/share/{product_name}/sshkeys/"
+        ssh_key_path = Path(ssh_dir).expanduser().resolve() / ssh_key_filename
+        try:
+            return ssh_key_path.read_text()
+        except OSError:
+            continue
+    msg = f"SSH file not found in local file system: {ssh_key_filename}"
+    raise OSError(msg)


### PR DESCRIPTION
Subject says it all - with that patch, UI tests that use network credentials with SSH key pass when running against UI v2. In fact, with that patch **all** the UI tests pass when running against UI v2.

The only new commit here is 735f6686772f40c3b2cd93d0af03b8bce388dd7d . Otherwise, it includes entirety of https://github.com/quipucords/camayoc/pull/541 . I open it as draft for now, with the plan that we merge #541 and then I will rebase that and open it for merge.