### PR TITLE
Allow API client to log in again on Invalid token response

### DIFF
--- a/camayoc/constants.py
+++ b/camayoc/constants.py
@@ -80,6 +80,9 @@ QPC_SCAN_STATES = QPC_SCAN_TERMINAL_STATES + ("running",)
 QPC_TOKEN_PATH = "v1/token/"
 """The path to the endpoint used for obtaining an authentication token."""
 
+QPC_API_INVALID_TOKEN_MESSAGE = "'Invalid token'"
+"""String that will be in API response when request token is invalid."""
+
 QPC_LOGOUT_PATH = "v1/users/logout/"
 """The path to the endpoint used to log user out."""
 

--- a/camayoc/qpc_models.py
+++ b/camayoc/qpc_models.py
@@ -33,6 +33,7 @@ class QPCObjectBulkDeleteMixin(object):
     same for objects that do have this endpoint.
     """
 
+    @api.try_reauthenticate
     def bulk_delete(self, ids, **kwargs):
         """Send POST request to the self.endpoint/bulk_delete/ of this object.
 
@@ -100,6 +101,7 @@ class QPCObject(object):
         """Return true if both objects are not equal."""
         return not self == other
 
+    @api.try_reauthenticate
     def create(self, **kwargs):
         """Send POST request to the self.endpoint of this object.
 
@@ -122,6 +124,7 @@ class QPCObject(object):
                 self.port = response.json().get("port")
         return response
 
+    @api.try_reauthenticate
     def list(self, **kwargs):
         """Send GET request to read all objects of this type.
 
@@ -134,6 +137,7 @@ class QPCObject(object):
         """
         return self.client.get(self.endpoint, **kwargs)
 
+    @api.try_reauthenticate
     def read(self, **kwargs):
         """Send GET request to the self.endpoint/{id} of this object.
 
@@ -145,6 +149,7 @@ class QPCObject(object):
         """
         return self.client.get(self.path(), **kwargs)
 
+    @api.try_reauthenticate
     def update(self, **kwargs):
         """Send PUT request to the self.endpoint/{id} of this object.
 
@@ -160,6 +165,7 @@ class QPCObject(object):
         """
         return self.client.put(self.path(), self.update_payload(), **kwargs)
 
+    @api.try_reauthenticate
     def delete(self, **kwargs):
         """Send DELETE request to the self.endpoint/{id} of this object.
 
@@ -492,6 +498,7 @@ class Scan(QPCObject, QPCObjectBulkDeleteMixin):
         definition_data.pop("expected_data", None)
         return cls(**definition_data)
 
+    @api.try_reauthenticate
     def delete(self, **kwargs):
         """Send DELETE request to the self.endpoint/{id} of this object.
 
@@ -503,6 +510,7 @@ class Scan(QPCObject, QPCObjectBulkDeleteMixin):
         """
         return self.client.delete(self.path(), **kwargs)
 
+    @api.try_reauthenticate
     def joblist(self, **kwargs):
         """Ask the server to list the ScanJobs associated with this scan.
 
@@ -562,6 +570,7 @@ class ScanJob(QPCObject):
         self.scan_id = scan_id
         self.endpoint = QPC_SCANJOB_PATH
 
+    @api.try_reauthenticate
     def create(self, **kwargs):
         """Send POST request to the scan's job endpoint.
 
@@ -583,6 +592,7 @@ class ScanJob(QPCObject):
             self._id = response.json().get("id")
         return response
 
+    @api.try_reauthenticate
     def list(self, **kwargs):
         """Send GET request to read all scanjobs associated with the same scan.
 
@@ -599,6 +609,7 @@ class ScanJob(QPCObject):
         path = urljoin(QPC_SCAN_PATH, "{}/jobs/".format(self.scan_id))
         return self.client.get(path, **kwargs)
 
+    @api.try_reauthenticate
     def cancel(self, **kwargs):
         """Send PUT request to self.endpoint/{id}/cancel/ to cancel a scan.
 
@@ -608,6 +619,7 @@ class ScanJob(QPCObject):
         path = urljoin(self.path(), "cancel/")
         return self.client.put(path, {}, **kwargs)
 
+    @api.try_reauthenticate
     def connection_results(self, **kwargs):
         """Send a GET self.endpoint/{id}/connection/ to read scan details.
 
@@ -617,6 +629,7 @@ class ScanJob(QPCObject):
         path = urljoin(self.path(), "connection/")
         return self.client.get(path, **kwargs)
 
+    @api.try_reauthenticate
     def inspection_results(self, **kwargs):
         """Send a GET self.endpoint/{id}/inspection/ to read scan details.
 
@@ -680,6 +693,7 @@ class Report(QPCObject):
         self.endpoint = QPC_REPORTS_PATH
         self._id = _id
 
+    @api.try_reauthenticate
     def retrieve_from_scan_job(self, scan_job_id, **kwargs):
         """Send GET request to /jobs/<scan_job_id>/ to get a scanjob.
 
@@ -707,6 +721,7 @@ class Report(QPCObject):
             )
         return response
 
+    @api.try_reauthenticate
     def details(self, **kwargs):
         """Send GET request to self.endpoint/{id}/details/ to view the report details.
 
@@ -717,6 +732,7 @@ class Report(QPCObject):
         response = self.client.get(path, **kwargs)
         return response
 
+    @api.try_reauthenticate
     def deployments(self, **kwargs):
         """Send GET request to self.endpoint/{id}/deployments/ to view deployments.
 
@@ -727,6 +743,7 @@ class Report(QPCObject):
         response = self.client.get(path, **kwargs)
         return response
 
+    @api.try_reauthenticate
     def aggregate(self, **kwargs):
         """Send GET request to self.endpoint/{id}/aggregate/ to view the aggregate report.
 
@@ -737,6 +754,7 @@ class Report(QPCObject):
         response = self.client.get(path, **kwargs)
         return response
 
+    @api.try_reauthenticate
     def reports_gzip(self, **kwargs):
         """Send GET request to self.endpoint/{id}/ to obtain report in gzip format.
 


### PR DESCRIPTION
Rarely we see pipeline failing due to "Invalid token" response from the server. We suppose it might be caused by [quipucords PR#2581](https://github.com/quipucords/quipucords/pull/2581).

So far we've seen it only in `camayoc/tests/qpc/ui/test_sources.py::test_create_delete_source`. UI tests indeed log out user at the end, which should remove all user tokens, which should invalidate all tokens that any Camayoc API clients might have. Objects inheriting from `QPCObject` have a private client reference. The theory is that if client was created before UI test, and then used after UI logged out, that client is fundamentally broken and will receive "Invalid token" response.

Based on that theory, introduce a decorator that inspects error received from server and tries to log in again if error is "Invalid token". We do that up to 10 times, which should be more than enough (in local testing, usually call succeeds on second try; the most I've observed was on third attempt). Decorator is used in all Quipucords server API calls, although we only observed tests failing on `QPCObject.create()` call.

Now, some loose threads.

The first occurrence of "Invalid token" I could identify dates to 2025-02-18, which is a bit over a year after PR#2581 was merged. If PR#2851 is a root cause, why didn't we see that error earlier?
For the record, we [moved to pytest 8 on 2025-01-17](https://github.com/quipucords/camayoc/pull/558) and [introduced a pytests plugin (which maintains execution order) on 2025-02-14](https://github.com/quipucords/camayoc/pull/562).

Jenkins has 1776 pipeline runs between 2025-02-18 and 2025-06-10, with caveat that we might be missing some runs between 2025-04-22 and 2025-06-10. Out of these, 23 had "Invalid token", which gives error rate of about 1.3%. I've executed affected tests 5000 times with this patch and without this patch (10k runs total), and have not seen a single failure or debug message. Probably there's something about environment that affects this outcome.

Relates to JIRA: DISCOVERY-978

## Summary by Sourcery

Automatically handle and recover from invalid token errors by retrying API calls with re-authentication.

Enhancements:
- Annotate HTTPError exceptions with an invalid token flag when the response contains the specific error message.
- Introduce a decorator to retry API calls up to ten times by clearing the token and re-authenticating upon receiving an invalid token response.
- Apply the retry decorator to all Quipucords API client methods across model operations.
- Log debug messages on each retry attempt to aid in tracing re-authentication loops.