### PR TITLE
Default to using uiv2

### DIFF
--- a/camayoc/config.py
+++ b/camayoc/config.py
@@ -19,7 +19,7 @@ from camayoc.types.settings import Configuration
 default_dynaconf_validators = [
     Validator("camayoc.run_scans", default=False),
     Validator("camayoc.scan_timeout", default=600),
-    Validator("camayoc.use_uiv2", default=False),
+    Validator("camayoc.use_uiv2", default=True),
     Validator("camayoc.db_cleanup", default=True),
     Validator("quipucords_server.hostname", default=""),
     Validator("quipucords_server.https", default=False),

--- a/camayoc/types/settings.py
+++ b/camayoc/types/settings.py
@@ -12,7 +12,7 @@ from typing_extensions import Annotated
 class CamayocOptions(BaseModel):
     run_scans: Optional[bool] = False
     scan_timeout: Optional[int] = 600
-    use_uiv2: Optional[bool] = False
+    use_uiv2: Optional[bool] = True
     db_cleanup: Optional[bool] = True
 
 


### PR DESCRIPTION
This should be merged **after** downstream container image with new UI is build (not necessarily released) - [DISCOVERY-867](https://issues.redhat.com/browse/DISCOVERY-867). There are also PRs in discovery-ci and swatch-ci repos that should go in at around the same time.

As UI v2 has been released downstream, it is now available everywhere. Default use_uiv2 to True, so Camayoc uses it by default.

Old UI can still be used by setting use_uiv2 to False. That support will be removed at later date.