### PR TITLE
Select tests to run based on --camayoc-pipeline command line argument

### DIFF
--- a/camayoc/pytest_plugin.py
+++ b/camayoc/pytest_plugin.py
@@ -1,0 +1,111 @@
+import pytest
+
+
+def pytest_addoption(parser: pytest.Parser, pluginmanager: pytest.PytestPluginManager) -> None:
+    parser.addoption(
+        "--camayoc-pipeline",
+        dest="camayoc_pipeline",
+        choices=("pr", "nightly", "upgrade"),
+        help="Only run tests relevant for this pipeline type",
+    )
+
+
+def pytest_collection_modifyitems(
+    session: pytest.Session, items: list[pytest.Item], config: pytest.Config
+) -> None:
+    filter_pipeline_tests(items, config)
+    run_cleaning_data_provider_first(items)
+
+
+def filter_pipeline_tests(items: list[pytest.Item], config: pytest.Config) -> None:
+    """Select tests to run based on --camayoc-pipeline command line argument."""
+    pipeline = config.getoption("camayoc_pipeline")
+    if not pipeline:
+        return
+
+    # gather_*_pipeline_tests return list of items to run, because it feels
+    # more natural to say "I want to run these tests" instead of "I want to
+    # run everything except these tests".
+    # However, later we want to *remove* items from list, so we generate
+    # indexes of all items and remove indexes of items we want to keep.
+    deselected_items = []
+    all_idxs = set(range(len(items)))
+    match pipeline:
+        case "pr":
+            matching_items_idxs = gather_pr_pipeline_tests(items)
+        case "nightly":
+            matching_items_idxs = gather_nightly_pipeline_tests(items)
+        case "upgrade":
+            matching_items_idxs = gather_upgrade_pipeline_tests(items)
+        case _:
+            return
+    deselected_idxs = all_idxs - set(matching_items_idxs)
+
+    for node_idx in sorted(deselected_idxs, reverse=True):
+        item = items.pop(node_idx)
+        deselected_items.append(item)
+    config.hook.pytest_deselected(items=deselected_items)
+
+
+def run_cleaning_data_provider_first(items: list[pytest.Item]) -> None:
+    """Reorder tests so these that use cleaning_data_provider fixture are run first."""
+    cleaning_dp_node_idxs = []
+    for node_idx, node in enumerate(items):
+        if "cleaning_data_provider" in getattr(node, "fixturenames", []):
+            cleaning_dp_node_idxs.append(node_idx)
+
+    cleaning_dp_nodes = []
+    for node_idx in sorted(cleaning_dp_node_idxs, reverse=True):
+        node = items.pop(node_idx)
+        cleaning_dp_nodes.append(node)
+
+    for node in reversed(cleaning_dp_nodes):
+        items.insert(0, node)
+
+
+def gather_pr_pipeline_tests(items: list[pytest.Item]) -> list[int]:
+    """Find items that should be run as part of PR pipeline.
+
+    As of February 2025, that's everything that has NOT been marked
+    with nightly_only or upgrade_only markers.
+    """
+    matching_idxs = []
+    for item_idx, item in enumerate(items):
+        marker_names = [i.name for i in item.iter_markers()]
+        item_is_nightly = "nightly_only" in marker_names
+        item_is_upgrade = "upgrade_only" in marker_names
+        if not item_is_nightly and not item_is_upgrade:
+            matching_idxs.append(item_idx)
+    return matching_idxs
+
+
+def gather_nightly_pipeline_tests(items: list[pytest.Item]) -> list[int]:
+    """Find items that should be run as part of nightly pipeline.
+
+    As of February 2025, that's everything that has NOT been marked
+    with pr_only or upgrade_only markers.
+    """
+    matching_idxs = []
+    for item_idx, item in enumerate(items):
+        marker_names = [i.name for i in item.iter_markers()]
+        item_is_pr = "pr_only" in marker_names
+        item_is_upgrade = "upgrade_only" in marker_names
+        if not item_is_pr and not item_is_upgrade:
+            matching_idxs.append(item_idx)
+    return matching_idxs
+
+
+def gather_upgrade_pipeline_tests(items: list[pytest.Item]) -> list[int]:
+    """Find items that should be run as part of upgrade pipeline.
+
+    As of February 2025, that's only things that have been marked with
+    upgrade_only marker, and end to end tests in UI and CLI.
+    """
+    matching_idxs = []
+    for item_idx, item in enumerate(items):
+        marker_names = [i.name for i in item.iter_markers()]
+        item_is_upgrade = "upgrade_only" in marker_names
+        item_is_endtoend = "test_endtoend.py::test_end_to_end" in item.nodeid
+        if item_is_upgrade or item_is_endtoend:
+            matching_idxs.append(item_idx)
+    return matching_idxs

--- a/camayoc/tests/conftest.py
+++ b/camayoc/tests/conftest.py
@@ -7,23 +7,6 @@ from camayoc import utils
 from camayoc.config import settings
 
 
-def pytest_collection_modifyitems(
-    session: pytest.Session, items: list[pytest.Item], config: pytest.Config
-) -> None:
-    cleaning_dp_node_idxs = []
-    for node_idx, node in enumerate(items):
-        if "cleaning_data_provider" in node.fixturenames:
-            cleaning_dp_node_idxs.append(node_idx)
-
-    cleaning_dp_nodes = []
-    for node_idx in sorted(cleaning_dp_node_idxs, reverse=True):
-        node = items.pop(node_idx)
-        cleaning_dp_nodes.append(node)
-
-    for node in reversed(cleaning_dp_nodes):
-        items.insert(0, node)
-
-
 @pytest.fixture
 def isolated_filesystem(request):
     """Fixture that creates a temporary directory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ classifiers = [
     "Topic :: Software Development :: Quality Assurance",
 ]
 
+[tool.poetry.plugins.pytest11]
+camayoc = "camayoc.pytest_plugin"
+
 [build-system]
 build-backend = "poetry.core.masonry.api"
 requires = ["poetry-core"]


### PR DESCRIPTION
The main goal is to introduce a new command line flag that allows pytest to select correct tests for the pipeline. Normally tests selection would be responsibility of a caller (in our case: discovery-ci), but pytest does not expose all the information that caller needs to make kinds of decisions that we want to make. So we are forced to implement actual selection logic here in Camayoc.

We use pytest_addoption hook, which may be defined in standard conftest.py file, but [pytest is somewhat finicky when it comes to supporting this specific hook from a file](https://docs.pytest.org/en/stable/how-to/writing_plugins.html#plugin-discovery-order-at-tool-startup). Flag may or may not be recognized depending on your current working directory and how you invoke pytest. Registering a new plugin and defining hook there will hopefully prove to be more robust solution.

This change should generally be safe to merge anytime, as nothing is fundamentally changed until you use the new flag. However, in my local testing I saw some slight differences in tests order, as reported by `--collect-only`. They shouldn't matter, but I guess we'll see.

To use the new flag in local installation, you need to re-install Camayoc. `poetry install --with dev --sync` should suffice. Run `pytest -VV` and check for "camayoc-1.8.5" in output to confirm that everything is set up correctly.