### PR TITLE
Add coverage for editing sources and credentials through UI

### DIFF
--- a/camayoc/tests/qpc/ui/test_credentials.py
+++ b/camayoc/tests/qpc/ui/test_credentials.py
@@ -12,9 +12,12 @@ import random
 from typing import get_args
 
 import pytest
+from attrs import evolve
+from attrs import fields_dict
 from littletable import Table
 
 from camayoc.qpc_models import Credential
+from camayoc.types.ui import AddCredentialDTO
 from camayoc.types.ui import AnsibleCredentialFormDTO
 from camayoc.types.ui import CredentialFormDTO
 from camayoc.types.ui import NetworkCredentialFormDTO
@@ -28,7 +31,6 @@ from camayoc.ui import Client
 from camayoc.ui import data_factories
 from camayoc.ui.enums import CredentialTypes
 from camayoc.ui.enums import MainMenuPages
-from camayoc.ui.enums import NetworkCredentialBecomeMethods
 
 CREDENTIAL_TYPE_MAP = {
     SatelliteCredentialFormDTO: CredentialTypes.SATELLITE,
@@ -40,27 +42,17 @@ CREDENTIAL_TYPE_MAP = {
 
 def create_credential_dto(credential_type, data_provider):
     if issubclass(credential_type, get_args(NetworkCredentialFormDTO)):
-        factory_kwargs = {
-            "username": "user",
-            "become_method": random.choice(tuple(NetworkCredentialBecomeMethods)),
-            "become_user": "root",
-            "become_password": "power!",
-        }
+        factory_kwargs = {}
         form_factory_cls = getattr(data_factories, f"{credential_type.__name__}Factory")
         if issubclass(credential_type, PlainNetworkCredentialFormDTO):
             form_factory_cls = data_factories.PlainNetworkCredentialFormDTOFactory
-            factory_kwargs["password"] = "123456"
         if issubclass(credential_type, SSHNetworkCredentialFormDTO):
             form_factory_cls = data_factories.SSHNetworkCredentialFormDTOFactory
             ssh_network_credential = data_provider.credentials.new_one(
                 {"type": "network", "sshkeyfile": Table.is_not_null()},
                 data_only=True,
             )
-            ssh_factory_kwargs = {
-                "ssh_key_file": ssh_network_credential.ssh_key,
-                "passphrase": "123456",
-            }
-            factory_kwargs.update(ssh_factory_kwargs)
+            factory_kwargs["ssh_key_file"] = ssh_network_credential.ssh_key
         credential_form = form_factory_cls(**factory_kwargs)
         credential = data_factories.AddCredentialDTOFactory(
             credential_type=CredentialTypes.NETWORK,
@@ -82,6 +74,33 @@ def create_credential_dto(credential_type, data_provider):
     )
     data_provider.mark_for_cleanup(Credential(name=credential.credential_form.credential_name))
     return credential
+
+
+def modify_credential_dto(credential_dto: AddCredentialDTO, data_provider):
+    credential_form_cls = credential_dto.credential_form.__class__
+    old_credential_form_cls = credential_form_cls
+    network_classes = get_args(NetworkCredentialFormDTO)
+    openshift_classes = get_args(OpenShiftCredentialFormDTO)
+
+    if issubclass(credential_form_cls, network_classes):
+        credential_form_cls = random.choice(network_classes)
+    elif issubclass(credential_form_cls, openshift_classes):
+        credential_form_cls = random.choice(openshift_classes)
+
+    another_credential = create_credential_dto(credential_form_cls, data_provider)
+
+    if old_credential_form_cls == credential_form_cls:
+        dto_fields = fields_dict(credential_form_cls).keys()
+        updated_fields = random.sample(list(dto_fields), k=random.randint(1, len(dto_fields)))
+        updated_fields = {
+            key: getattr(another_credential.credential_form, key) for key in updated_fields
+        }
+        new_form_dto = evolve(credential_dto.credential_form, **updated_fields)
+    else:
+        new_form_dto = another_credential.credential_form
+    new_dto = evolve(credential_dto, credential_form=new_form_dto)
+
+    return new_dto
 
 
 # FIXME: this never actually deletes in UI
@@ -108,37 +127,26 @@ def test_create_delete_credential(data_provider, ui_client: Client, credential_t
     )
 
 
-# @pytest.mark.parametrize("source_type", SOURCE_TYPES)
-# def test_edit_credential(ui_client: Client, source_type):
-#     """Edit a credential's parameters.
+@pytest.mark.parametrize("credential_type", get_args(CredentialFormDTO))
+def test_edit_credential(data_provider, ui_client: Client, credential_type):
+    """Create and then edit a credential in the quipucords UI.
 
-#     :id: 3a4626ab-c667-41dc-944e-62ac05d51bbe
-#     :description: Creates a credential, then attempts to edit all of the
-#         parameters that were set, then verifies that they were changed.
-#     :steps:
-#         1) Log into the UI.
-#         2) Go to the credentials page and open the Add Credential modal.
-#         3) Fill required + optional fields, using the password option and save.
-#         4) Edit the credential parameters and save, make sure it changed.
-#     :expectedresults: A new credential is created and then edited.
-#     """
-#     # options = {
-#     #     "name": utils.uuid4(),
-#     #     "username": utils.uuid4(),
-#     #     "password": utils.uuid4(),
-#     #     "source_type": source_type,
-#     # }
-#     # if source_type == "Network":
-#     #     options["become_user"] = utils.uuid4()
-#     # create_credential(selenium_browser, options)
-#     # new_options = {
-#     #     "name": utils.uuid4(),
-#     #     "username": utils.uuid4(),
-#     #     "password": utils.uuid4(),
-#     #     "source_type": source_type,
-#     # }
-#     # if source_type == "Network":
-#     #     new_options["become_user"] = utils.uuid4()
-#     # edit_credential(selenium_browser, options["name"], new_options)
-#     # delete_credential(selenium_browser, {new_options["name"]})
-#     pass
+    :id: 3a4626ab-c667-41dc-944e-62ac05d51bbe
+    :description: Creates and edits a credential in the UI.
+    :steps:
+        1) Go to the credentials page and open the credential modal.
+        2) Fill in the required information and create a new credential.
+        3) Open the modal for editing of created credential.
+        4) Modify some of the information and save changes.
+    :expectedresults: A new credential is created and then edited.
+    """
+    credential_dto = create_credential_dto(credential_type, data_provider)
+    edit_credential_dto = modify_credential_dto(credential_dto, data_provider)
+    (
+        ui_client.begin()
+        .login(data_factories.LoginFormDTOFactory())
+        .navigate_to(MainMenuPages.CREDENTIALS)
+        .add_credential(credential_dto)
+        .edit_credential(credential_dto.credential_form.credential_name, edit_credential_dto)
+        .logout()
+    )

--- a/camayoc/ui/models/fields.py
+++ b/camayoc/ui/models/fields.py
@@ -63,7 +63,10 @@ class FilteredMultipleSelectField(Field):
             values_list = self.driver.locator(self.locator).locator(
                 "xpath=following-sibling::div//ul[contains(@id, 'select')]"
             )
-            values_list.locator(f"text='{actual_value}'").click()
+            label_elem = values_list.locator(f"text='{actual_value}'")
+            checkbox_elem = label_elem.locator("xpath=parent::span//input[@type='checkbox']")
+            if not checkbox_elem.is_checked():
+                label_elem.click()
             self.driver.locator(self.locator).locator(filter_input).clear()
 
         if values_list.is_visible():


### PR DESCRIPTION
There are three commits. I don't want to squash them during a merge, as commit messages contain useful information.

See individual commit messages for details. Pay extra attention to d1fad4aeeaafdcc577739383f22166f3cfe64ead .

## Summary by Sourcery

Add full support and test coverage for editing credentials and sources via the UI by extending page models, DTO helpers, and end-to-end tests

New Features:
- Add UI model methods for opening and submitting edit forms for credentials and sources

Enhancements:
- Consolidate credential and source type mappings into reusable CREDENTIAL_TYPE_MAP and SOURCE_TYPE_MAP constants
- Improve FilteredMultipleSelectField and InputField implementations to clear existing values and prevent redundant fills

Tests:
- Introduce modify_credential_dto and modify_source_dto helpers to generate edited DTOs
- Add end-to-end UI tests for editing credentials and sources through the quipucords UI

Chores:
- Remove outdated commented-out test stubs for credential editing