### PR TITLE
Introduce a tool to take a snapshot of server data

### DIFF
--- a/camayoc/constants.py
+++ b/camayoc/constants.py
@@ -3,6 +3,27 @@
 
 from camayoc import utils
 
+DBSERIALIZER_CREDENTIALS_FILE_PATH = "credentials.json"
+"""Path to file that stores serialized credentials data, relative to main serializer destination."""
+
+DBSERIALIZER_SOURCES_FILE_PATH = "sources.json"
+"""Path to file that stores serialized sources data, relative to main serializer destination."""
+
+DBSERIALIZER_SCANS_FILE_PATH = "scans.json"
+"""Path to file that stores serialized scans data, relative to main serializer destination."""
+
+DBSERIALIZER_CONNECTIONJOBS_DIR_PATH = "jobs"
+"""Path to directory that stores job connections data, relative to main serializer destination."""
+
+DBSERIALIZER_SCANJOBS_DIR_PATH = "scans"
+"""Path to directory that stores scan jobs data, relative to main serializer destination."""
+
+DBSERIALIZER_REPORTS_DIR_PATH = "reports"
+"""Path to directory that stores reports, relative to main serializer destination.
+
+Each report is represented by directory named after report id. Only details.json
+and aggregate.json are stored."""
+
 VALID_BOOLEAN_CHOICES = ["true", "false"]
 """Valid qpc/dsc CLI boolean choices."""
 

--- a/camayoc/db_serializer.py
+++ b/camayoc/db_serializer.py
@@ -1,0 +1,172 @@
+import io
+import json
+import logging
+import tarfile
+from pathlib import Path
+
+from camayoc import api
+from camayoc.constants import DBSERIALIZER_CONNECTIONJOBS_DIR_PATH
+from camayoc.constants import DBSERIALIZER_CREDENTIALS_FILE_PATH
+from camayoc.constants import DBSERIALIZER_REPORTS_DIR_PATH
+from camayoc.constants import DBSERIALIZER_SCANJOBS_DIR_PATH
+from camayoc.constants import DBSERIALIZER_SCANS_FILE_PATH
+from camayoc.constants import DBSERIALIZER_SOURCES_FILE_PATH
+from camayoc.qpc_models import Credential
+from camayoc.qpc_models import Report
+from camayoc.qpc_models import Scan
+from camayoc.qpc_models import ScanJob
+from camayoc.qpc_models import Source
+
+logger = logging.getLogger(__name__)
+
+
+class DBSerializer:
+    def __init__(self, destination: Path, overwrite=False):
+        self._destination = destination
+        self._overwrite = overwrite
+        self._client: api.Client | None = None
+
+    def serialize(self):
+        self._destination.mkdir(parents=True, exist_ok=True)
+        self._client = api.Client()
+
+        self._serialize_credentials()
+        self._serialize_sources()
+        self._serialize_scans()
+        self._serialize_jobconnectionresults()
+        self._serialize_scanjobs()
+        self._serialize_reports()
+
+    def _serialize_credentials(self):
+        destination = self._destination / DBSERIALIZER_CREDENTIALS_FILE_PATH
+        if not self.__check_destination(destination):
+            return
+
+        cred = Credential(client=self._client)
+        all_credentials = self.__list_paged(cred.list)
+        self.__save_json(all_credentials, destination)
+
+    def _serialize_sources(self):
+        destination = self._destination / DBSERIALIZER_SOURCES_FILE_PATH
+        if not self.__check_destination(destination):
+            return
+
+        source = Source(client=self._client)
+        all_sources = self.__list_paged(source.list)
+        self.__save_json(all_sources, destination)
+
+    def _serialize_scans(self):
+        destination = self._destination / DBSERIALIZER_SCANS_FILE_PATH
+        if not self.__check_destination(destination):
+            return
+
+        scan = Scan(client=self._client)
+        all_scans = self.__list_paged(scan.list)
+        self.__save_json(all_scans, destination)
+
+    def _serialize_jobconnectionresults(self):
+        def gen_job_ids(all_sources):
+            for source_json in all_sources:
+                if job_id := source_json.get("connection", {}).get("id"):
+                    yield job_id
+
+        sources_file = self._destination / DBSERIALIZER_SOURCES_FILE_PATH
+        with sources_file.open() as fh:
+            all_sources = json.load(fh)
+
+        for job_id in gen_job_ids(all_sources):
+            sources_destination = self._destination / DBSERIALIZER_CONNECTIONJOBS_DIR_PATH
+            sources_destination.mkdir(parents=True, exist_ok=True)
+
+            destination = sources_destination / f"connection_{job_id}.json"
+            if not self.__check_destination(destination):
+                continue
+
+            scanjob = ScanJob(client=self._client, _id=job_id)
+            all_connectionjobs = self.__list_paged(scanjob.connection_results)
+            self.__save_json(all_connectionjobs, destination)
+
+    def _serialize_scanjobs(self):
+        scans_file = self._destination / DBSERIALIZER_SCANS_FILE_PATH
+        with scans_file.open() as fh:
+            all_scans = json.load(fh)
+
+        scan_ids = [scan_json.get("id") for scan_json in all_scans]
+
+        for scan_id in scan_ids:
+            scans_destination = self._destination / DBSERIALIZER_SCANJOBS_DIR_PATH
+            scans_destination.mkdir(parents=True, exist_ok=True)
+
+            destination = scans_destination / f"jobs_{scan_id}.json"
+            if not self.__check_destination(destination):
+                continue
+
+            scanjob = ScanJob(client=self._client, scan_id=scan_id)
+            all_scanjobs = self.__list_paged(scanjob.list)
+            self.__save_json(all_scanjobs, destination)
+
+    def _serialize_reports(self):  # noqa: C901
+        def gen_report_ids(all_scans):
+            for scan_json in all_scans:
+                for job in scan_json.get("jobs", []):
+                    if report_id := job.get("report_id"):
+                        yield report_id
+
+        def extractfiles(tar, destination, files):
+            for member in tar.getmembers():
+                member_name = Path(member.name).name
+                if member_name not in files:
+                    continue
+                file_destination = destination / member_name
+                if not self.__check_destination(file_destination):
+                    continue
+                if tar_fh := tar.extractfile(member):
+                    file_destination.write_bytes(tar_fh.read())
+
+        scans_file = self._destination / DBSERIALIZER_SCANS_FILE_PATH
+        with scans_file.open() as fh:
+            all_scans = json.load(fh)
+
+        for report_id in gen_report_ids(all_scans):
+            report_destination = self._destination / DBSERIALIZER_REPORTS_DIR_PATH / str(report_id)
+            report_destination.mkdir(parents=True, exist_ok=True)
+
+            report = Report(client=self._client, _id=report_id)
+            gzip_response = report.reports_gzip()
+            gzip_response.raise_for_status()
+
+            tar_bytes = io.BytesIO(gzip_response.content)
+            with tarfile.open(fileobj=tar_bytes, mode="r:gz") as tar:
+                extractfiles(tar, report_destination, ("details.json", "aggregate.json"))
+
+    def __list_paged(self, obj_fn):
+        all_objs = []
+        page = 1
+        while True:
+            payload = {"page": page}
+            http_response = obj_fn(params=payload)
+            http_response.raise_for_status()
+            response_json = http_response.json()
+
+            if results := response_json.get("results"):
+                all_objs.extend(results)
+
+            if not response_json.get("next"):
+                break
+
+            page += 1
+
+        return all_objs
+
+    def __check_destination(self, destination: Path) -> bool:
+        may_write = not destination.exists() or self._overwrite
+        if not may_write:
+            logger.info(
+                "Refusing to overwrite file that already exists [destination=%s]",
+                destination.as_posix(),
+            )
+        return may_write
+
+    def __save_json(self, json_data, destination: Path) -> None:
+        with destination.open("w") as fh:
+            json.dump(json_data, fh)

--- a/camayoc/qpc_models.py
+++ b/camayoc/qpc_models.py
@@ -721,3 +721,14 @@ class Report(QPCObject):
         path = urljoin(self.endpoint, "{}/aggregate/".format(self._id))
         response = self.client.get(path, **kwargs)
         return response
+
+    def reports_gzip(self, **kwargs):
+        """Send GET request to self.endpoint/{id}/ to obtain report in gzip format.
+
+        :param ``**kwargs``: Additional arguments accepted by Requests's
+            `request.request()` method.
+        """
+        extra_headers = {"Accept": "application/gzip"}
+        path = urljoin(self.endpoint, "{}/".format(self._id))
+        response = self.client.get(path, headers=extra_headers, **kwargs)
+        return response

--- a/scripts/snapshot-data.py
+++ b/scripts/snapshot-data.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""
+Save a snapshot of server data in directory.
+
+This is part of database migrations testing pipeline. Usually you create an instance
+and take a snapshot of data. Then you stand up new instance, load database from backup
+and take another snapshot. Then you can compare snapshots and draw conclusions.
+"""
+
+import argparse
+import logging
+import warnings
+from pathlib import Path
+
+from camayoc.db_serializer import DBSerializer
+
+# urllib is a bit too noisy
+warnings.filterwarnings("module")
+
+logging.basicConfig(
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    level=logging.INFO,
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+
+logger = logging.getLogger()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description="Save a snapshot of server data in directory, usually for future comparisons.",
+    )
+    parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        default=False,
+        help="Overwrite existing files",
+    )
+    parser.add_argument(
+        "destination",
+        type=Path,
+        help="Path to directory where data will be stored. Will be created if does not exist.",
+    )
+    args = parser.parse_args()
+    return args
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    serializer = DBSerializer(args.destination, args.force)
+    serializer.serialize()


### PR DESCRIPTION
The tool will be a part of database migrations testing pipeline.

For context, the general migrations workflow will be:
- prepare a Discovery server instance
- take a snapshot of Postgres database (raw SQL) and use a tool from this PR to take a snapshot of server data
- in pipeline, discovery-ci will load raw SQL and run migrations. Then it will use a tool from this PR to take another snapshot of server data
- finally, it will compare both snapshots to assert if they are the same. If they are, it means that migrations did not break any of users data

After careful consideration, I decided it's best to compare snapshots of API responses. The alternative is to compare raw SQL files (or some transformations of them), but that feels like setting up for much more maintenance work. Imagine that table is renamed - comparing raw SQL files forces us to handle that case somehow, comparing API responses does not.

Comparing API responses still forces maintenance work when API changes. But that's historically relatively rare, and well, API is already contract with external world and changing API forces a change in multiple consumers. This really only adds one to the list.

This phase is relatively lightweight, basically saving API responses to files. We know that some differences between API responses are not substantial - like JSON can't express unordered list / set, but this is what we want when comparing responses for most of "list" endpoints. All such cases are going to be accounted in a tool that compares snapshots. The reasoning is simple - it's better to save too much data than too little. We can always ignore certain differences when comparing, we can't check for differences in something we never saved in the first place.

A tool to compare snapshots will be introduced in future PR. I might do some changes to this code then, if it turns out that certain structures I have chosen are a bit unwieldy.