### PR TITLE
UI refactors

### DIFF
--- a/camayoc/tests/qpc/ui/test_scans.py
+++ b/camayoc/tests/qpc/ui/test_scans.py
@@ -19,7 +19,7 @@ from camayoc.ui import Client
 from camayoc.ui import data_factories
 from camayoc.ui.enums import ColumnOrdering
 from camayoc.ui.enums import MainMenuPages
-from camayoc.ui.enums import ScansPopupTableColumns
+from camayoc.ui.enums import ScansModalTableColumns
 
 SUMMARY_RESULTS_ITEMS = (
     "ansible_hosts_all",
@@ -113,7 +113,7 @@ def test_download_scan_modal(tmp_path, scans, ui_client: Client, scan_name):
         .navigate_to(MainMenuPages.SCANS)
         .download_scan_modal(
             finished_scan.definition.name,
-            ScansPopupTableColumns.SCAN_TIME,
+            ScansModalTableColumns.SCAN_TIME,
             ColumnOrdering.DESCENDING,
             0,
         )

--- a/camayoc/types/ui.py
+++ b/camayoc/types/ui.py
@@ -58,6 +58,8 @@ class UIListItem(Protocol):
     locator: Locator
     _client: Client
 
+    def select_action(self, ouiaid: str, timeout: int) -> None: ...
+
 
 class UIField(Protocol):
     locator: str

--- a/camayoc/ui/enums.py
+++ b/camayoc/ui/enums.py
@@ -74,7 +74,7 @@ class SourceConnectionTypes(StrEnum):
     DISABLE = "Disable SSL"
 
 
-class ScansPopupTableColumns(StrEnum):
+class ScansModalTableColumns(StrEnum):
     SCAN_TIME = "header_scan_time"
     SCAN_RESULT = "header_scan_result"
 

--- a/camayoc/ui/models/components/items_list.py
+++ b/camayoc/ui/models/components/items_list.py
@@ -11,9 +11,25 @@ from camayoc.types.ui import UIPage
 
 
 class AbstractListItem(UIListItem):
+    ACTION_MENU_TOGGLE_LOCATOR = "button[data-ouia-component-id=action_menu_toggle]"
+    ACTION_MENU_ITEM_LOCATOR_TEMPLATE = (
+        ACTION_MENU_TOGGLE_LOCATOR + "~ div *[data-ouia-component-id={ouiaid}] button"
+    )
+
     def __init__(self, locator: Locator, client):
         self.locator = locator
         self._client = client
+
+    def select_action(self, ouiaid: str, timeout: int = 30_000) -> None:
+        self._open_kebab()
+        item_locator = self.ACTION_MENU_ITEM_LOCATOR_TEMPLATE.format(ouiaid=ouiaid)
+        self.locator.locator(item_locator).click(timeout=timeout)
+
+    def _open_kebab(self) -> None:
+        toggle_elem = self.locator.locator(self.ACTION_MENU_TOGGLE_LOCATOR)
+        if str(toggle_elem.get_attribute("aria-expanded")).lower() == "true":
+            return
+        toggle_elem.click()
 
 
 class ItemsList(UIPage):

--- a/camayoc/ui/models/components/modal.py
+++ b/camayoc/ui/models/components/modal.py
@@ -4,7 +4,7 @@ from camayoc.exceptions import MisconfiguredWidgetException
 from camayoc.types.ui import UIPage
 
 
-class PopUp(UIPage):
+class Modal(UIPage):
     SAVE_LOCATOR = "*[class*=-c-modal-box__body] button.pf-m-primary"
     CANCEL_LOCATOR = "*[class*=-c-modal-box__body] button.pf-m-link"
     SAVE_RESULT_CLASS = None

--- a/camayoc/ui/models/pages/credentials.py
+++ b/camayoc/ui/models/pages/credentials.py
@@ -138,18 +138,7 @@ class RHACSCredentialForm(CredentialForm):
 
 
 class CredentialListElem(AbstractListItem):
-    def open_edit_credential(self) -> CredentialForm:
-        edit_locator = (
-            "button[data-ouia-component-id=action_menu_toggle] "
-            "~ div *[data-ouia-component-id=edit-credential] button"
-        )
-        self._toggle_kebab()
-        self.locator.locator(edit_locator).click()
-        return CredentialForm(client=self._client)
-
-    def _toggle_kebab(self) -> None:
-        kebab_menu_locator = "button[data-ouia-component-id=action_menu_toggle]"
-        self.locator.locator(kebab_menu_locator).click()
+    pass
 
 
 CREDENTIAL_TYPE_MAP = {
@@ -206,5 +195,5 @@ class CredentialsMainPage(AddNewDropdown, MainPageMixin):
     def open_edit_credential(self, name: str, credential_type: CredentialTypes) -> CredentialForm:
         cls = CREDENTIAL_TYPE_MAP.get(credential_type).get("class")
         item: CredentialListElem = self._get_item(name)
-        item.open_edit_credential()
+        item.select_action("edit-credential")
         return self._new_page(cls)

--- a/camayoc/ui/models/pages/credentials.py
+++ b/camayoc/ui/models/pages/credentials.py
@@ -18,14 +18,14 @@ from camayoc.ui.enums import Pages
 from ..components.add_new_dropdown import AddNewDropdown
 from ..components.form import Form
 from ..components.items_list import AbstractListItem
-from ..components.popup import PopUp
+from ..components.modal import Modal
 from ..fields import InputField
 from ..fields import SelectField
 from ..mixins import MainPageMixin
 from .abstract_page import AbstractPage
 
 
-class CredentialForm(Form, PopUp, AbstractPage):
+class CredentialForm(Form, Modal, AbstractPage):
     SAVE_RESULT_CLASS = Pages.CREDENTIALS
     CANCEL_RESULT_CLASS = Pages.CREDENTIALS
 
@@ -175,15 +175,15 @@ class CredentialsMainPage(AddNewDropdown, MainPageMixin):
 
     @service
     def add_credential(self, data: AddCredentialDTO) -> CredentialsMainPage:
-        add_credential_popup = self.open_add_credential(data.credential_type)
-        add_credential_popup.fill(data.credential_form)
-        return add_credential_popup.confirm()
+        add_credential_modal = self.open_add_credential(data.credential_type)
+        add_credential_modal.fill(data.credential_form)
+        return add_credential_modal.confirm()
 
     @service
     def edit_credential(self, name: str, data: AddCredentialDTO) -> CredentialsMainPage:
-        edit_credential_popup = self.open_edit_credential(name, data.credential_type)
-        edit_credential_popup.fill(data.credential_form)
-        return edit_credential_popup.confirm()
+        edit_credential_modal = self.open_edit_credential(name, data.credential_type)
+        edit_credential_modal.fill(data.credential_form)
+        return edit_credential_modal.confirm()
 
     @record_action
     def open_add_credential(self, credential_type: CredentialTypes) -> CredentialForm:

--- a/camayoc/ui/models/pages/scans.py
+++ b/camayoc/ui/models/pages/scans.py
@@ -15,23 +15,23 @@ from camayoc.ui.decorators import record_action
 from camayoc.ui.decorators import service
 from camayoc.ui.enums import ColumnOrdering
 from camayoc.ui.enums import Pages
-from camayoc.ui.enums import ScansPopupTableColumns
+from camayoc.ui.enums import ScansModalTableColumns
 
 from ..components.items_list import AbstractListItem
-from ..components.popup import PopUp
+from ..components.modal import Modal
 from ..mixins import MainPageMixin
 from .abstract_page import AbstractPage
 
 REFRESH_BUTTON_LOCATOR = "div[class*=-c-toolbar] button[data-ouia-component-id=refresh]"
 
 
-class ScanHistoryPopup(PopUp, AbstractPage):
+class ScanHistoryModal(Modal, AbstractPage):
     SAVE_LOCATOR = None
     CANCEL_LOCATOR = "*[class$='modal-box__close'] button"
     SAVE_RESULT_CLASS = None
     CANCEL_RESULT_CLASS = Pages.SCANS
 
-    def sort_table(self, sort_by: ScansPopupTableColumns, ordering: ColumnOrdering) -> None:
+    def sort_table(self, sort_by: ScansModalTableColumns, ordering: ColumnOrdering) -> None:
         tries = 0
         table_header_locator = (
             "table[data-ouia-component-id=scan_jobs_table] thead "
@@ -72,7 +72,7 @@ def to_date(value: str):
         return None
 
 
-class SummaryReportPopup(PopUp, AbstractPage):
+class SummaryReportModal(Modal, AbstractPage):
     CANCEL_LOCATOR = "*[class$='modal-box__close'] button"
     CANCEL_RESULT_CLASS = Pages.SCANS
     VALUE_TRANSFORMER_MAP = {
@@ -129,36 +129,36 @@ class ScanListElem(AbstractListItem):
 
     @_wait_for_scan
     def download_scan_modal(
-        self, sort_by: ScansPopupTableColumns, ordering: ColumnOrdering, item: int
+        self, sort_by: ScansModalTableColumns, ordering: ColumnOrdering, item: int
     ) -> Download | None:
         try:
-            scans_popup = self._open_scans_popup()
-            scans_popup.sort_table(sort_by, ordering)
-            download = scans_popup.get_nth_download(item)
-            scans_popup.cancel()
+            scans_modal = self._open_scans_modal()
+            scans_modal.sort_table(sort_by, ordering)
+            download = scans_modal.get_nth_download(item)
+            scans_modal.cancel()
             return download
         except PlaywrightTimeoutError:
-            scans_popup.cancel()
+            scans_modal.cancel()
             self._client.driver.locator(REFRESH_BUTTON_LOCATOR).click()
 
     @_wait_for_scan
     def read_summary_modal(self) -> SummaryReportData | None:
         try:
-            summary_popup = self._open_summary_popup()
-            data = summary_popup.get_data()
-            summary_popup.cancel()
+            summary_modal = self._open_summary_modal()
+            data = summary_modal.get_data()
+            summary_modal.cancel()
             return data
         except PlaywrightTimeoutError:
             self._client.driver.locator(REFRESH_BUTTON_LOCATOR).click()
 
-    def _open_scans_popup(self) -> ScanHistoryPopup:
+    def _open_scans_modal(self) -> ScanHistoryModal:
         last_scanned_locator = "td[data-label='Last scanned'] button"
         self.locator.locator(last_scanned_locator).click()
-        return ScanHistoryPopup(client=self._client)
+        return ScanHistoryModal(client=self._client)
 
-    def _open_summary_popup(self) -> SummaryReportPopup:
+    def _open_summary_modal(self) -> SummaryReportModal:
         self.select_action("summary")
-        return SummaryReportPopup(client=self._client)
+        return SummaryReportModal(client=self._client)
 
 
 class ScansMainPage(MainPageMixin):
@@ -177,7 +177,7 @@ class ScansMainPage(MainPageMixin):
     @service
     @record_action
     def download_scan_modal(
-        self, scan_name: str, sort_by: ScansPopupTableColumns, ordering: ColumnOrdering, item: int
+        self, scan_name: str, sort_by: ScansModalTableColumns, ordering: ColumnOrdering, item: int
     ) -> ScansMainPage:
         scan: ScanListElem = self._get_item(scan_name)
         downloaded_report = scan.download_scan_modal(sort_by, ordering, item)

--- a/camayoc/ui/models/pages/sources.py
+++ b/camayoc/ui/models/pages/sources.py
@@ -20,7 +20,7 @@ from camayoc.ui.enums import SourceTypes
 from ..components.add_new_dropdown import AddNewDropdown
 from ..components.form import Form
 from ..components.items_list import AbstractListItem
-from ..components.popup import PopUp
+from ..components.modal import Modal
 from ..fields import CheckboxField
 from ..fields import FilteredMultipleSelectField
 from ..fields import InputField
@@ -29,7 +29,7 @@ from ..mixins import MainPageMixin
 from .abstract_page import AbstractPage
 
 
-class SourceForm(Form, PopUp, AbstractPage):
+class SourceForm(Form, Modal, AbstractPage):
     SAVE_RESULT_CLASS = Pages.SOURCES
     CANCEL_RESULT_CLASS = Pages.SOURCES
 
@@ -165,7 +165,7 @@ class RHACSSourceCredentialsForm(SourceForm):
         return self
 
 
-class ScanForm(Form, PopUp, AbstractPage):
+class ScanForm(Form, Modal, AbstractPage):
     SAVE_RESULT_CLASS = Pages.SOURCES
     CANCEL_RESULT_CLASS = Pages.SOURCES
 
@@ -227,15 +227,15 @@ class SourcesMainPage(AddNewDropdown, MainPageMixin):
 
     @service
     def add_source(self, data: AddSourceDTO) -> SourcesMainPage:
-        add_sources_popup = self.open_add_source(data.source_type)
-        add_sources_popup.fill(data.source_form)
-        return add_sources_popup.confirm()
+        add_sources_modal = self.open_add_source(data.source_type)
+        add_sources_modal.fill(data.source_form)
+        return add_sources_modal.confirm()
 
     @service
     def edit_source(self, name: str, data: AddSourceDTO) -> SourcesMainPage:
-        edit_source_popup = self.open_edit_source(name, data.source_type)
-        edit_source_popup.fill(data.source_form)
-        return edit_source_popup.confirm()
+        edit_source_modal = self.open_edit_source(name, data.source_type)
+        edit_source_modal.fill(data.source_form)
+        return edit_source_modal.confirm()
 
     @record_action
     def open_add_source(self, source_type: SourceTypes) -> SourceForm:
@@ -254,6 +254,6 @@ class SourcesMainPage(AddNewDropdown, MainPageMixin):
     @record_action
     def trigger_scan(self, data: TriggerScanDTO) -> SourcesMainPage:
         item: SourceListElem = self._get_item(data.source_name)
-        popup = item.open_scan()
-        popup.fill(data.scan_form)
-        return popup.confirm()
+        modal = item.open_scan()
+        modal.fill(data.scan_form)
+        return modal.confirm()

--- a/camayoc/ui/models/pages/sources.py
+++ b/camayoc/ui/models/pages/sources.py
@@ -192,19 +192,6 @@ class SourceListElem(AbstractListItem):
         self.locator.locator(scan_locator).click()
         return ScanForm(client=self._client)
 
-    def open_edit_source(self) -> SourceForm:
-        edit_locator = (
-            "button[data-ouia-component-id=action_menu_toggle] "
-            "~ div *[data-ouia-component-id=edit-source] button"
-        )
-        self._toggle_kebab()
-        self.locator.locator(edit_locator).click()
-        return SourceForm(client=self._client)
-
-    def _toggle_kebab(self) -> None:
-        kebab_menu_locator = "button[data-ouia-component-id=action_menu_toggle]"
-        self.locator.locator(kebab_menu_locator).click()
-
 
 SOURCE_TYPE_MAP = {
     SourceTypes.NETWORK_RANGE: {
@@ -260,7 +247,7 @@ class SourcesMainPage(AddNewDropdown, MainPageMixin):
     def open_edit_source(self, name: str, source_type: SourceTypes) -> SourceForm:
         cls = SOURCE_TYPE_MAP.get(source_type).get("class")
         item: SourceListElem = self._get_item(name)
-        item.open_edit_source()
+        item.select_action("edit-source")
         return self._new_page(cls)
 
     @creates_toast


### PR DESCRIPTION
Few refactors I did while working on Summary modal / editing sources and credentials. See individual commit messages for details.

## Summary by Sourcery

Refactor UI page models to replace popup abstractions with a unified Modal component, consolidate kebab-menu interactions, and centralize retry logic for scan operations.

Enhancements:
- Replace PopUp component with Modal across scan, source, and credential models and rename ScansPopupTableColumns to ScansModalTableColumns
- Consolidate action-menu interactions into AbstractListItem.select_action and remove redundant toggle and open_popup methods
- Introduce _wait_for_scan decorator to centralize retry logic for download_scan and read_summary_modal methods
- Update tests and service methods to use the new Modal abstraction and ScansModalTableColumns enum