### PR TITLE
Make ScanContainer more robust

### DIFF
--- a/camayoc/data_provider.py
+++ b/camayoc/data_provider.py
@@ -296,7 +296,7 @@ class ScanContainer:
                 logger.info(
                     "Finished scanjob %s for scan %s", scan.scan_job_id, scan.definition.name
                 )
-            except (WaitTimeError, StoppedScanException) as e:
+            except (WaitTimeError, StoppedScanException, HTTPError) as e:
                 finished_scan = evolve(
                     scan,
                     status=ScanSimplifiedStatusEnum.FAILED,


### PR DESCRIPTION
Code inside try-except block may raise HTTPError if endpoint returns 4xx or 5xx code. That exception was not correctly handled and stopped all `scans` methods - instead of marking specific scan as failed and moving on.