### PR TITLE
Fix assertion after downstream branding change

### DIFF
--- a/camayoc/tests/qpc/ui/test_login.py
+++ b/camayoc/tests/qpc/ui/test_login.py
@@ -25,5 +25,5 @@ def test_login_logout(ui_client: Client):
     :expectedresults: Both login and logout must work.
     """
     page = ui_client.begin().login(data_factories.LoginFormDTOFactory())
-    assert page._driver.title() in ("Quipucords", "product discovery")
+    assert page._driver.title() in ("Quipucords", "Discovery")
     page.logout()


### PR DESCRIPTION
New UI uses "Discovery" as downstream brand name, not "product discovery".