### PR TITLE
Raise exception when ScanJob does not have report_id

### DIFF
--- a/camayoc/data_provider.py
+++ b/camayoc/data_provider.py
@@ -10,6 +10,7 @@ from littletable import Table
 from camayoc.api import HTTPError
 from camayoc.config import settings
 from camayoc.exceptions import NoMatchingDataDefinitionException
+from camayoc.exceptions import ScanJobWithoutReportException
 from camayoc.exceptions import StoppedScanException
 from camayoc.exceptions import WaitTimeError
 from camayoc.qpc_models import Credential
@@ -296,7 +297,12 @@ class ScanContainer:
                 logger.info(
                     "Finished scanjob %s for scan %s", scan.scan_job_id, scan.definition.name
                 )
-            except (WaitTimeError, StoppedScanException, HTTPError) as e:
+            except (
+                WaitTimeError,
+                StoppedScanException,
+                HTTPError,
+                ScanJobWithoutReportException,
+            ) as e:
                 finished_scan = evolve(
                     scan,
                     status=ScanSimplifiedStatusEnum.FAILED,

--- a/camayoc/exceptions.py
+++ b/camayoc/exceptions.py
@@ -44,6 +44,14 @@ class StoppedScanException(Exception):
     """
 
 
+class ScanJobWithoutReportException(Exception):
+    """Raised when trying to obtain report_id from ScanJob that does not have it.
+
+    Raised by Report.retrieve_from_scan_job() when ScanJob does not have report_id
+    key. Usually that happens because ScanJob failed.
+    """
+
+
 class MisconfiguredWidgetException(Exception):
     """Raised by UI Widget when expected property is not there."""
 

--- a/camayoc/qpc_models.py
+++ b/camayoc/qpc_models.py
@@ -14,6 +14,7 @@ from camayoc.constants import QPC_REPORTS_PATH
 from camayoc.constants import QPC_SCAN_PATH
 from camayoc.constants import QPC_SCANJOB_PATH
 from camayoc.constants import QPC_SOURCE_PATH
+from camayoc.exceptions import ScanJobWithoutReportException
 from camayoc.types.settings import CredentialOptions
 from camayoc.types.settings import ScanOptions
 from camayoc.types.settings import SourceOptions
@@ -690,6 +691,20 @@ class Report(QPCObject):
         response = self.client.get(path, **kwargs)
         if response.status_code in range(200, 203):
             self._id = response.json().get("report_id")
+        if not self._id:
+            response_data = response.json()
+            msg = (
+                "Scan job does not have report_id."
+                " scan_job_id={} scan.name={} status={} status_message:\n{}"
+            )
+            raise ScanJobWithoutReportException(
+                msg.format(
+                    response_data.get("id"),
+                    response_data.get("scan", {}).get("name"),
+                    response_data.get("status"),
+                    response_data.get("status_message"),
+                )
+            )
         return response
 
     def details(self, **kwargs):


### PR DESCRIPTION
When creating Report from ScanJob, it tries to use ScanJob.report_id. However, failed ScanJobs won't have that field and Report._id will remain None. Nothing tells caller about a problem, and we consistently don't check for id before calling API endpoints on Report(), which results in 4xx errors later in the code. Raising exception forces caller to consider it, or fails a test right where the issue occurs with clearer error message.

Before:

```
E         ============================================================
E
E         The request you made received a status code that indicates
E         an error was encountered. Details about the request and the
E         response are below.
E
E         ============================================================
E         request path : '/api/v1/reports/None/details/'
E
E         request body : None
E
E         request headers : {'User-Agent': 'python-requests/2.32.3', 'Accept-Encoding': 'gzip, deflate', 'Accept': '*/*', 'Connection': 'keep-alive', 'Authorization': 'Token 0c311ec0fe9b129c7fb7f563e136f658ba73b37c'}
E
E         response code : 404
E
E         text_error_message : ('\n'
E          '<!doctype html>\n'
E          '<html lang="en">\n'
E          '<head>\n'
E          '  <title>Not Found</title>\n'
E          '</head>\n'
E          '<body>\n'
E          '  <h1>Not Found</h1><p>The requested resource was not found on this '
E          'server.</p>\n'
E          '</body>\n'
E          '</html>\n')
E         ============================================================
```

After:

```
E Scan job does not have report_id. scan_job_id=19 scan.name=VCenterOnly status=failed status_message:
E         Unable to connect to VCenter source, vcenter, with supplied credential, vcenter.
E         Connect scan failed for ScanTask(id=55, scan_type=connect, status=running, job_id=19, sequence_number=1). (vim.fault.InvalidLogin) {
E            dynamicType = <unset>,
E            dynamicProperty = (vmodl.DynamicProperty) [],
E            msg = 'Cannot complete login due to an incorrect user name or password.',
E            faultCause = <unset>,
E            faultMessage = (vmodl.LocalizableMessage) []
E         }
```