### PR TITLE
Move credentials to API V2

### DIFF
--- a/camayoc/api.py
+++ b/camayoc/api.py
@@ -17,7 +17,9 @@ from requests.exceptions import HTTPError
 
 from camayoc import exceptions
 from camayoc.config import settings
-from camayoc.constants import QPC_API_VERSION
+from camayoc.constants import QPC_API_ROOT
+from camayoc.constants import QPC_CURRENT_USER_PATH
+from camayoc.constants import QPC_LOGOUT_PATH
 from camayoc.constants import QPC_TOKEN_PATH
 
 
@@ -136,7 +138,7 @@ class Client(object):
             scheme = "https" if self.config.https else "http"
             port = str(self.config.port)
             netloc = hostname + ":{}".format(port) if port else hostname
-            self.url = urlunparse((scheme, netloc, QPC_API_VERSION, "", "", ""))
+            self.url = urlunparse((scheme, netloc, QPC_API_ROOT, "", "", ""))
 
         if not self.url:
             raise exceptions.QPCBaseUrlNotFound(
@@ -170,7 +172,7 @@ class Client(object):
         Send a PUT request /api/v1/users/logout to make
         current token invalid.
         """
-        url = urljoin(self.url, "users/logout/")
+        url = urljoin(self.url, QPC_LOGOUT_PATH)
         self.request("PUT", url, **kwargs)
         self.token = None
 
@@ -179,7 +181,7 @@ class Client(object):
 
         Send a GET request ot /api/v1/users/current/' and return the response.
         """
-        url = urljoin(self.url, "users/current/")
+        url = urljoin(self.url, QPC_CURRENT_USER_PATH)
         return self.request("GET", url, **kwargs)
 
     def default_headers(self):

--- a/camayoc/constants.py
+++ b/camayoc/constants.py
@@ -36,7 +36,7 @@ VAULT_PASSWORD = utils.uuid4()
 QPC_API_ROOT = "api/"
 """The root path to access the QPC server API."""
 
-QPC_CREDENTIALS_PATH = "v1/credentials/"
+QPC_CREDENTIALS_PATH = "v2/credentials/"
 """The path to the credentials endpoint for CRUD tasks."""
 
 QPC_SOURCE_PATH = "v1/sources/"

--- a/camayoc/constants.py
+++ b/camayoc/constants.py
@@ -33,22 +33,22 @@ SUDO_PASSWORD_INPUT = "Provide password for sudo.\r\nPassword:"
 VAULT_PASSWORD = utils.uuid4()
 """Vault password will be unique across Python sessions."""
 
-QPC_API_VERSION = "api/v1/"
+QPC_API_ROOT = "api/"
 """The root path to access the QPC server API."""
 
-QPC_CREDENTIALS_PATH = "credentials/"
+QPC_CREDENTIALS_PATH = "v1/credentials/"
 """The path to the credentials endpoint for CRUD tasks."""
 
-QPC_SOURCE_PATH = "sources/"
+QPC_SOURCE_PATH = "v1/sources/"
 """The path to the profiles endpoint for CRUD tasks."""
 
-QPC_SCAN_PATH = "scans/"
+QPC_SCAN_PATH = "v1/scans/"
 """The path to the scans endpoint for CRUD tasks."""
 
-QPC_SCANJOB_PATH = "jobs/"
+QPC_SCANJOB_PATH = "v1/jobs/"
 """The path to the scanjob endpoint for CRUD tasks."""
 
-QPC_REPORTS_PATH = "reports/"
+QPC_REPORTS_PATH = "v1/reports/"
 """The path to the endpoint used for obtaining reports."""
 
 QPC_SCAN_TERMINAL_STATES = ("completed", "failed", "canceled")
@@ -57,8 +57,14 @@ QPC_SCAN_TERMINAL_STATES = ("completed", "failed", "canceled")
 QPC_SCAN_STATES = QPC_SCAN_TERMINAL_STATES + ("running",)
 """All the states that a quipucords scan can take."""
 
-QPC_TOKEN_PATH = "token/"
+QPC_TOKEN_PATH = "v1/token/"
 """The path to the endpoint used for obtaining an authentication token."""
+
+QPC_LOGOUT_PATH = "v1/users/logout/"
+"""The path to the endpoint used to log user out."""
+
+QPC_CURRENT_USER_PATH = "v1/users/current/"
+"""The path to the endpoint that has information about current user."""
 
 QPC_SOURCE_TYPES = (
     "vcenter",

--- a/camayoc/qpc_models.py
+++ b/camayoc/qpc_models.py
@@ -17,6 +17,7 @@ from camayoc.constants import QPC_SOURCE_PATH
 from camayoc.types.settings import CredentialOptions
 from camayoc.types.settings import ScanOptions
 from camayoc.types.settings import SourceOptions
+from camayoc.utils import server_container_ssh_key_content
 from camayoc.utils import uuid4
 
 OPTIONAL_PROD_KEY = "disabled_optional_products"
@@ -176,7 +177,7 @@ class Credential(QPCObject, QPCObjectBulkDeleteMixin):
     Host credentials can be created by instantiating a Credential
     object. A unique name and username are provided by default.
     In order to create a valid host credential you must specify either a
-    password or ssh_keyfile or auth_token.
+    password or ssh_key or auth_token.
 
     Example::
         >>> from camayoc import api
@@ -195,7 +196,7 @@ class Credential(QPCObject, QPCObjectBulkDeleteMixin):
         name=None,
         username=None,
         password=None,
-        ssh_keyfile=None,
+        ssh_key=None,
         auth_token=None,
         cred_type=None,
         become_method=None,
@@ -215,7 +216,7 @@ class Credential(QPCObject, QPCObjectBulkDeleteMixin):
             username = uuid4()
         self.username = username
         self.password = password
-        self.ssh_keyfile = ssh_keyfile
+        self.ssh_key = ssh_key
         self.auth_token = auth_token
         self.cred_type = cred_type
         if become_method is not None:
@@ -230,7 +231,7 @@ class Credential(QPCObject, QPCObjectBulkDeleteMixin):
         cls, definition: CredentialOptions, dependencies: Optional[list[int]] = None
     ):
         attrs_translation_map = {
-            "sshkeyfile": "ssh_keyfile",
+            "sshkeyfile": "ssh_key",
             "type": "cred_type",
         }
         definition_data = {}
@@ -239,6 +240,8 @@ class Credential(QPCObject, QPCObjectBulkDeleteMixin):
                 continue
             if new_definition_key := attrs_translation_map.get(definition_key):
                 definition_key = new_definition_key
+            if definition_key == "ssh_key":
+                definition_value = server_container_ssh_key_content(definition_value)
             definition_data[definition_key] = definition_value
         return cls(**definition_data)
 

--- a/camayoc/tests/qpc/cli/test_credentials.py
+++ b/camayoc/tests/qpc/cli/test_credentials.py
@@ -25,7 +25,6 @@ from camayoc.tests.qpc.cli.utils import cred_show_and_check
 from camayoc.tests.qpc.cli.utils import source_add_and_check
 from camayoc.tests.qpc.cli.utils import source_show
 from camayoc.utils import client_cmd
-from camayoc.utils import server_container_ssh_key_content
 
 
 def generate_show_output(data):
@@ -144,9 +143,7 @@ def test_add_with_username_sshkeyfile(data_provider, qpc_server_config):
 
     cred_add_and_check(
         {"name": name, "username": username, "sshkey": None},
-        inputs=[
-            ("Private SSH Key:", server_container_ssh_key_content(sshkeyfile_cred.ssh_keyfile))
-        ],
+        inputs=[("Private SSH Key:", sshkeyfile_cred.ssh_key)],
     )
 
     cred_show_and_check(
@@ -191,7 +188,7 @@ def test_add_with_username_sshkeyfile_become_password(data_provider, qpc_server_
             "become-password": None,
         },
         inputs=[
-            ("Private SSH Key:", server_container_ssh_key_content(sshkeyfile_cred.ssh_keyfile)),
+            ("Private SSH Key:", sshkeyfile_cred.ssh_key),
             (BECOME_PASSWORD_INPUT, utils.uuid4()),
         ],
     )
@@ -400,9 +397,7 @@ def test_edit_sshkeyfile_negative(data_provider, qpc_server_config):
     )
     cred_add_and_check(
         {"name": name, "username": username, "sshkey": None},
-        inputs=[
-            ("Private SSH Key:", server_container_ssh_key_content(sshkeyfile_cred.ssh_keyfile))
-        ],
+        inputs=[("Private SSH Key:", sshkeyfile_cred.ssh_key)],
     )
 
     name = utils.uuid4()

--- a/camayoc/tests/qpc/cli/utils.py
+++ b/camayoc/tests/qpc/cli/utils.py
@@ -107,6 +107,12 @@ def cred_add_and_check(options, inputs=None, exitstatus=0):
     for prompt, value in inputs:
         assert qpc_cred_add.expect(prompt) == 0
         qpc_cred_add.sendline(value)
+        # SSH key (and potentially other fields in the future) is multiline input,
+        # which requires signaling end of input with ^D. Unfortunately, inputs
+        # is a list of 2-tuples and we can't mark *some* inputs as multiline
+        # without modifying all calls that have `inputs` param...
+        if "private ssh key" in prompt.lower():
+            qpc_cred_add.sendcontrol("d")
     if "name" in options:
         assert qpc_cred_add.expect('Credential "{}" was added'.format(options["name"])) == 0
     assert qpc_cred_add.expect(pexpect.EOF) == 0

--- a/camayoc/tests/qpc/ui/test_credentials.py
+++ b/camayoc/tests/qpc/ui/test_credentials.py
@@ -29,7 +29,6 @@ from camayoc.ui import data_factories
 from camayoc.ui.enums import CredentialTypes
 from camayoc.ui.enums import MainMenuPages
 from camayoc.ui.enums import NetworkCredentialBecomeMethods
-from camayoc.utils import server_container_ssh_key_content
 
 CREDENTIAL_TYPE_MAP = {
     SatelliteCredentialFormDTO: CredentialTypes.SATELLITE,
@@ -59,9 +58,7 @@ def create_credential_dto(credential_type, data_provider):
                 data_only=True,
             )
             ssh_factory_kwargs = {
-                "ssh_key_file": server_container_ssh_key_content(
-                    ssh_network_credential.ssh_keyfile
-                ),
+                "ssh_key_file": ssh_network_credential.ssh_key,
                 "passphrase": "123456",
             }
             factory_kwargs.update(ssh_factory_kwargs)

--- a/camayoc/types/ui.py
+++ b/camayoc/types/ui.py
@@ -21,7 +21,6 @@ from camayoc.ui.enums import NetworkCredentialAuthenticationTypes
 from camayoc.ui.enums import NetworkCredentialBecomeMethods
 from camayoc.ui.enums import SourceConnectionTypes
 from camayoc.ui.enums import SourceTypes
-from camayoc.utils import server_container_ssh_key_content
 
 if TYPE_CHECKING:
     from camayoc.ui import Client
@@ -129,7 +128,7 @@ class SSHNetworkCredentialFormDTO(_NetworkCredentialFormDTO):
         return cls(
             credential_name=model.name,
             username=model.username,
-            ssh_key_file=server_container_ssh_key_content(model.ssh_keyfile),
+            ssh_key_file=model.ssh_key,
             passphrase=model.auth_token,
             become_method=become_method,
             become_user=getattr(model, "become_user", None),
@@ -141,7 +140,7 @@ class SSHNetworkCredentialFormDTO(_NetworkCredentialFormDTO):
             cred_type="network",
             name=self.credential_name,
             username=self.username,
-            ssh_keyfile=self.ssh_key_file,
+            ssh_key=self.ssh_key_file,
             auth_token=self.passphrase,
             become_method=self.become_method.value,
             become_user=self.become_user,
@@ -273,7 +272,7 @@ class AddCredentialDTO:
             case "network":
                 credential_type = CredentialTypes.NETWORK
                 dto_cls = PlainNetworkCredentialFormDTO
-                if model.ssh_keyfile:
+                if model.ssh_key:
                     dto_cls = SSHNetworkCredentialFormDTO
                 credential_form_dto = dto_cls.from_model(model)
             case "satellite":

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -25,7 +25,7 @@ MOCK_CREDENTIAL = {
     "id": 34,
     "name": "91311585-77b3-4352-a277-cf9507a04ffc",
     "password": "********",
-    "ssh_keyfile": None,
+    "ssh_key": None,
     "sudo_password": None,
     "cred_type": "network",
     "username": "6c71666b-df97-4d50-91bd-10003569e843",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -66,7 +66,7 @@ class APIClientTestCase(unittest.TestCase):
     def test_create_with_config(self):
         """If a hostname is specified in the config file, we use it."""
         client = api.Client(authenticate=False, config=CAMAYOC_CONFIG)
-        self.assertEqual(client.url, "http://example.com:8000/api/v1/")
+        self.assertEqual(client.url, "http://example.com:8000/api/")
 
     def test_create_specific_url(self):
         """If a base url is specified we use it."""
@@ -93,7 +93,7 @@ class APIClientTestCase(unittest.TestCase):
         cl = client(config=CAMAYOC_CONFIG)
         u = cl.get_user().json()["username"]
         assert u == CAMAYOC_CONFIG.username
-        client.request.assert_called_once_with("GET", urljoin(cl.url, "users/current/"))
+        client.request.assert_called_once_with("GET", urljoin(cl.url, "v1/users/current/"))
 
     def test_logout(self):
         """Test that when we log out, all credentials are cleared."""

--- a/tests/test_data_provider.py
+++ b/tests/test_data_provider.py
@@ -9,13 +9,15 @@ from camayoc.types.settings import SourceOptions
 from camayoc.types.settings import SSHNetworkCredentialOptions
 from camayoc.types.settings import VCenterCredentialOptions
 
+MOCK_SSH_KEY_CONTENT = "--BEGIN OPENSSH PRIVATE KEY--"
+
 CREDENTIALS = [
     SSHNetworkCredentialOptions(
         **{
             "name": "network",
             "type": "network",
             "username": "root",
-            "sshkeyfile": "~/.ssh/id_rsa",
+            "sshkeyfile": "/sshkeys/id_rsa",
         }
     ),
     VCenterCredentialOptions(
@@ -64,63 +66,79 @@ SCANS = [
 
 def test_defined_one():
     dp = DataProvider(credentials=CREDENTIALS, sources=SOURCES, scans=SCANS)
-    with mock.patch("camayoc.api.Client"):
-        with mock.patch.object(dp.credentials._model_class, "create") as mock_create:
-            cred = dp.credentials.defined_one({"type": "network"})
-            mock_create.assert_called_once()
+    with (
+        mock.patch("camayoc.api.Client"),
+        mock.patch.object(dp.credentials._model_class, "create") as mock_create,
+        mock.patch("camayoc.qpc_models.server_container_ssh_key_content") as mock_ssh_key_content,
+    ):
+        mock_ssh_key_content.return_value = MOCK_SSH_KEY_CONTENT
+        cred = dp.credentials.defined_one({"type": "network"})
+        mock_create.assert_called_once()
     assert cred.name == "network"
     assert cred.username == "root"
-    assert cred.ssh_keyfile == "~/.ssh/id_rsa"
+    assert cred.ssh_key == MOCK_SSH_KEY_CONTENT
 
 
 def test_defined_reuse():
     dp = DataProvider(credentials=CREDENTIALS, sources=SOURCES, scans=SCANS)
-    with mock.patch("camayoc.api.Client"):
-        with mock.patch.object(dp.credentials._model_class, "create") as mock_create:
-            cred1 = dp.credentials.defined_one({"type": "network"})
-            cred2 = dp.credentials.defined_one({"type": "network"})
-            mock_create.assert_called_once()
+    with (
+        mock.patch("camayoc.api.Client"),
+        mock.patch.object(dp.credentials._model_class, "create") as mock_create,
+        mock.patch("camayoc.qpc_models.server_container_ssh_key_content") as mock_ssh_key_content,
+    ):
+        mock_ssh_key_content.return_value = MOCK_SSH_KEY_CONTENT
+        cred1 = dp.credentials.defined_one({"type": "network"})
+        cred2 = dp.credentials.defined_one({"type": "network"})
+        mock_create.assert_called_once()
     assert cred1.name == "network"
     assert cred1.username == "root"
-    assert cred1.ssh_keyfile == "~/.ssh/id_rsa"
+    assert cred1.ssh_key == MOCK_SSH_KEY_CONTENT
     assert cred1.equivalent(cred2)
 
 
 def test_new_one():
     dp = DataProvider(credentials=CREDENTIALS, sources=SOURCES, scans=SCANS)
-    with mock.patch("camayoc.api.Client"):
-        with mock.patch.object(dp.credentials._model_class, "create") as mock_create:
-            cred = dp.credentials.new_one({"type": "network"}, data_only=False)
-            mock_create.assert_called_once()
+    with (
+        mock.patch("camayoc.api.Client"),
+        mock.patch.object(dp.credentials._model_class, "create") as mock_create,
+        mock.patch("camayoc.qpc_models.server_container_ssh_key_content") as mock_ssh_key_content,
+    ):
+        mock_ssh_key_content.return_value = MOCK_SSH_KEY_CONTENT
+        cred = dp.credentials.new_one({"type": "network"}, data_only=False)
+        mock_create.assert_called_once()
     assert cred.name != "network"
     assert cred.username == "root"
-    assert cred.ssh_keyfile == "~/.ssh/id_rsa"
+    assert cred.ssh_key == MOCK_SSH_KEY_CONTENT
 
 
 def test_new_one_data_only():
     dp = DataProvider(credentials=CREDENTIALS, sources=SOURCES, scans=SCANS)
-    with mock.patch("camayoc.api.Client"):
-        with mock.patch.object(dp.credentials._model_class, "create") as mock_create:
-            cred = dp.credentials.new_one({"type": "network"}, data_only=True)
-            mock_create.assert_not_called()
+    with (
+        mock.patch("camayoc.api.Client"),
+        mock.patch.object(dp.credentials._model_class, "create") as mock_create,
+        mock.patch("camayoc.qpc_models.server_container_ssh_key_content") as mock_ssh_key_content,
+    ):
+        mock_ssh_key_content.return_value = MOCK_SSH_KEY_CONTENT
+        cred = dp.credentials.new_one({"type": "network"}, data_only=True)
+        mock_create.assert_not_called()
     assert cred.name != "network"
     assert cred.username == "root"
-    assert cred.ssh_keyfile == "~/.ssh/id_rsa"
+    assert cred.ssh_key == MOCK_SSH_KEY_CONTENT
 
 
 def test_new_with_dependencies():
     dp = DataProvider(credentials=CREDENTIALS, sources=SOURCES, scans=SCANS)
-    with mock.patch("camayoc.api.Client"):
-        with mock.patch.object(dp.credentials._model_class, "create") as mock_cred_create:
-            with mock.patch.object(dp.sources._model_class, "create") as mock_source_create:
-                source1 = dp.sources.new_one(
-                    {"type": "network"}, new_dependencies=True, data_only=False
-                )
-                source2 = dp.sources.new_one(
-                    {"type": "network"}, new_dependencies=True, data_only=False
-                )
-                assert mock_cred_create.call_count == 2
-                assert mock_source_create.call_count == 2
+    with (
+        mock.patch("camayoc.api.Client"),
+        mock.patch.object(dp.credentials._model_class, "create") as mock_cred_create,
+        mock.patch.object(dp.sources._model_class, "create") as mock_source_create,
+        mock.patch("camayoc.qpc_models.server_container_ssh_key_content") as mock_ssh_key_content,
+    ):
+        mock_ssh_key_content.return_value = MOCK_SSH_KEY_CONTENT
+        source1 = dp.sources.new_one({"type": "network"}, new_dependencies=True, data_only=False)
+        source2 = dp.sources.new_one({"type": "network"}, new_dependencies=True, data_only=False)
+        assert mock_cred_create.call_count == 2
+        assert mock_source_create.call_count == 2
     assert len(dp.credentials._created_models) == 2
     assert source1.name != "mynetwork"
     assert source1.name.startswith("mynetwork")
@@ -129,17 +147,17 @@ def test_new_with_dependencies():
 
 def test_new_without_dependencies():
     dp = DataProvider(credentials=CREDENTIALS, sources=SOURCES, scans=SCANS)
-    with mock.patch("camayoc.api.Client"):
-        with mock.patch.object(dp.credentials._model_class, "create") as mock_cred_create:
-            with mock.patch.object(dp.sources._model_class, "create") as mock_source_create:
-                source1 = dp.sources.new_one(
-                    {"type": "network"}, new_dependencies=False, data_only=False
-                )
-                source2 = dp.sources.new_one(
-                    {"type": "network"}, new_dependencies=False, data_only=False
-                )
-                mock_cred_create.assert_called_once()
-                assert mock_source_create.call_count == 2
+    with (
+        mock.patch("camayoc.api.Client"),
+        mock.patch.object(dp.credentials._model_class, "create") as mock_cred_create,
+        mock.patch.object(dp.sources._model_class, "create") as mock_source_create,
+        mock.patch("camayoc.qpc_models.server_container_ssh_key_content") as mock_ssh_key_content,
+    ):
+        mock_ssh_key_content.return_value = MOCK_SSH_KEY_CONTENT
+        source1 = dp.sources.new_one({"type": "network"}, new_dependencies=False, data_only=False)
+        source2 = dp.sources.new_one({"type": "network"}, new_dependencies=False, data_only=False)
+        mock_cred_create.assert_called_once()
+        assert mock_source_create.call_count == 2
     assert len(dp.credentials._created_models) == 1
     assert source1.name != "mynetwork"
     assert source1.name.startswith("mynetwork")
@@ -154,26 +172,34 @@ def test_new_no_match():
 
 def test_automatic_cleanup():
     dp = DataProvider(credentials=CREDENTIALS, sources=SOURCES, scans=SCANS)
-    with mock.patch("camayoc.api.Client"):
-        with mock.patch.object(dp.credentials._model_class, "bulk_delete") as mock_delete:
-            cred = dp.credentials.new_one({"type": "network"}, data_only=False)
-            cred._id = 123
-            mock_delete.return_value = mock.Mock
-            mock_delete.return_value.status_code = mock.PropertyMock(return_value=200)
-            dp.cleanup()
-            mock_delete.assert_called()
+    with (
+        mock.patch("camayoc.api.Client"),
+        mock.patch.object(dp.credentials._model_class, "bulk_delete") as mock_delete,
+        mock.patch("camayoc.qpc_models.server_container_ssh_key_content") as mock_ssh_key_content,
+    ):
+        mock_ssh_key_content.return_value = MOCK_SSH_KEY_CONTENT
+        cred = dp.credentials.new_one({"type": "network"}, data_only=False)
+        cred._id = 123
+        mock_delete.return_value = mock.Mock
+        mock_delete.return_value.status_code = mock.PropertyMock(return_value=200)
+        dp.cleanup()
+        mock_delete.assert_called()
 
 
 def test_mark_for_cleanup():
     dp = DataProvider(credentials=CREDENTIALS, sources=SOURCES, scans=SCANS)
-    with mock.patch("camayoc.api.Client"):
-        with mock.patch.object(dp.credentials._model_class, "bulk_delete") as mock_delete:
-            cred = dp.credentials.new_one({"type": "network"}, data_only=True)
-            cred._id = 123
-            mock_delete.return_value = mock.Mock
-            mock_delete.return_value.status_code = mock.PropertyMock(return_value=200)
-            dp.cleanup()
-            mock_delete.assert_not_called()
-            dp.mark_for_cleanup(cred)
-            dp.cleanup()
-            mock_delete.assert_called()
+    with (
+        mock.patch("camayoc.api.Client"),
+        mock.patch.object(dp.credentials._model_class, "bulk_delete") as mock_delete,
+        mock.patch("camayoc.qpc_models.server_container_ssh_key_content") as mock_ssh_key_content,
+    ):
+        mock_ssh_key_content.return_value = MOCK_SSH_KEY_CONTENT
+        cred = dp.credentials.new_one({"type": "network"}, data_only=True)
+        cred._id = 123
+        mock_delete.return_value = mock.Mock
+        mock_delete.return_value.status_code = mock.PropertyMock(return_value=200)
+        dp.cleanup()
+        mock_delete.assert_not_called()
+        dp.mark_for_cleanup(cred)
+        dp.cleanup()
+        mock_delete.assert_called()


### PR DESCRIPTION
Let Camayoc use API V2 for credentials.

This is just enough changes needed to make entire Camayoc pass locally. Admittedly, this is not the best time to introduce it, as we are already in the middle of UI transition, where Camayoc is in awkward spot where it still supports old UI. If support for old UI is removed first, it will most likely conflict with changes here.

qpc tests need [qpc `credentials-v2` branch](https://github.com/quipucords/qpc/pull/352). Both qpc PR and that one will need to be merged close to each other, and we will have to rely on standalone jobs for tests results until then. Obviously this is not backwards-compatible, so it will wreak havoc on downstream pipeline. I would suggest to let downstream run at least few times before we merge that.

See individual commits for detailed changes. I separated them to tell a story, and would prefer to merge them without squashing.