### PR TITLE
Add a test to verify Summary report in UI

### DIFF
--- a/camayoc/types/ui.py
+++ b/camayoc/types/ui.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
@@ -516,3 +517,14 @@ class NewScanFormDTO:
 class TriggerScanDTO:
     source_name: str
     scan_form: NewScanFormDTO
+
+
+@frozen
+class SummaryReportDataPoint:
+    key: str
+    label: str
+    value: str
+    parsed_value: Any
+
+
+SummaryReportData = MappingProxyType[str, SummaryReportDataPoint]

--- a/camayoc/ui/client.py
+++ b/camayoc/ui/client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from typing import Any
 from typing import Optional
 from urllib.parse import urlunparse
 
@@ -75,6 +76,7 @@ class Client:
 
         self.session = session or DummySession()
         self.downloaded_files: list[Download] = []
+        self.page_contents: list[Any] = []
         self.driver = driver
         self.page_errors = []
 


### PR DESCRIPTION
This depends on https://github.com/quipucords/quipucords-ui/pull/630

A bit of explanation about `Client.page_contents` is in order. UI framework is using fluent page model and all our UI tests follow a pattern of single chain of method invocations, from starting a browser to logging out. Reading data from page and running assertions on that is a bit awkward. Especially when this is the first time where we actually want to do such thing.

So the idea is that there are special methods that read something from a browser and put that in `Client.page_contents`. After browser session ends, you select requested data from `page_contents` and run assertions. This way of working is consistent with how we handle downloads.

That approach will break when you want to change further actions in browser session based on content obtained from a page, but as of this commit there are no plans for such scenarios.

## Summary by Sourcery

Add UI support for extracting and parsing the Summary Report modal in the scans page and validate its contents via a new end-to-end test.

New Features:
- Introduce SummaryReportPopup page object with get_data method to extract and parse summary report fields.
- Add read_summary_modal actions to ScanListElem and ScansMainPage to capture summary report data into Client.page_contents.
- Add test_show_summary_report UI test to open the summary report modal and verify displayed data against the API response.

Enhancements:
- Introduce KEBAB_ITEM_LOCATOR_TEMPLATE for reusable action menu locators.
- Add to_int and to_date transformer functions for parsing numerical and date values in the UI.
- Define SummaryReportDataPoint and SummaryReportData types for structured summary data storage.
- Extend Client to collect page_contents for later assertions.

Tests:
- Parametrize test_show_summary_report to assert both results and diagnostics fields match the API aggregate report.