### PR TITLE
refactor: add codecov.yml config to override defaults

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           make test-coverage
       - name: Code Coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,20 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: 70..90
+
+  status:
+    patch:
+      default:
+        target: 80%
+        threshold: 5
+    project:
+      default: false
+      camayoc:
+        target: auto
+        threshold: 5
+        paths:
+          - "camayoc/"


### PR DESCRIPTION
Yet another sibling to https://github.com/quipucords/qpc/pull/360 and https://github.com/quipucords/quipucords/pull/2824 so that all quipucords projects follow the same coverage requirements.

This config basically says:

* For the diff, require 80% coverage to pass the PR check.
* For the overall project, target the previous/parent commit's recorded coverage, but allow it to dip by 5% before it fails the PR check.
* The "range" value is purely aesthetic, IIUC. Files under 70% show as red, under 90% as yellow, and over 90% as green when viewed on codecov's website.
