### PR TITLE
Introduce setting to not clean up on test suite run end

### DIFF
--- a/camayoc/config.py
+++ b/camayoc/config.py
@@ -20,6 +20,7 @@ default_dynaconf_validators = [
     Validator("camayoc.run_scans", default=False),
     Validator("camayoc.scan_timeout", default=600),
     Validator("camayoc.use_uiv2", default=False),
+    Validator("camayoc.db_cleanup", default=True),
     Validator("quipucords_server.hostname", default=""),
     Validator("quipucords_server.https", default=False),
     Validator("quipucords_server.port", default=8000),

--- a/camayoc/tests/qpc/conftest.py
+++ b/camayoc/tests/qpc/conftest.py
@@ -3,6 +3,7 @@
 import pytest
 
 from camayoc import api
+from camayoc.config import settings
 from camayoc.data_provider import DataProvider
 from camayoc.data_provider import ScanContainer
 from camayoc.tests.qpc.cli.utils import clear_all_entities
@@ -14,7 +15,8 @@ def data_provider():
 
     yield dp
 
-    dp.cleanup()
+    if settings.camayoc.db_cleanup:
+        dp.cleanup()
 
 
 @pytest.fixture(scope="module")

--- a/camayoc/types/settings.py
+++ b/camayoc/types/settings.py
@@ -13,6 +13,7 @@ class CamayocOptions(BaseModel):
     run_scans: Optional[bool] = False
     scan_timeout: Optional[int] = 600
     use_uiv2: Optional[bool] = False
+    db_cleanup: Optional[bool] = True
 
 
 class QuipucordsServerOptions(BaseModel):


### PR DESCRIPTION
Camayoc deletes all data it has created at the end of test suite run. Historically it was because we used long-running Discovery servers. It still provides value in implicitly testing deletion, and is still useful in local runs when you are developing a test and want to start with clean state every time.

But sometimes you want to have Discovery with some data, and you might want to use Camayoc to create that data. And in this specific case you don't want Camayoc to clean up because you are not really testing, you are preparing the environment.

Thanks to this new setting, you can now decide if Camayoc should remove data or not. The default is to remove.

Usually you will probably use it like that:

    DYNACONF_camayoc__db_cleanup=False pytest -v camayoc/tests/...