### PR TITLE
Disable vcenter scans tests

### DIFF
--- a/camayoc/tests/qpc/cli/test_scanjobs.py
+++ b/camayoc/tests/qpc/cli/test_scanjobs.py
@@ -73,7 +73,7 @@ def test_scanjob_with_multiple_sources(qpc_server_config, data_provider):
         should be available.
     """
     source_generator = data_provider.sources.defined_many(
-        {"type": Table.is_in(("network", "satellite", "vcenter"))}
+        {"type": Table.is_in(("network", "satellite"))}
     )
     sources = [next(source_generator)]
     while True:


### PR DESCRIPTION
Disable some of vcenter tests until we have a stable vcenter instance back to normal.