### PR TITLE
Updated the credentials cli tests to support --sshkeyfile

### DIFF
--- a/camayoc/tests/qpc/cli/test_credentials.py
+++ b/camayoc/tests/qpc/cli/test_credentials.py
@@ -11,7 +11,6 @@
 import json
 import random
 from io import BytesIO
-from pathlib import Path
 
 import pexpect
 import pytest
@@ -178,8 +177,7 @@ def test_add_with_username_sshkeyfile_fromfile(data_provider, qpc_server_config,
     username = utils.uuid4()
     ssh_key_content = "Multi-Line\nOpenSSH Key\nFrom File\n"
     ssh_file_path = tmp_path / "test_ssh_key"
-    with Path.open(ssh_file_path, "w") as ssh_file:
-        ssh_file.write(ssh_key_content)
+    ssh_file_path.write_text(ssh_key_content)
 
     cred_add_and_check(
         {"name": name, "username": username, "sshkeyfile": ssh_file_path},
@@ -440,9 +438,7 @@ def test_edit_sshkeyfile_negative(data_provider, qpc_server_config):
     )
 
     name = utils.uuid4()
-    qpc_cred_edit = pexpect.spawn(
-        "{} -v cred edit --name={} --sshkeyfile -".format(client_cmd, name)
-    )
+    qpc_cred_edit = pexpect.spawn(f"{client_cmd} -v cred edit --name={name} --sshkeyfile -")
     qpc_cred_edit.logfile = BytesIO()
     assert qpc_cred_edit.expect('Credential "{}" does not exist'.format(name)) == 0
     assert qpc_cred_edit.expect(pexpect.EOF) == 0

--- a/camayoc/tests/qpc/cli/test_credentials.py
+++ b/camayoc/tests/qpc/cli/test_credentials.py
@@ -11,6 +11,7 @@
 import json
 import random
 from io import BytesIO
+from pathlib import Path
 
 import pexpect
 import pytest
@@ -142,8 +143,46 @@ def test_add_with_username_sshkeyfile(data_provider, qpc_server_config):
     )
 
     cred_add_and_check(
-        {"name": name, "username": username, "sshkey": None},
+        {"name": name, "username": username, "sshkeyfile": "-"},
         inputs=[("Private SSH Key:", sshkeyfile_cred.ssh_key)],
+    )
+
+    cred_show_and_check(
+        {"name": name},
+        generate_show_output(
+            {
+                "name": name,
+                "ssh_key": True,
+                "username": username,
+                "auth_type": "ssh_key",
+                "become_method": '"sudo"',
+                "become_user": '"root"',
+            }
+        ),
+    )
+
+
+@pytest.mark.ssh_keyfile_path
+def test_add_with_username_sshkeyfile_fromfile(data_provider, qpc_server_config, tmp_path):
+    """Add an auth with username and sshkeyfile from file.
+
+    :id: 9fd6b032-f78e-4056-b32b-9bd90cb41131
+    :description: Add an auth entry providing the ``--name``, ``--username``
+        and ``--sshkeyfile`` options.
+    :steps: Run ``qpc cred add --name <name> --username <username>
+        --sshkeyfile <ssh_keyfile_path>``
+    :expectedresults: A new auth entry is created with the data provided as
+        input.
+    """
+    name = utils.uuid4()
+    username = utils.uuid4()
+    ssh_key_content = "Multi-Line\nOpenSSH Key\nFrom File\n"
+    ssh_file_path = tmp_path / "test_ssh_key"
+    with Path.open(ssh_file_path, "w") as ssh_file:
+        ssh_file.write(ssh_key_content)
+
+    cred_add_and_check(
+        {"name": name, "username": username, "sshkeyfile": ssh_file_path},
     )
 
     cred_show_and_check(
@@ -184,7 +223,7 @@ def test_add_with_username_sshkeyfile_become_password(data_provider, qpc_server_
         {
             "name": name,
             "username": username,
-            "sshkey": None,
+            "sshkeyfile": "-",
             "become-password": None,
         },
         inputs=[
@@ -396,12 +435,14 @@ def test_edit_sshkeyfile_negative(data_provider, qpc_server_config):
         data_only=True,
     )
     cred_add_and_check(
-        {"name": name, "username": username, "sshkey": None},
+        {"name": name, "username": username, "sshkeyfile": "-"},
         inputs=[("Private SSH Key:", sshkeyfile_cred.ssh_key)],
     )
 
     name = utils.uuid4()
-    qpc_cred_edit = pexpect.spawn("{} -v cred edit --name={} --sshkey".format(client_cmd, name))
+    qpc_cred_edit = pexpect.spawn(
+        "{} -v cred edit --name={} --sshkeyfile -".format(client_cmd, name)
+    )
     qpc_cred_edit.logfile = BytesIO()
     assert qpc_cred_edit.expect('Credential "{}" does not exist'.format(name)) == 0
     assert qpc_cred_edit.expect(pexpect.EOF) == 0

--- a/camayoc/tests/qpc/cli/test_endtoend.py
+++ b/camayoc/tests/qpc/cli/test_endtoend.py
@@ -61,7 +61,7 @@ def test_end_to_end(tmp_path, qpc_server_config, data_provider, source_name):
         cred_add_args["password"] = None
     if cred_ssh_key := credential_model.ssh_key:
         secret_inputs.append(("Private SSH Key:", cred_ssh_key))
-        cred_add_args["sshkey"] = None
+        cred_add_args["sshkeyfile"] = "-"
     cred_add_and_check(cred_add_args, inputs=secret_inputs)
 
     # Create a source


### PR DESCRIPTION
- Updated use of the qpc CLI for sshkey, now specifying the --sshkeyfile with the path of the SSH private key to use or - for taking in the private key via stdin as it does today via --sshkey.

To go with: https://github.com/quipucords/qpc/pull/372

Standalone Discovery tests with the above qpc branch: https://jenkins-csb-smqe-stage.dno.corp.redhat.com/view/Discovery/job/discovery-standalone/296/


## Summary by Sourcery

Update credentials CLI tests to support the new --sshkeyfile option for specifying SSH private keys

Tests:
- Modified test cases to use --sshkeyfile instead of --sshkey when adding and editing credentials
- Updated test scenarios to pass SSH key via stdin using sshkeyfile parameter

## Summary by Sourcery

Update credentials CLI tests to support the new --sshkeyfile option for specifying SSH private keys

Enhancements:
- Added support for specifying SSH private key via file path or stdin in credential tests

Tests:
- Modified test cases to use --sshkeyfile instead of --sshkey when adding and editing credentials
- Added new test scenario for adding credentials with SSH key from a file
- Updated test scenarios to pass SSH key via stdin using sshkeyfile parameter