### PR TITLE
Don't try to assign port 0 in CLI sources tests

### DIFF
--- a/camayoc/tests/qpc/cli/test_sources.py
+++ b/camayoc/tests/qpc/cli/test_sources.py
@@ -220,7 +220,7 @@ def test_add_with_port(isolated_filesystem, qpc_server_config, source_type):
     cred_name = utils.uuid4()
     name = utils.uuid4()
     hosts = "127.0.0.1"
-    port = random.randint(0, 65535)
+    port = random.randint(1, 65535)
     cred_add_and_check(
         {
             "name": cred_name,
@@ -1124,9 +1124,9 @@ def test_edit_port(isolated_filesystem, qpc_server_config, source_type):
     cred_name = utils.uuid4()
     name = utils.uuid4()
     hosts = "127.0.0.1"
-    port = new_port = random.randint(0, 65535)
+    port = new_port = random.randint(1, 65535)
     while port == new_port:
-        new_port = random.randint(0, 65535)
+        new_port = random.randint(1, 65535)
     cred_add_and_check(
         {
             "name": cred_name,
@@ -1194,9 +1194,9 @@ def test_edit_port_negative(isolated_filesystem, qpc_server_config, source_type)
     cred_name = utils.uuid4()
     name = utils.uuid4()
     hosts = "127.0.0.1"
-    port = new_port = random.randint(0, 65535)
+    port = new_port = random.randint(1, 65535)
     while port == new_port:
-        new_port = random.randint(0, 65535)
+        new_port = random.randint(1, 65535)
     invalid_name = utils.uuid4()
     cred_add_and_check(
         {

--- a/camayoc/tests/qpc/cli/test_sources.py
+++ b/camayoc/tests/qpc/cli/test_sources.py
@@ -220,6 +220,8 @@ def test_add_with_port(isolated_filesystem, qpc_server_config, source_type):
     cred_name = utils.uuid4()
     name = utils.uuid4()
     hosts = "127.0.0.1"
+    # Technically Quipucords supports port 0, but qpc ignores it
+    # See commit 29c4edec
     port = random.randint(1, 65535)
     cred_add_and_check(
         {


### PR DESCRIPTION
Discovery claims to support port 0, but in fact qpc will never put it in payload. It's debatable if port 0 should even be supported, and highly unlikely that any customer actually tries to bind their services to it.

Stop randomly drawing port 0 to avoid pipeline failure that might happen about once every 13 000 runs including CLI.

This needs to be two commits because with git it's impossible to reference to a commit that you are about to create (and hash is computed from commit content, among other things).

## Summary by Sourcery

Prevent test flakiness by excluding port 0 when randomly selecting ports in CLI sources tests.

Bug Fixes:
- Exclude port 0 from random port generation in CLI sources tests to avoid intermittent failures

Tests:
- Change random.randint lower bound to 1 in multiple CLI sources tests