### PR TITLE
Don't be so strict about json filenames in reports

### DIFF
--- a/camayoc/db_serializer.py
+++ b/camayoc/db_serializer.py
@@ -1,6 +1,7 @@
 import io
 import json
 import logging
+import re
 import tarfile
 from pathlib import Path
 
@@ -112,10 +113,10 @@ class DBSerializer:
                     if report_id := job.get("report_id"):
                         yield report_id
 
-        def extractfiles(tar, destination, files):
+        def extractfiles(tar, destination, filename_patterns):
             for member in tar.getmembers():
                 member_name = Path(member.name).name
-                if member_name not in files:
+                if not any(re.fullmatch(regex, member_name) for regex in filename_patterns):
                     continue
                 file_destination = destination / member_name
                 if not self.__check_destination(file_destination):
@@ -137,7 +138,7 @@ class DBSerializer:
 
             tar_bytes = io.BytesIO(gzip_response.content)
             with tarfile.open(fileobj=tar_bytes, mode="r:gz") as tar:
-                extractfiles(tar, report_destination, ("details.json", "aggregate.json"))
+                extractfiles(tar, report_destination, (r"details.*\.json", r"aggregate.*\.json"))
 
     def __list_paged(self, obj_fn):
         all_objs = []

--- a/camayoc/db_snapshot.py
+++ b/camayoc/db_snapshot.py
@@ -102,8 +102,8 @@ def read_reports(source: Path) -> dict[str, Any]:
 
 
 def _read_report_directory(directory: Path):
-    details_data = _read_report_details(directory / "details.json")
-    aggregate_data = _read_report_aggregate(directory / "aggregate.json")
+    details_data = _read_report_details(next(directory.glob("details*.json")))
+    aggregate_data = _read_report_aggregate(next(directory.glob("aggregate*.json")))
     return {
         "details": details_data,
         "aggregate": aggregate_data,


### PR DESCRIPTION
https://github.com/quipucords/quipucords/pull/2945 changed json filenames in reports - now they include report id. `DBSerializer` and `DBSnapshot` were looking for specific files and did not find them, which failed snapshot test.

With this patch, DBSerializer is looking for all files matching regular expressions, while DBSnapshot takes first file matching a glob. Hopefully these changes are going to be robust enough for any future filename changes.

Relates to JIRA: DISCOVERY-788

## Summary by Sourcery

Relax JSON filename lookups in report serialization and snapshot modules to support dynamic filenames.

Bug Fixes:
- Fix report snapshot tests by adapting to renamed JSON report files.

Enhancements:
- Update DBSerializer to use regex-based filename matching for details and aggregate JSON files.
- Update DBSnapshot to locate report JSON files via glob patterns instead of fixed names.