### PR TITLE
get-version.py: implement obtaining frontend and installer versions

### DIFF
--- a/scripts/get-version.py
+++ b/scripts/get-version.py
@@ -33,7 +33,7 @@ def rpm_pkg_versions(*package_names):
 
 def get_backend_version():
     api_client = api.Client()
-    server_status = api_client.get("status/")
+    server_status = api_client.get("v1/status/")
     server_version = server_status.json().get("server_version")
     return server_version
 


### PR DESCRIPTION
Teach `get-version.py` to obtain frontend (app) version from running container, and read installer version from rpm data or git.

Kind-of depends on https://github.com/quipucords/quipucords-ui/pull/530

Relates to JIRA: DISCOVERY-748