### PR TITLE
New UI: Ensure there's single element to click

### DIFF
--- a/camayoc/ui/models/components/add_new_dropdown.py
+++ b/camayoc/ui/models/components/add_new_dropdown.py
@@ -25,8 +25,8 @@ class AddNewDropdown(UIPage):
         exp = TimeoutError(exp_msg)
         for _ in range(5):
             try:
-                self._driver.locator(add_button_locator).click(timeout=default_timeout)
-                self._driver.locator(dropdown_item_locator).click(timeout=default_timeout)
+                self._driver.locator(add_button_locator).first.click(timeout=default_timeout)
+                self._driver.locator(dropdown_item_locator).first.click(timeout=default_timeout)
                 return
             except TimeoutError as e:
                 exp = e


### PR DESCRIPTION
`.locator()` can match multiple elements on the page. `.locator().click()` [works in strict mode](https://playwright.dev/python/docs/locators#strictness), i.e. Playwright will refuse the operation if `.locator()` matches multiple elements. This is a change compared to `.click(locator_string)`, which would happily operate on first element matching the locator_string.

Using `.first` between `.locator()` and `.click()` ensures there's single element to operate on.

This fixes a bug that is only present when running some tests on empty database. Which happens to be a case in pipeline.