### PR TITLE
Fix `FAIL_FAST=false reports.py`

### DIFF
--- a/scripts/reports.py
+++ b/scripts/reports.py
@@ -14,7 +14,10 @@ import warnings
 from datetime import datetime
 from pathlib import Path
 
+from camayoc.api import HTTPError
 from camayoc.data_provider import DataProvider
+from camayoc.exceptions import ScanJobWithoutReportException
+from camayoc.exceptions import StoppedScanException
 from camayoc.exceptions import WaitTimeError
 from camayoc.qpc_models import Report
 from camayoc.qpc_models import ScanJob
@@ -90,7 +93,13 @@ def run_scans(data_provider, timeout, fail_fast, insights_report):
         download_insights = insights_report and should_download_insights(data_provider, scan)
         try:
             run_scan(scan, timeout, download_insights)
-        except WaitTimeError:
+        except (
+            WaitTimeError,
+            StoppedScanException,
+            HTTPError,
+            ScanJobWithoutReportException,
+        ) as e:
+            logger.error("%s", e)
             if fail_fast:
                 raise SomeScanFailedException
             some_scan_failed = True


### PR DESCRIPTION
Align exception handler in `scripts/reports.py` with ScanContainer. As discussed in abe2bc9866, there are few exceptions that scan may raise, and we should catch all of them.

`reports.py` predates ScanContainer, and maybe it should be ported to it. However, ScanContainer runs all scans in parallel, which would kid of obsolete the concept of failing fast (or not). So for now I am leaving things as they are, but feel free to comment if that is desired direction or not.