### PR TITLE
Try to prevent rare failure in UI tests

### DIFF
--- a/camayoc/ui/models/pages/login.py
+++ b/camayoc/ui/models/pages/login.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING
 
 from camayoc.types.ui import LoginFormDTO
@@ -19,6 +20,15 @@ class Login(AbstractPage):
         username_input = "input[name=pf-login-username-id]"
         password_input = "input[name=pf-login-password-id]"
         submit_button = "button[type=submit]"
+
+        # Login page has fade in animation set. It has animation delay of 150 ms
+        # and animation length of 150 ms. We *think* extremely rare failures that
+        # we observe on OpenStack might be caused by Playwright trying to insert
+        # letters while animation is ongoing.
+        # Unfortunately, Playwright does not seem to provide "animation end" event,
+        # so we just explicitly wait for about half a second. If our assumption
+        # about failures root cause is correct, this should help.
+        time.sleep(0.5)
 
         if self._driver.locator(login_page_indicator).is_visible():
             self._driver.fill(username_input, data.username)


### PR DESCRIPTION
Login page has fade in animation set. I *think* extremely rare failures that we observe on OpenStack might be caused by Playwright trying to insert letters while animation is ongoing.

Let's wait about half a second before doing anything. If my assumption about failure root cause is correct, it should help. If not - half a second is small enough to disappear in normal variability. When testing this locally, I had a run with delay that finished faster than a run without this patch on.

To test this, I am running `pytest -v -ra -m "not pr_only" camayoc/tests/qpc/ui` in a loop 20 times. pytest effectively runs 27 tests (excluding deselected and skipped). So that gives 540 individual test runs for a "try".

Without that patch, I observe 1-2 tests failing.

With that patch, I have not observed any failures. I tried two times (so, 1080 tests total). But one of attempts was while VCenter was down, and these problems could affect the issue we are talking about, so take that one with a grain of salt.

Either way, in worst case it does not help and adds about 15 seconds to total pipeline runtime.