### PR TITLE
More UI tests

### DIFF
--- a/camayoc/tests/qpc/ui/test_credentials.py
+++ b/camayoc/tests/qpc/ui/test_credentials.py
@@ -33,7 +33,6 @@ from camayoc.ui.enums import NetworkCredentialBecomeMethods
 CREDENTIAL_TYPE_MAP = {
     SatelliteCredentialFormDTO: CredentialTypes.SATELLITE,
     VCenterCredentialFormDTO: CredentialTypes.VCENTER,
-    OpenShiftCredentialFormDTO: CredentialTypes.OPENSHIFT,
     AnsibleCredentialFormDTO: CredentialTypes.ANSIBLE,
     RHACSCredentialFormDTO: CredentialTypes.RHACS,
 }
@@ -66,6 +65,14 @@ def create_credential_dto(credential_type, data_provider):
         credential = data_factories.AddCredentialDTOFactory(
             credential_type=CredentialTypes.NETWORK,
             credential_form=credential_form,
+        )
+        data_provider.mark_for_cleanup(Credential(name=credential_form.credential_name))
+        return credential
+    elif issubclass(credential_type, get_args(OpenShiftCredentialFormDTO)):
+        form_factory_cls = getattr(data_factories, f"{credential_type.__name__}Factory")
+        credential_form = form_factory_cls()
+        credential = data_factories.AddCredentialDTOFactory(
+            credential_type=CredentialTypes.OPENSHIFT, credential_form=credential_form
         )
         data_provider.mark_for_cleanup(Credential(name=credential_form.credential_name))
         return credential

--- a/camayoc/types/ui.py
+++ b/camayoc/types/ui.py
@@ -19,6 +19,7 @@ from camayoc.qpc_models import Source
 from camayoc.ui.enums import CredentialTypes
 from camayoc.ui.enums import NetworkCredentialAuthenticationTypes
 from camayoc.ui.enums import NetworkCredentialBecomeMethods
+from camayoc.ui.enums import OpenShiftCredentialAuthenticationTypes
 from camayoc.ui.enums import SourceConnectionTypes
 from camayoc.ui.enums import SourceTypes
 
@@ -196,9 +197,35 @@ class VCenterCredentialFormDTO:
 
 
 @frozen
-class OpenShiftCredentialFormDTO:
+class PlainOpenShiftCredentialFormDTO:
+    credential_name: str
+    username: str
+    password: str
+    authentication_type: OpenShiftCredentialAuthenticationTypes = (
+        OpenShiftCredentialAuthenticationTypes.USERNAME_AND_PASSWORD
+    )
+
+    @classmethod
+    def from_model(cls, model: Credential):
+        return cls(credential_name=model.name, username=model.username, password=model.password)
+
+    def to_model(self):
+        model = Credential(
+            cred_type="openshift",
+            name=self.credential_name,
+            username=self.username,
+            password=self.password,
+        )
+        return model
+
+
+@frozen
+class TokenOpenShiftCredentialFormDTO:
     credential_name: str
     token: str
+    authentication_type: OpenShiftCredentialAuthenticationTypes = (
+        OpenShiftCredentialAuthenticationTypes.TOKEN
+    )
 
     @classmethod
     def from_model(cls, model: Credential):
@@ -211,6 +238,12 @@ class OpenShiftCredentialFormDTO:
             auth_token=self.token,
         )
         return model
+
+
+OpenShiftCredentialFormDTO = Union[
+    PlainOpenShiftCredentialFormDTO,
+    TokenOpenShiftCredentialFormDTO,
+]
 
 
 @frozen

--- a/camayoc/ui/data_factories.py
+++ b/camayoc/ui/data_factories.py
@@ -20,12 +20,14 @@ from camayoc.types.ui import NewScanFormDTO
 from camayoc.types.ui import OpenShiftCredentialFormDTO
 from camayoc.types.ui import OpenShiftSourceFormDTO
 from camayoc.types.ui import PlainNetworkCredentialFormDTO
+from camayoc.types.ui import PlainOpenShiftCredentialFormDTO
 from camayoc.types.ui import RHACSCredentialFormDTO
 from camayoc.types.ui import RHACSSourceFormDTO
 from camayoc.types.ui import SatelliteCredentialFormDTO
 from camayoc.types.ui import SatelliteSourceFormDTO
 from camayoc.types.ui import SourceFormDTO
 from camayoc.types.ui import SSHNetworkCredentialFormDTO
+from camayoc.types.ui import TokenOpenShiftCredentialFormDTO
 from camayoc.types.ui import TriggerScanDTO
 from camayoc.types.ui import VCenterCredentialFormDTO
 from camayoc.types.ui import VCenterSourceFormDTO
@@ -33,6 +35,7 @@ from camayoc.types.ui import VCenterSourceFormDTO
 from .enums import CredentialTypes
 from .enums import NetworkCredentialAuthenticationTypes
 from .enums import NetworkCredentialBecomeMethods
+from .enums import OpenShiftCredentialAuthenticationTypes
 from .enums import SourceConnectionTypes
 from .enums import SourceTypes
 
@@ -46,7 +49,7 @@ class UnionDTOFactoryOptions(factory.base.FactoryOptions):
             setattr(self, "original_model", self.model)
 
         if get_origin(self.original_model) != Union:
-            msg = "Meta.model must be an Union in Factory inheriting from " "UnionDTOFactory"
+            msg = "Meta.model must be an Union in Factory inheriting from UnionDTOFactory"
             raise factory.errors.FactoryError(msg)
 
         faker = factory.Faker._get_faker()
@@ -141,12 +144,28 @@ class VCenterCredentialFormDTOFactory(factory.Factory):
     password = factory.Faker("password")
 
 
-class OpenShiftCredentialFormDTOFactory(factory.Factory):
+class PlainOpenShiftCredentialFormDTOFactory(factory.Factory):
     class Meta:
-        model = OpenShiftCredentialFormDTO
+        model = PlainOpenShiftCredentialFormDTO
+
+    credential_name = factory.Faker("text", max_nb_chars=56)
+    username = factory.Faker("user_name")
+    password = factory.Faker("password")
+    authentication_type = OpenShiftCredentialAuthenticationTypes.USERNAME_AND_PASSWORD
+
+
+class TokenOpenShiftCredentialFormDTOFactory(factory.Factory):
+    class Meta:
+        model = TokenOpenShiftCredentialFormDTO
 
     credential_name = factory.Faker("text", max_nb_chars=56)
     token = factory.Faker("password")
+    authentication_type = OpenShiftCredentialAuthenticationTypes.TOKEN
+
+
+class OpenShiftCredentialFormDTOFactory(UnionDTOFactory):
+    class Meta:
+        model = OpenShiftCredentialFormDTO
 
 
 class AnsibleCredentialFormDTOFactory(factory.Factory):

--- a/camayoc/ui/enums.py
+++ b/camayoc/ui/enums.py
@@ -72,3 +72,13 @@ class SourceConnectionTypes(StrEnum):
     TLS11 = "TLSv1.1"
     TLS12 = "TLSv1.2"
     DISABLE = "Disable SSL"
+
+
+class ScansPopupTableColumns(StrEnum):
+    SCAN_TIME = "header_scan_time"
+    SCAN_RESULT = "header_scan_result"
+
+
+class ColumnOrdering(StrEnum):
+    ASCENDING = "ascending"
+    DESCENDING = "descending"

--- a/camayoc/ui/enums.py
+++ b/camayoc/ui/enums.py
@@ -52,6 +52,11 @@ class NetworkCredentialBecomeMethods(LowercasedStrEnum):
     RUNAS = auto()
 
 
+class OpenShiftCredentialAuthenticationTypes(StrEnum):
+    USERNAME_AND_PASSWORD = "Username and Password"
+    TOKEN = "Token"
+
+
 class SourceTypes(StrEnum):
     NETWORK_RANGE = "network"
     SATELLITE = "satellite"

--- a/camayoc/ui/models/pages/credentials.py
+++ b/camayoc/ui/models/pages/credentials.py
@@ -92,7 +92,10 @@ class VCenterCredentialForm(CredentialForm):
 
 class OpenShiftCredentialForm(CredentialForm):
     class FormDefinition:
+        authentication_type = SelectField("button[data-ouia-component-id=auth_type]")
         credential_name = InputField("input[data-ouia-component-id=cred_name]")
+        username = InputField("input[data-ouia-component-id=username]")
+        password = InputField("input[data-ouia-component-id=password]")
         token = InputField("input[data-ouia-component-id=auth_token]")
 
     @overload

--- a/camayoc/ui/models/pages/scans.py
+++ b/camayoc/ui/models/pages/scans.py
@@ -9,12 +9,16 @@ from camayoc.exceptions import FailedScanException
 from camayoc.ui.decorators import creates_toast
 from camayoc.ui.decorators import record_action
 from camayoc.ui.decorators import service
+from camayoc.ui.enums import ColumnOrdering
 from camayoc.ui.enums import Pages
+from camayoc.ui.enums import ScansPopupTableColumns
 
 from ..components.items_list import AbstractListItem
 from ..components.popup import PopUp
 from ..mixins import MainPageMixin
 from .abstract_page import AbstractPage
+
+REFRESH_BUTTON_LOCATOR = "div[class*=-c-toolbar] button[data-ouia-component-id=refresh]"
 
 
 class ScanHistoryPopup(PopUp, AbstractPage):
@@ -23,11 +27,25 @@ class ScanHistoryPopup(PopUp, AbstractPage):
     SAVE_RESULT_CLASS = None
     CANCEL_RESULT_CLASS = Pages.SCANS
 
-    def get_last_download(self) -> Download:
+    def sort_table(self, sort_by: ScansPopupTableColumns, ordering: ColumnOrdering) -> None:
+        tries = 0
+        table_header_locator = (
+            "table[data-ouia-component-id=scan_jobs_table] thead "
+            f"th[data-ouia-component-id={sort_by.value}]"
+        )
+        while 3 >= tries:
+            header = self._driver.locator(table_header_locator)
+            if header.get_attribute("aria-sort") == ordering.value:
+                return
+            header.click()
+            tries += 1
+        raise RuntimeError("Failed to sort table")
+
+    def get_nth_download(self, item: int) -> Download:
         table_row_locator = "table[data-ouia-component-id=scan_jobs_table] tbody tr"
         download_button_locator = "td[data-label=Download] button"
 
-        last_download = self._driver.locator(table_row_locator).last
+        last_download = self._driver.locator(table_row_locator).nth(item)
         with self._driver.expect_download() as download_info:
             last_download.locator(download_button_locator).click(timeout=10_000)
         download = download_info.value
@@ -39,20 +57,45 @@ class ScanListElem(AbstractListItem):
     def download_scan(self) -> Download:
         timeout_start = time.monotonic()
         timeout = self._client._camayoc_config.camayoc.scan_timeout
+        download_locator = (
+            "button[data-ouia-component-id=action_menu_toggle] "
+            "~ div *[data-ouia-component-id=download] button"
+        )
         while timeout > (time.monotonic() - timeout_start):
             try:
-                scans_popup = self._open_scans()
-                download = scans_popup.get_last_download()
+                self._toggle_kebab()
+                with self._client.driver.expect_download() as download_info:
+                    self.locator.locator(download_locator).click(timeout=10_000)
+                download = download_info.value
+                download.path()  # blocks the script while file is downloaded
+                self._toggle_kebab()
+                return download
+            except PlaywrightTimeoutError:
+                self._client.driver.locator(REFRESH_BUTTON_LOCATOR).click()
+        raise FailedScanException("Scan could not be downloaded")
+
+    def download_scan_modal(
+        self, sort_by: ScansPopupTableColumns, ordering: ColumnOrdering, item: int
+    ) -> Download:
+        timeout_start = time.monotonic()
+        timeout = self._client._camayoc_config.camayoc.scan_timeout
+        while timeout > (time.monotonic() - timeout_start):
+            try:
+                scans_popup = self._open_scans_popup()
+                scans_popup.sort_table(sort_by, ordering)
+                download = scans_popup.get_nth_download(item)
                 scans_popup.cancel()
                 return download
             except PlaywrightTimeoutError:
                 scans_popup.cancel()
-                self._client.driver.locator(
-                    "div[class*=-c-toolbar] button[data-ouia-component-id=refresh]"
-                ).click()
+                self._client.driver.locator(REFRESH_BUTTON_LOCATOR).click()
         raise FailedScanException("Scan could not be downloaded")
 
-    def _open_scans(self) -> ScanHistoryPopup:
+    def _toggle_kebab(self) -> None:
+        kebab_menu_locator = "button[data-ouia-component-id=action_menu_toggle]"
+        self.locator.locator(kebab_menu_locator).click()
+
+    def _open_scans_popup(self) -> ScanHistoryPopup:
         last_scanned_locator = "td[data-label='Last scanned'] button"
         self.locator.locator(last_scanned_locator).click()
         return ScanHistoryPopup(client=self._client)
@@ -67,5 +110,16 @@ class ScansMainPage(MainPageMixin):
     def download_scan(self, scan_name: str) -> ScansMainPage:
         scan: ScanListElem = self._get_item(scan_name)
         downloaded_report = scan.download_scan()
+        self._client.downloaded_files.append(downloaded_report)
+        return self
+
+    @creates_toast
+    @service
+    @record_action
+    def download_scan_modal(
+        self, scan_name: str, sort_by: ScansPopupTableColumns, ordering: ColumnOrdering, item: int
+    ) -> ScansMainPage:
+        scan: ScanListElem = self._get_item(scan_name)
+        downloaded_report = scan.download_scan_modal(sort_by, ordering, item)
         self._client.downloaded_files.append(downloaded_report)
         return self


### PR DESCRIPTION
These two commits add some new UI tests that were hard to implement while we still needed to think about supporting old UI:

- a test for creating OpenShift credential using username and password
- a test to download report through kebab menu item (technically kebab becomes the default way of downloading reports, and new test covers downloading through modal)

This depends on ouia IDs added in https://github.com/quipucords/quipucords-ui/pull/531