### PR TITLE
Remove references to "connect" scan type

### DIFF
--- a/camayoc/constants.py
+++ b/camayoc/constants.py
@@ -104,7 +104,7 @@ QPC_SOURCES_DEFAULT_PORT = {
 }
 """Default sources port that the quipucords server supports."""
 
-QPC_SCAN_TYPES = ("inspect", "connect")
+QPC_SCAN_TYPES = ("inspect",)
 """Types of scans that the quipucords server supports."""
 
 QPC_HOST_MANAGER_TYPES = ("vcenter", "satellite", "openshift", "ansible")

--- a/camayoc/qpc_models.py
+++ b/camayoc/qpc_models.py
@@ -471,7 +471,7 @@ class Scan(QPCObject, QPCObjectBulkDeleteMixin):
         self.endpoint = QPC_SCAN_PATH
         self.name = uuid4() if name is None else name
 
-        # valid scan types are 'connect' and 'inspect'
+        # only valid scan type is 'inspect'
         self.scan_type = scan_type
         self.options = {"max_concurrency": max_concurrency}
         if disabled_optional_products:

--- a/camayoc/tests/qpc/cli/conftest.py
+++ b/camayoc/tests/qpc/cli/conftest.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-from camayoc.constants import QPC_SCAN_TYPES
 from camayoc.constants import QPC_SOURCE_TYPES
 
 from .utils import setup_qpc
@@ -17,10 +16,4 @@ def qpc_server_config():
 @pytest.fixture(params=QPC_SOURCE_TYPES)
 def source_type(request):
     """Fixture that returns the quipucords source types."""
-    return request.param
-
-
-@pytest.fixture(params=QPC_SCAN_TYPES)
-def scan_type(request):
-    """Fixture that returns the quipucords scan types."""
     return request.param

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -54,7 +54,7 @@ MOCK_SCAN = {
     "id": 21,
     "name": "testscan",
     "options": {"max_concurrency": 50},
-    "scan_type": "connect",
+    "scan_type": "inspect",
     "sources": [{"id": 153, "name": "mock_source"}],
     "status": "created",
 }
@@ -220,7 +220,7 @@ class ScanTestCase(unittest.TestCase):
     def test_equivalent(self):
         """If a hostname is specified in the config file, we use it."""
         client = api.Client(authenticate=False, config=CAMAYOC_CONFIG)
-        scn = Scan(source_ids=[153], scan_type="connect", name=MOCK_SCAN["name"], client=client)
+        scn = Scan(source_ids=[153], scan_type="inspect", name=MOCK_SCAN["name"], client=client)
         scn._id = MOCK_SCAN["id"]
         self.assertTrue(scn.equivalent(MOCK_SCAN))
         self.assertTrue(scn.equivalent(scn))


### PR DESCRIPTION
Since server dropped "connect" scan types (https://github.com/quipucords/quipucords/pull/2899), remove references to it from Camayoc.

As far as I can tell, the removed fixture was unused. This is corroborated by the fact that Camayoc tests never failed since we removed "connect" type from backend. I suspect fixture is a leftover of API tests that were ported to backend unit tests.

## Summary by Sourcery

Remove all references to the deprecated "connect" scan type from Camayoc test suite

Bug Fixes:
- Replace hardcoded 'connect' scan type with 'inspect' in test configurations

Tests:
- Update test cases to use 'inspect' scan type instead of 'connect'

Chores:
- Remove unused scan type fixtures and constants related to 'connect' scan type