### PR TITLE
wait_for_scan: CLI default scan timeout comes from camayoc.scan_timeout configuration

### DIFF
--- a/camayoc/tests/qpc/cli/test_openshift.py
+++ b/camayoc/tests/qpc/cli/test_openshift.py
@@ -150,7 +150,7 @@ def test_openshift_clusters(qpc_server_config, data_provider, source_definition:
     match_scan_id = re.match(r'Scan "(\d+)" started.', output)
     assert match_scan_id is not None
     scan_job_id = match_scan_id.group(1)
-    wait_for_scan(scan_job_id, timeout=1200)
+    wait_for_scan(scan_job_id)
     result = scan_job({"id": scan_job_id})
     assert result["status"] == "completed"
     details, deployments = retrieve_report(scan_job_id)

--- a/camayoc/tests/qpc/cli/test_rhacs.py
+++ b/camayoc/tests/qpc/cli/test_rhacs.py
@@ -63,7 +63,7 @@ def test_rhacs_data(qpc_server_config, data_provider, source_definition: SourceO
     match_scan_id = re.match(r'Scan "(\d+)" started.', output)
     assert match_scan_id is not None
     scan_job_id = match_scan_id.group(1)
-    wait_for_scan(scan_job_id, timeout=1200)
+    wait_for_scan(scan_job_id)
     result = scan_job({"id": scan_job_id})
     assert result["status"] == "completed"
     # to here

--- a/camayoc/tests/qpc/cli/test_scanjobs.py
+++ b/camayoc/tests/qpc/cli/test_scanjobs.py
@@ -97,7 +97,7 @@ def test_scanjob_with_multiple_sources(qpc_server_config, data_provider):
     match = re.match(r'Scan "(\d+)" started.', result)
     assert match is not None
     scan_job_id = match.group(1)
-    wait_for_scan(scan_job_id, timeout=1200)
+    wait_for_scan(scan_job_id)
     result = scan_job({"id": scan_job_id})
     assert result["status"] == "completed"
     report_id = result["report_id"]
@@ -143,7 +143,7 @@ def test_scanjob_with_all_sources(qpc_server_config, data_provider):
     match = re.match(r'Scan "(\d+)" started.', result)
     assert match is not None
     scan_job_id = match.group(1)
-    wait_for_scan(scan_job_id, timeout=1200)
+    wait_for_scan(scan_job_id)
     result = scan_job({"id": scan_job_id})
     assert result["status"] == "completed"
     report_id = result["report_id"]
@@ -191,7 +191,7 @@ def test_scanjob_with_disabled_products(isolated_filesystem, qpc_server_config, 
     match = re.match(r'Scan "(\d+)" started.', result)
     assert match is not None
     scan_job_id = match.group(1)
-    wait_for_scan(scan_job_id, timeout=1200)
+    wait_for_scan(scan_job_id)
     result = scan_job({"id": scan_job_id})
     assert result["status"] == "completed"
     report_id = result["report_id"]
@@ -251,7 +251,7 @@ def test_scanjob_with_enabled_extended_products(qpc_server_config, data_provider
     match = re.match(r'Scan "(\d+)" started.', result)
     assert match is not None
     scan_job_id = match.group(1)
-    wait_for_scan(scan_job_id, timeout=1200)
+    wait_for_scan(scan_job_id)
     result = scan_job({"id": scan_job_id})
     assert result["status"] == "completed"
     report_id = result["report_id"]

--- a/camayoc/tests/qpc/cli/utils.py
+++ b/camayoc/tests/qpc/cli/utils.py
@@ -34,12 +34,12 @@ def clear_all_entities():
     assert errors == [], output
 
 
-def wait_for_scan(scan_job_id, status="completed", timeout=900):
+def wait_for_scan(scan_job_id, status="completed", timeout=settings.camayoc.scan_timeout):
     """Wait for a scan to reach some ``status`` up to ``timeout`` seconds.
 
     :param scan_job_id: Scan ID to wait for.
     :param status: Scan status which will wait for. Default is completed.
-    :param timeout: wait up to this amount of seconds. Default is 900.
+    :param timeout: wait up to this amount of seconds. Default is camayoc.scan_timeout.
     """
     while timeout > 0:
         result = scan_job({"id": scan_job_id})


### PR DESCRIPTION
Notes:
* ~~I will rebase and squash the commits before it get merged~~ I rebased and squashed the commits.
* This PR requires coordination in order to avoid breaking the pipelines.

This PR will make the CLI default scan timeout set to Camayoc's configuration defined in `camayoc.scan_timeout`. Also, the `ui` tests are already using this default value from the configuration.

Rationale: Many CLI tests are already using hardcoded 20 minutes (1200 seconds) timeout as default. Let's make it more flexivel and define this on a configuration. This will allows us to set the default scan timeout as we wish in different pipelines.

Relates to:
* https://github.com/quipucords/camayoc/blob/main/camayoc/config.py#L21
* https://github.com/quipucords/camayoc/blob/main/camayoc/types/settings.py#L15
* https://url.corp.redhat.com/discovery-ci-long-run

Relates to JIRA: DISCOVERY-913
https://issues.redhat.com/browse/DISCOVERY-913
