### PR TITLE
Log API/CLI/UI actions and pytest execution

### DIFF
--- a/camayoc/api.py
+++ b/camayoc/api.py
@@ -271,4 +271,5 @@ class Client(object):
         headers.update(kwargs.get("headers", {}))
         kwargs["headers"] = headers
         kwargs.setdefault("verify", self.verify)
+        logger.debug("Outgoing request [method='%s' url='%s' kwargs=%s]", method, url, kwargs)
         return self.response_handler(requests.request(method, url, **kwargs))

--- a/camayoc/constants.py
+++ b/camayoc/constants.py
@@ -24,6 +24,9 @@ DBSERIALIZER_REPORTS_DIR_PATH = "reports"
 Each report is represented by directory named after report id. Only details.json
 and aggregate.json are stored."""
 
+CLI_DEBUG_MSG = "Executing command: %s"
+"""Message to log when executing command through CLI."""
+
 VALID_BOOLEAN_CHOICES = ["true", "false"]
 """Valid qpc/dsc CLI boolean choices."""
 

--- a/camayoc/data_provider.py
+++ b/camayoc/data_provider.py
@@ -116,6 +116,11 @@ class ModelWorker:
         return new_model
 
     def defined_many(self, match_criteria):
+        logger.debug(
+            "Called DataProvider.defined_many [model=%s criteria=%s]",
+            self._model_class.__name__,
+            match_criteria,
+        )
         matching_definitions = self._select_definitions(match_criteria)
         random.shuffle(matching_definitions)
 
@@ -126,10 +131,22 @@ class ModelWorker:
             yield model
 
     def defined_one(self, match_criteria):
+        logger.debug(
+            "Called DataProvider.defined_one [model=%s criteria=%s]",
+            self._model_class.__name__,
+            match_criteria,
+        )
         defined_generator = self.defined_many(match_criteria)
         return next(defined_generator)
 
     def new_many(self, match_criteria, new_dependencies=True, data_only=True):
+        logger.debug(
+            "Called DataProvider.new_many [model=%s criteria=%s dependencies=%s data_only=%s]",
+            self._model_class.__name__,
+            match_criteria,
+            new_dependencies,
+            data_only,
+        )
         matching_definitions = self._select_definitions(match_criteria)
         random.shuffle(matching_definitions)
 
@@ -143,6 +160,13 @@ class ModelWorker:
             yield model
 
     def new_one(self, match_criteria, new_dependencies=True, data_only=True):
+        logger.debug(
+            "Called DataProvider.new_one [model=%s criteria=%s dependencies=%s data_only=%s]",
+            self._model_class.__name__,
+            match_criteria,
+            new_dependencies,
+            data_only,
+        )
         new_generator = self.new_many(
             match_criteria=match_criteria,
             new_dependencies=new_dependencies,
@@ -174,6 +198,7 @@ class DataProvider:
                     worker._created_models[obj_name] = obj
 
     def cleanup(self):
+        logger.debug("Called DataProvider.cleanup")
         trash = chain.from_iterable(
             (getattr(self, store)._created_models.values() for store in self._stores)
         )
@@ -211,6 +236,7 @@ class ScanContainer:
         return self._get_or_run_scans(scans=wanted_scans, ok_only=True)
 
     def _get_or_run_scans(self, scans: Sequence[str], ok_only=False) -> dict[str, FinishedScan]:
+        logger.debug("Called ScanContainer._get_or_run_scans [scans=%s ok_only=%s]", scans, ok_only)
         self._sync_finished_scans_with_dp()
         self._ensure_wanted_scans_finished(scans)
 

--- a/camayoc/tests/qpc/cli/test_credentials.py
+++ b/camayoc/tests/qpc/cli/test_credentials.py
@@ -9,6 +9,7 @@
 """
 
 import json
+import logging
 import random
 from io import BytesIO
 
@@ -18,6 +19,7 @@ from littletable import Table
 
 from camayoc import utils
 from camayoc.constants import BECOME_PASSWORD_INPUT
+from camayoc.constants import CLI_DEBUG_MSG
 from camayoc.constants import CONNECTION_PASSWORD_INPUT
 from camayoc.constants import MASKED_PASSWORD_OUTPUT
 from camayoc.tests.qpc.cli.utils import cred_add_and_check
@@ -25,6 +27,8 @@ from camayoc.tests.qpc.cli.utils import cred_show_and_check
 from camayoc.tests.qpc.cli.utils import source_add_and_check
 from camayoc.tests.qpc.cli.utils import source_show
 from camayoc.utils import client_cmd
+
+logger = logging.getLogger(__name__)
 
 
 def generate_show_output(data):
@@ -282,9 +286,9 @@ def test_edit_username(isolated_filesystem, qpc_server_config, source_type):
         ),
     )
 
-    qpc_cred_edit = pexpect.spawn(
-        "{} -v cred edit --name={} --username={}".format(client_cmd, name, new_username)
-    )
+    command = "{} -v cred edit --name={} --username={}".format(client_cmd, name, new_username)
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_cred_edit = pexpect.spawn(command)
     qpc_cred_edit.logfile = BytesIO()
     assert qpc_cred_edit.expect('Credential "{}" was updated'.format(name)) == 0
     assert qpc_cred_edit.expect(pexpect.EOF) == 0
@@ -324,9 +328,9 @@ def test_edit_username_negative(isolated_filesystem, qpc_server_config):
 
     name = utils.uuid4()
     username = utils.uuid4()
-    qpc_cred_edit = pexpect.spawn(
-        "{} -v cred edit --name={} --username={}".format(client_cmd, name, username)
-    )
+    command = "{} -v cred edit --name={} --username={}".format(client_cmd, name, username)
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_cred_edit = pexpect.spawn(command)
     qpc_cred_edit.logfile = BytesIO()
     assert qpc_cred_edit.expect('Credential "{}" does not exist'.format(name)) == 0
     assert qpc_cred_edit.expect(pexpect.EOF) == 0
@@ -369,7 +373,9 @@ def test_edit_password(isolated_filesystem, qpc_server_config, source_type):
         ),
     )
 
-    qpc_cred_edit = pexpect.spawn("{} -v cred edit --name={} --password".format(client_cmd, name))
+    command = "{} -v cred edit --name={} --password".format(client_cmd, name)
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_cred_edit = pexpect.spawn(command)
     assert qpc_cred_edit.expect(CONNECTION_PASSWORD_INPUT) == 0
     qpc_cred_edit.sendline(new_password)
     assert qpc_cred_edit.expect('Credential "{}" was updated'.format(name)) == 0
@@ -410,7 +416,9 @@ def test_edit_password_negative(isolated_filesystem, qpc_server_config):
     )
 
     name = utils.uuid4()
-    qpc_cred_edit = pexpect.spawn("{} -v cred edit --name={} --password".format(client_cmd, name))
+    command = "{} -v cred edit --name={} --password".format(client_cmd, name)
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_cred_edit = pexpect.spawn(command)
     assert qpc_cred_edit.expect('Credential "{}" does not exist'.format(name)) == 0
     assert qpc_cred_edit.expect(pexpect.EOF) == 0
     qpc_cred_edit.close()
@@ -438,7 +446,9 @@ def test_edit_sshkeyfile_negative(data_provider, qpc_server_config):
     )
 
     name = utils.uuid4()
-    qpc_cred_edit = pexpect.spawn(f"{client_cmd} -v cred edit --name={name} --sshkeyfile -")
+    command = f"{client_cmd} -v cred edit --name={name} --sshkeyfile -"
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_cred_edit = pexpect.spawn(command)
     qpc_cred_edit.logfile = BytesIO()
     assert qpc_cred_edit.expect('Credential "{}" does not exist'.format(name)) == 0
     assert qpc_cred_edit.expect(pexpect.EOF) == 0
@@ -485,9 +495,9 @@ def test_edit_become_password(isolated_filesystem, qpc_server_config):
         ),
     )
 
-    qpc_cred_edit = pexpect.spawn(
-        "{} -v cred edit --name={} --become-password".format(client_cmd, name)
-    )
+    command = "{} -v cred edit --name={} --become-password".format(client_cmd, name)
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_cred_edit = pexpect.spawn(command)
     assert qpc_cred_edit.expect(BECOME_PASSWORD_INPUT) == 0
     qpc_cred_edit.sendline(new_become_password)
     assert qpc_cred_edit.expect('Credential "{}" was updated'.format(name)) == 0
@@ -528,9 +538,9 @@ def test_edit_become_password_negative(isolated_filesystem, qpc_server_config):
     )
 
     name = utils.uuid4()
-    qpc_cred_edit = pexpect.spawn(
-        "{} -v cred edit --name={} --become-password".format(client_cmd, name)
-    )
+    command = "{} -v cred edit --name={} --become-password".format(client_cmd, name)
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_cred_edit = pexpect.spawn(command)
     assert qpc_cred_edit.expect('Credential "{}" does not exist'.format(name)) == 0
     assert qpc_cred_edit.expect(pexpect.EOF) == 0
     qpc_cred_edit.close()
@@ -549,7 +559,9 @@ def test_edit_no_credentials(isolated_filesystem, qpc_server_config):
     """
     name = utils.uuid4()
 
-    qpc_cred_edit = pexpect.spawn("{} -v cred edit --name={} --password".format(client_cmd, name))
+    command = "{} -v cred edit --name={} --password".format(client_cmd, name)
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_cred_edit = pexpect.spawn(command)
     qpc_cred_edit.logfile = BytesIO()
     assert qpc_cred_edit.expect('Credential "{}" does not exist'.format(name)) == 0
     assert qpc_cred_edit.expect(pexpect.EOF) == 0
@@ -588,13 +600,17 @@ def test_clear(isolated_filesystem, qpc_server_config):
         ),
     )
 
-    qpc_cred_clear = pexpect.spawn("{} -v cred clear --name={}".format(client_cmd, name))
+    command = "{} -v cred clear --name={}".format(client_cmd, name)
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_cred_clear = pexpect.spawn(command)
     assert qpc_cred_clear.expect('Credential "{}" was removed'.format(name)) == 0
     assert qpc_cred_clear.expect(pexpect.EOF) == 0
     qpc_cred_clear.close()
     assert qpc_cred_clear.exitstatus == 0
 
-    qpc_cred_show = pexpect.spawn("{} -v cred show --name={}".format(client_cmd, name))
+    command = "{} -v cred show --name={}".format(client_cmd, name)
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_cred_show = pexpect.spawn(command)
     assert qpc_cred_show.expect('Credential "{}" does not exist'.format(name)) == 0
     assert qpc_cred_show.expect(pexpect.EOF) == 0
     qpc_cred_show.close()
@@ -655,7 +671,9 @@ def test_clear_with_source(isolated_filesystem, qpc_server_config):
     output = source_show({"name": source_name})
     output = json.loads(output)
     # try to delete credential
-    qpc_cred_clear = pexpect.spawn("{} -v cred clear --name={}".format(client_cmd, cred_name))
+    command = "{} -v cred clear --name={}".format(client_cmd, cred_name)
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_cred_clear = pexpect.spawn(command)
     qpc_cred_clear.logfile = BytesIO()
     assert qpc_cred_clear.expect(pexpect.EOF) == 0
     assert (
@@ -671,19 +689,25 @@ def test_clear_with_source(isolated_filesystem, qpc_server_config):
     assert qpc_cred_clear.exitstatus == 1
     qpc_cred_clear.close()
     # delete the source using credential
-    qpc_source_clear = pexpect.spawn("{} -v source clear --name={}".format(client_cmd, source_name))
+    command = "{} -v source clear --name={}".format(client_cmd, source_name)
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_clear = pexpect.spawn(command)
     assert qpc_source_clear.expect('Source "{}" was removed'.format(source_name)) == 0
     assert qpc_source_clear.expect(pexpect.EOF) == 0
     qpc_source_clear.close()
     assert qpc_source_clear.exitstatus == 0
     # successfully remove credential
-    qpc_cred_clear = pexpect.spawn("{} -v cred clear --name={}".format(client_cmd, cred_name))
+    command = "{} -v cred clear --name={}".format(client_cmd, cred_name)
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_cred_clear = pexpect.spawn(command)
     assert qpc_cred_clear.expect('Credential "{}" was removed'.format(cred_name)) == 0
     assert qpc_cred_clear.expect(pexpect.EOF) == 0
     qpc_cred_clear.close()
     assert qpc_cred_clear.exitstatus == 0
     # try showing cred
-    qpc_cred_show = pexpect.spawn("{} -v cred show --name={}".format(client_cmd, cred_name))
+    command = "{} -v cred show --name={}".format(client_cmd, cred_name)
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_cred_show = pexpect.spawn(command)
     assert qpc_cred_show.expect('Credential "{}" does not exist'.format(cred_name)) == 0
     assert qpc_cred_show.expect(pexpect.EOF) == 0
     qpc_cred_show.close()
@@ -700,7 +724,9 @@ def test_clear_negative(isolated_filesystem, qpc_server_config):
         be removed.
     """
     name = utils.uuid4()
-    qpc_cred_clear = pexpect.spawn("{} -v cred clear --name={}".format(client_cmd, name))
+    command = "{} -v cred clear --name={}".format(client_cmd, name)
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_cred_clear = pexpect.spawn(command)
     qpc_cred_clear.logfile = BytesIO()
     assert qpc_cred_clear.expect(pexpect.EOF) == 0
     assert qpc_cred_clear.logfile.getvalue().strip().decode(
@@ -731,8 +757,10 @@ def test_clear_all(isolated_filesystem, qpc_server_config, cleaning_data_provide
         ]
         cred_add_and_check(options, inputs)
 
+    command = "{} -v cred clear --all".format(client_cmd)
+    logger.debug(CLI_DEBUG_MSG, command)
     output, exitstatus = pexpect.run(
-        "{} -v cred clear --all".format(client_cmd),
+        command,
         encoding="utf-8",
         withexitstatus=True,
     )
@@ -742,9 +770,9 @@ def test_clear_all(isolated_filesystem, qpc_server_config, cleaning_data_provide
     )
     assert exitstatus == 0
 
-    output, exitstatus = pexpect.run(
-        "{} -v cred list".format(client_cmd), encoding="utf8", withexitstatus=True
-    )
+    command = "{} -v cred list".format(client_cmd)
+    logger.debug(CLI_DEBUG_MSG, command)
+    output, exitstatus = pexpect.run(command, encoding="utf8", withexitstatus=True)
     assert "No credentials exist yet." in output
     assert exitstatus == 0
 
@@ -769,8 +797,10 @@ def test_edit_existing_credential_username(qpc_server_config, source_type):
     """
     new_username = utils.uuid4()
 
+    command = "{} -v cred list --type {}".format(client_cmd, source_type)
+    logger.debug(CLI_DEBUG_MSG, command)
     output, _ = pexpect.run(
-        "{} -v cred list --type {}".format(client_cmd, source_type),
+        command,
         encoding="utf8",
         withexitstatus=True,
     )
@@ -787,10 +817,12 @@ def test_edit_existing_credential_username(qpc_server_config, source_type):
     credential_name = credential.get("name")
 
     # Edit credential
+    command = "{} -v cred edit --name='{}' --username={}".format(
+        client_cmd, credential_name, new_username
+    )
+    logger.debug(CLI_DEBUG_MSG, command)
     output, exitstatus = pexpect.run(
-        "{} -v cred edit --name='{}' --username={}".format(
-            client_cmd, credential_name, new_username
-        ),
+        command,
         encoding="utf-8",
         withexitstatus=True,
     )
@@ -798,8 +830,10 @@ def test_edit_existing_credential_username(qpc_server_config, source_type):
     assert exitstatus == 0
 
     # Grab the new data, prepare both for comparison, compare
+    command = "{} -v cred show --name='{}'".format(client_cmd, credential_name)
+    logger.debug(CLI_DEBUG_MSG, command)
     output, exitstatus = pexpect.run(
-        "{} -v cred show --name='{}'".format(client_cmd, credential_name),
+        command,
         encoding="utf-8",
         withexitstatus=True,
     )
@@ -812,8 +846,8 @@ def test_edit_existing_credential_username(qpc_server_config, source_type):
     assert expected == updated_credential
 
     # Restore old username
-    pexpect.run(
-        "{} -v cred edit --name='{}' --username='{}'".format(
-            client_cmd, credential_name, credential.get("username")
-        )
+    command = "{} -v cred edit --name='{}' --username='{}'".format(
+        client_cmd, credential_name, credential.get("username")
     )
+    logger.debug(CLI_DEBUG_MSG, command)
+    pexpect.run(command)

--- a/camayoc/tests/qpc/cli/test_sources.py
+++ b/camayoc/tests/qpc/cli/test_sources.py
@@ -9,6 +9,7 @@
 """
 
 import json
+import logging
 import operator
 import random
 from io import BytesIO
@@ -17,6 +18,7 @@ import pexpect
 import pytest
 
 from camayoc import utils
+from camayoc.constants import CLI_DEBUG_MSG
 from camayoc.constants import CONNECTION_PASSWORD_INPUT
 from camayoc.constants import QPC_HOST_MANAGER_TYPES
 from camayoc.constants import QPC_SOURCES_DEFAULT_PORT
@@ -31,6 +33,9 @@ from camayoc.tests.qpc.cli.utils import source_edit_and_check
 from camayoc.tests.qpc.cli.utils import source_show_and_check
 from camayoc.utils import client_cmd
 from camayoc.utils import client_cmd_name
+
+logger = logging.getLogger(__name__)
+
 
 ISSUE_449_MARK = pytest.mark.xfail(
     reason="https://github.com/quipucords/quipucords/issues/449", strict=True
@@ -127,10 +132,12 @@ def test_add_with_cred_hosts(isolated_filesystem, qpc_server_config, hosts, sour
         [(CONNECTION_PASSWORD_INPUT, utils.uuid4())],
     )
 
+    command = "{} -v source add --name {} --cred {} --hosts {} --type {}".format(
+        client_cmd, name, cred_name, hosts, source_type
+    )
+    logger.debug(CLI_DEBUG_MSG, command)
     qpc_source_add = pexpect.spawn(
-        "{} -v source add --name {} --cred {} --hosts {} --type {}".format(
-            client_cmd, name, cred_name, hosts, source_type
-        )
+        command,
     )
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
@@ -181,10 +188,12 @@ def test_add_with_cred_hosts_file(isolated_filesystem, qpc_server_config, hosts,
     with open("hosts_file", "w") as handler:
         handler.write(hosts.replace(" ", "\n") + "\n")
 
+    command = "{} -v source add --name {} --cred {} --hosts {} --type {}".format(
+        client_cmd, name, cred_name, "hosts_file", source_type
+    )
+    logger.debug(CLI_DEBUG_MSG, command)
     qpc_source_add = pexpect.spawn(
-        "{} -v source add --name {} --cred {} --hosts {} --type {}".format(
-            client_cmd, name, cred_name, "hosts_file", source_type
-        )
+        command,
     )
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
@@ -233,10 +242,12 @@ def test_add_with_port(isolated_filesystem, qpc_server_config, source_type):
         [(CONNECTION_PASSWORD_INPUT, utils.uuid4())],
     )
 
+    command = "{} -v source add --name {} --cred {} --hosts {} --port {} --type {}".format(
+        client_cmd, name, cred_name, hosts, port, source_type
+    )
+    logger.debug(CLI_DEBUG_MSG, command)
     qpc_source_add = pexpect.spawn(
-        "{} -v source add --name {} --cred {} --hosts {} --port {} --type {}".format(
-            client_cmd, name, cred_name, hosts, port, source_type
-        )
+        command,
     )
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
@@ -285,11 +296,13 @@ def test_add_with_ssl_cert_verify(
         [(CONNECTION_PASSWORD_INPUT, utils.uuid4())],
     )
 
-    qpc_source_add = pexpect.spawn(
+    command = (
         "{} -v source add --name {} --cred {} --hosts {} --ssl-cert-verify {} --type {}".format(
             client_cmd, name, cred_name, hosts, ssl_cert_verify, source_type
         )
     )
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_add = pexpect.spawn(command)
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
@@ -341,12 +354,14 @@ def test_add_with_ssl_cert_verify_negative(isolated_filesystem, qpc_server_confi
         [(CONNECTION_PASSWORD_INPUT, utils.uuid4())],
     )
 
-    qpc_source_add = pexpect.spawn(
+    command = (
         "{} source add --name {} --cred {} --hosts {} --port {} "
         "--ssl-cert-verify {} --type {}".format(
             client_cmd_name, name, cred_name, hosts, port, ssl_cert_verify, source_type
         )
     )
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_add = pexpect.spawn(command)
     assert qpc_source_add.expect(expected_error) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
@@ -379,11 +394,11 @@ def test_add_with_ssl_protocol(isolated_filesystem, qpc_server_config, source_ty
         [(CONNECTION_PASSWORD_INPUT, utils.uuid4())],
     )
 
-    qpc_source_add = pexpect.spawn(
-        "{} -v source add --name {} --cred {} --hosts {} --ssl-protocol {} --type {}".format(
-            client_cmd, name, cred_name, hosts, ssl_protocol, source_type
-        )
+    command = "{} -v source add --name {} --cred {} --hosts {} --ssl-protocol {} --type {}".format(
+        client_cmd, name, cred_name, hosts, ssl_protocol, source_type
     )
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_add = pexpect.spawn(command)
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
@@ -434,12 +449,14 @@ def test_add_with_ssl_protocol_negative(isolated_filesystem, qpc_server_config):
         [(CONNECTION_PASSWORD_INPUT, utils.uuid4())],
     )
 
-    qpc_source_add = pexpect.spawn(
+    command = (
         "{} -v source add --name {} --cred {} --hosts {} --port {} "
         "--ssl-protocol {} --type {}".format(
             client_cmd, name, cred_name, hosts, port, ssl_protocol, source_type
         )
     )
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_add = pexpect.spawn(command)
     assert qpc_source_add.expect(expected_error) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
@@ -472,11 +489,11 @@ def test_add_with_disable_ssl(isolated_filesystem, qpc_server_config, source_typ
         [(CONNECTION_PASSWORD_INPUT, utils.uuid4())],
     )
 
-    qpc_source_add = pexpect.spawn(
-        "{} -v source add --name {} --cred {} --hosts {} --disable-ssl {} --type {}".format(
-            client_cmd, name, cred_name, hosts, disable_ssl, source_type
-        )
+    command = "{} -v source add --name {} --cred {} --hosts {} --disable-ssl {} --type {}".format(
+        client_cmd, name, cred_name, hosts, disable_ssl, source_type
     )
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_add = pexpect.spawn(command)
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
@@ -527,12 +544,14 @@ def test_add_with_disable_ssl_negative(isolated_filesystem, qpc_server_config, s
         [(CONNECTION_PASSWORD_INPUT, utils.uuid4())],
     )
 
-    qpc_source_add = pexpect.spawn(
+    command = (
         "{} -v source add --name {} --cred {} --hosts {} --port {} "
         "--disable-ssl {} --type {}".format(
             client_cmd, name, cred_name, hosts, port, disable_ssl, source_type
         )
     )
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_add = pexpect.spawn(command)
     assert qpc_source_add.expect(expected_error) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
@@ -566,10 +585,11 @@ def test_add_with_exclude_hosts(
         [(CONNECTION_PASSWORD_INPUT, utils.uuid4())],
     )
 
-    qpc_source_add = pexpect.spawn(
-        """{} -v source add --name {} --cred {} --hosts {} --exclude-hosts {}
-        --type {}""".format(client_cmd, name, cred_name, hosts, exclude_hosts, source_type)
+    command = "{} -v source add --name {} --cred {} --hosts {} --exclude-hosts {} --type {}".format(
+        client_cmd, name, cred_name, hosts, exclude_hosts, source_type
     )
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_add = pexpect.spawn(command)
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
@@ -623,10 +643,11 @@ def test_add_with_cred_hosts_exclude_file(
     with open("exclude_hosts_file", "w") as handler:
         handler.write(exclude_hosts.replace(" ", "\n") + "\n")
 
-    qpc_source_add = pexpect.spawn(
-        """{} -v source add --name {} --cred {} --hosts {} --exclude-hosts={}
-        --type {}""".format(client_cmd, name, cred_name, hosts, "exclude_hosts_file", source_type)
+    command = "{} -v source add --name {} --cred {} --hosts {} --exclude-hosts={} --type {}".format(
+        client_cmd, name, cred_name, hosts, "exclude_hosts_file", source_type
     )
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_add = pexpect.spawn(command)
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
@@ -679,10 +700,11 @@ def test_add_exclude_hosts_negative(
         [(CONNECTION_PASSWORD_INPUT, utils.uuid4())],
     )
 
-    qpc_source_add = pexpect.spawn(
-        """{} -v source add --name {} --cred {} --hosts {} --exclude-hosts {}
-        --type {}""".format(client_cmd, name, cred_name, hosts, exclude_hosts, source_type)
+    command = "{} -v source add --name {} --cred {} --hosts {} --exclude-hosts {} --type {}".format(
+        client_cmd, name, cred_name, hosts, exclude_hosts, source_type
     )
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_add = pexpect.spawn(command)
     assert (
         qpc_source_add.expect(
             "exclude_hosts: The exclude_hosts option is not valid for this source."
@@ -715,11 +737,11 @@ def test_edit_cred(isolated_filesystem, qpc_server_config, source_type):
             [(CONNECTION_PASSWORD_INPUT, utils.uuid4())],
         )
 
-    qpc_source_add = pexpect.spawn(
-        "{} -v source add --name {} --cred {} --hosts {} --type {}".format(
-            client_cmd, name, cred_name, hosts, source_type
-        )
+    command = "{} -v source add --name {} --cred {} --hosts {} --type {}".format(
+        client_cmd, name, cred_name, hosts, source_type
     )
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_add = pexpect.spawn(command)
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
@@ -738,9 +760,9 @@ def test_edit_cred(isolated_filesystem, qpc_server_config, source_type):
         ),
     )
 
-    qpc_source_edit = pexpect.spawn(
-        "{} -v source edit --name {} --cred {}".format(client_cmd, name, new_cred_name)
-    )
+    command = "{} -v source edit --name {} --cred {}".format(client_cmd, name, new_cred_name)
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_edit = pexpect.spawn(command)
     assert qpc_source_edit.expect('Source "{}" was updated'.format(name)) == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
     qpc_source_edit.close()
@@ -782,19 +804,21 @@ def test_edit_cred_negative(isolated_filesystem, qpc_server_config, source_type)
         [(CONNECTION_PASSWORD_INPUT, utils.uuid4())],
     )
 
-    qpc_source_add = pexpect.spawn(
-        "{} -v source add --name {} --cred {} --hosts {} --type {}".format(
-            client_cmd, name, cred_name, hosts, source_type
-        )
+    command = "{} -v source add --name {} --cred {} --hosts {} --type {}".format(
+        client_cmd, name, cred_name, hosts, source_type
     )
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_add = pexpect.spawn(command)
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
     assert qpc_source_add.exitstatus == 0
 
-    qpc_source_edit = pexpect.spawn(
-        "{} -v source edit --name {} --cred {}".format(client_cmd, invalid_name, utils.uuid4())
+    command = "{} -v source edit --name {} --cred {}".format(
+        client_cmd, invalid_name, utils.uuid4()
     )
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_edit = pexpect.spawn(command)
     qpc_source_edit.logfile = BytesIO()
     assert qpc_source_edit.expect('Source "{}" does not exist.'.format(invalid_name)) == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
@@ -825,11 +849,11 @@ def test_edit_hosts(isolated_filesystem, qpc_server_config, new_hosts, source_ty
         [(CONNECTION_PASSWORD_INPUT, utils.uuid4())],
     )
 
-    qpc_source_add = pexpect.spawn(
-        "{} -v source add --name {} --cred {} --hosts {} --type {}".format(
-            client_cmd, name, cred_name, hosts, source_type
-        )
+    command = "{} -v source add --name {} --cred {} --hosts {} --type {}".format(
+        client_cmd, name, cred_name, hosts, source_type
     )
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_add = pexpect.spawn(command)
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
@@ -848,9 +872,9 @@ def test_edit_hosts(isolated_filesystem, qpc_server_config, new_hosts, source_ty
         ),
     )
 
-    qpc_source_edit = pexpect.spawn(
-        "{} -v source edit --name {} --hosts {}".format(client_cmd, name, new_hosts)
-    )
+    command = "{} -v source edit --name {} --hosts {}".format(client_cmd, name, new_hosts)
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_edit = pexpect.spawn(command)
     assert qpc_source_edit.expect('Source "{}" was updated'.format(name)) == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
     qpc_source_edit.close()
@@ -894,11 +918,11 @@ def test_edit_hosts_file(isolated_filesystem, qpc_server_config, new_hosts, sour
         [(CONNECTION_PASSWORD_INPUT, utils.uuid4())],
     )
 
-    qpc_source_add = pexpect.spawn(
-        "{} -v source add --name {} --cred {} --hosts {} --type {}".format(
-            client_cmd, name, cred_name, hosts, source_type
-        )
+    command = "{} -v source add --name {} --cred {} --hosts {} --type {}".format(
+        client_cmd, name, cred_name, hosts, source_type
     )
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_add = pexpect.spawn(command)
     qpc_source_add.logfile = BytesIO()
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
@@ -921,9 +945,9 @@ def test_edit_hosts_file(isolated_filesystem, qpc_server_config, new_hosts, sour
     with open("hosts_file", "w") as handler:
         handler.write(new_hosts.replace(" ", "\n") + "\n")
 
-    qpc_source_edit = pexpect.spawn(
-        "{} -v source edit --name {} --hosts {}".format(client_cmd, name, "hosts_file")
-    )
+    command = "{} -v source edit --name {} --hosts {}".format(client_cmd, name, "hosts_file")
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_edit = pexpect.spawn(command)
     qpc_source_edit.logfile = BytesIO()
     assert qpc_source_edit.expect('Source "{}" was updated'.format(name)) == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
@@ -971,19 +995,19 @@ def test_edit_hosts_negative(isolated_filesystem, qpc_server_config, new_hosts, 
         [(CONNECTION_PASSWORD_INPUT, utils.uuid4())],
     )
 
-    qpc_source_add = pexpect.spawn(
-        "{} -v source add --name {} --cred {} --hosts {} --type {}".format(
-            client_cmd, name, cred_name, hosts, source_type
-        )
+    command = "{} -v source add --name {} --cred {} --hosts {} --type {}".format(
+        client_cmd, name, cred_name, hosts, source_type
     )
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_add = pexpect.spawn(command)
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
     assert qpc_source_add.exitstatus == 0
 
-    qpc_source_edit = pexpect.spawn(
-        "{} -v source edit --name {} --hosts {}".format(client_cmd, name, new_hosts)
-    )
+    command = "{} -v source edit --name {} --hosts {}".format(client_cmd, name, new_hosts)
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_edit = pexpect.spawn(command)
     qpc_source_edit.logfile = BytesIO()
     assert qpc_source_edit.expect("hosts: This source must have a single host.") == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
@@ -1139,11 +1163,11 @@ def test_edit_port(isolated_filesystem, qpc_server_config, source_type):
         [(CONNECTION_PASSWORD_INPUT, utils.uuid4())],
     )
 
-    qpc_source_add = pexpect.spawn(
-        "{} -v source add --name {} --cred {} --hosts {} --port {} --type {}".format(
-            client_cmd, name, cred_name, hosts, port, source_type
-        )
+    command = "{} -v source add --name {} --cred {} --hosts {} --port {} --type {}".format(
+        client_cmd, name, cred_name, hosts, port, source_type
     )
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_add = pexpect.spawn(command)
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
@@ -1162,9 +1186,9 @@ def test_edit_port(isolated_filesystem, qpc_server_config, source_type):
         ),
     )
 
-    qpc_source_edit = pexpect.spawn(
-        "{} -v source edit --name {} --port {}".format(client_cmd, name, new_port)
-    )
+    command = "{} -v source edit --name {} --port {}".format(client_cmd, name, new_port)
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_edit = pexpect.spawn(command)
     assert qpc_source_edit.expect('Source "{}" was updated'.format(name)) == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
     qpc_source_edit.close()
@@ -1210,18 +1234,20 @@ def test_edit_port_negative(isolated_filesystem, qpc_server_config, source_type)
         [(CONNECTION_PASSWORD_INPUT, utils.uuid4())],
     )
 
-    qpc_source_add = pexpect.spawn(
-        "{} -v source add --name {} --cred {} --hosts {} --port {} --type {}".format(
-            client_cmd, name, cred_name, hosts, port, source_type
-        )
+    command = "{} -v source add --name {} --cred {} --hosts {} --port {} --type {}".format(
+        client_cmd, name, cred_name, hosts, port, source_type
     )
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_add = pexpect.spawn(command)
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
     assert qpc_source_add.exitstatus == 0
 
+    command = "{} -v source edit --name {} --port {}".format(client_cmd, invalid_name, new_port)
+    logger.debug(CLI_DEBUG_MSG, command)
     qpc_source_edit = pexpect.spawn(
-        "{} -v source edit --name {} --port {}".format(client_cmd, invalid_name, new_port)
+        command,
     )
     qpc_source_edit.logfile = BytesIO()
     assert qpc_source_edit.expect('Source "{}" does not exist.'.format(invalid_name)) == 0
@@ -1255,11 +1281,13 @@ def test_edit_ssl_cert_verify(isolated_filesystem, qpc_server_config, source_typ
         [(CONNECTION_PASSWORD_INPUT, utils.uuid4())],
     )
 
-    qpc_source_add = pexpect.spawn(
+    command = (
         "{} -v source add --name {} --cred {} --hosts {} --ssl-cert-verify {} --type {}".format(
             client_cmd, name, cred_name, hosts, ssl_cert_verify, source_type
         )
     )
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_add = pexpect.spawn(command)
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
@@ -1279,11 +1307,11 @@ def test_edit_ssl_cert_verify(isolated_filesystem, qpc_server_config, source_typ
         ),
     )
 
-    qpc_source_edit = pexpect.spawn(
-        "{} -v source edit --name {} --ssl-cert-verify {}".format(
-            client_cmd, name, new_ssl_cert_verify
-        )
+    command = "{} -v source edit --name {} --ssl-cert-verify {}".format(
+        client_cmd, name, new_ssl_cert_verify
     )
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_edit = pexpect.spawn(command)
     assert qpc_source_edit.expect('Source "{}" was updated'.format(name)) == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
     qpc_source_edit.close()
@@ -1329,11 +1357,11 @@ def test_edit_ssl_protocol(isolated_filesystem, qpc_server_config, source_type):
         [(CONNECTION_PASSWORD_INPUT, utils.uuid4())],
     )
 
-    qpc_source_add = pexpect.spawn(
-        "{} -v source add --name {} --cred {} --hosts {} --ssl-protocol {} --type {}".format(
-            client_cmd, name, cred_name, hosts, ssl_protocol, source_type
-        )
+    command = "{} -v source add --name {} --cred {} --hosts {} --ssl-protocol {} --type {}".format(
+        client_cmd, name, cred_name, hosts, ssl_protocol, source_type
     )
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_add = pexpect.spawn(command)
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
@@ -1353,8 +1381,12 @@ def test_edit_ssl_protocol(isolated_filesystem, qpc_server_config, source_type):
         ),
     )
 
+    command = "{} -v source edit --name {} --ssl-protocol {}".format(
+        client_cmd, name, new_ssl_protocol
+    )
+    logger.debug(CLI_DEBUG_MSG, command)
     qpc_source_edit = pexpect.spawn(
-        "{} -v source edit --name {} --ssl-protocol {}".format(client_cmd, name, new_ssl_protocol)
+        command,
     )
     assert qpc_source_edit.expect('Source "{}" was updated'.format(name)) == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
@@ -1401,11 +1433,11 @@ def test_edit_disable_ssl(isolated_filesystem, qpc_server_config, source_type):
         [(CONNECTION_PASSWORD_INPUT, utils.uuid4())],
     )
 
-    qpc_source_add = pexpect.spawn(
-        "{} -v source add --name {} --cred {} --hosts {} --disable-ssl {} --type {}".format(
-            client_cmd, name, cred_name, hosts, disable_ssl, source_type
-        )
+    command = "{} -v source add --name {} --cred {} --hosts {} --disable-ssl {} --type {}".format(
+        client_cmd, name, cred_name, hosts, disable_ssl, source_type
     )
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_add = pexpect.spawn(command)
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
@@ -1425,8 +1457,12 @@ def test_edit_disable_ssl(isolated_filesystem, qpc_server_config, source_type):
         ),
     )
 
+    command = "{} -v source edit --name {} --disable-ssl {}".format(
+        client_cmd, name, new_disable_ssl
+    )
+    logger.debug(CLI_DEBUG_MSG, command)
     qpc_source_edit = pexpect.spawn(
-        "{} -v source edit --name {} --disable-ssl {}".format(client_cmd, name, new_disable_ssl)
+        command,
     )
     assert qpc_source_edit.expect('Source "{}" was updated'.format(name)) == 0
     assert qpc_source_edit.expect(pexpect.EOF) == 0
@@ -1471,11 +1507,11 @@ def test_clear(isolated_filesystem, qpc_server_config, source_type):
         [(CONNECTION_PASSWORD_INPUT, utils.uuid4())],
     )
 
-    qpc_source_add = pexpect.spawn(
-        "{} -v source add --name {} --cred {} --hosts {} --type {}".format(
-            client_cmd, name, cred_name, hosts, source_type
-        )
+    command = "{} -v source add --name {} --cred {} --hosts {} --type {}".format(
+        client_cmd, name, cred_name, hosts, source_type
     )
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_add = pexpect.spawn(command)
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
@@ -1494,19 +1530,25 @@ def test_clear(isolated_filesystem, qpc_server_config, source_type):
         ),
     )
 
-    qpc_source_clear = pexpect.spawn("{} -v source clear --name={}".format(client_cmd, name))
+    command = "{} -v source clear --name={}".format(client_cmd, name)
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_clear = pexpect.spawn(command)
     assert qpc_source_clear.expect('Source "{}" was removed'.format(name)) == 0
     assert qpc_source_clear.expect(pexpect.EOF) == 0
     qpc_source_clear.close()
     assert qpc_source_clear.exitstatus == 0
 
-    qpc_source_clear = pexpect.spawn("{} -v source clear --name={}".format(client_cmd, name))
+    command = "{} -v source clear --name={}".format(client_cmd, name)
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_clear = pexpect.spawn(command)
     assert qpc_source_clear.expect('Source "{}" was not found.'.format(name)) == 0
     assert qpc_source_clear.expect(pexpect.EOF) == 0
     qpc_source_clear.close()
     assert qpc_source_clear.exitstatus == 1
 
-    qpc_source_show = pexpect.spawn("{} -v source show --name={}".format(client_cmd, name))
+    command = "{} -v source show --name={}".format(client_cmd, name)
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_show = pexpect.spawn(command)
     assert qpc_source_show.expect('Source "{}" does not exist.'.format(name)) == 0
     assert qpc_source_show.expect(pexpect.EOF) == 0
     qpc_source_show.close()
@@ -1541,11 +1583,11 @@ def test_clear_with_scans(isolated_filesystem, qpc_server_config, source_type):
         [(CONNECTION_PASSWORD_INPUT, utils.uuid4())],
     )
 
-    qpc_source_add = pexpect.spawn(
-        "{} -v source add --name {} --cred {} --hosts {} --type {}".format(
-            client_cmd, name, cred_name, hosts, source_type
-        )
+    command = "{} -v source add --name {} --cred {} --hosts {} --type {}".format(
+        client_cmd, name, cred_name, hosts, source_type
     )
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_add = pexpect.spawn(command)
     assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
     assert qpc_source_add.expect(pexpect.EOF) == 0
     qpc_source_add.close()
@@ -1570,7 +1612,9 @@ def test_clear_with_scans(isolated_filesystem, qpc_server_config, source_type):
     scan_show_result = scan_show({"name": scan_name})
     scan_show_result = json.loads(scan_show_result)
 
-    qpc_source_clear = pexpect.spawn("{} -v source clear --name={}".format(client_cmd, name))
+    command = "{} -v source clear --name={}".format(client_cmd, name)
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_clear = pexpect.spawn(command)
 
     qpc_source_clear.logfile = BytesIO()
     assert qpc_source_clear.expect(pexpect.EOF) == 0
@@ -1581,24 +1625,32 @@ def test_clear_with_scans(isolated_filesystem, qpc_server_config, source_type):
         'Failed to remove source "%s".' % (scan_show_result["id"], scan_name, name)
     ).encode("utf-8")
 
-    qpc_scan_clear = pexpect.spawn("{} -v scan clear --name={}".format(client_cmd, scan_name))
+    command = "{} -v scan clear --name={}".format(client_cmd, scan_name)
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_scan_clear = pexpect.spawn(command)
 
     assert qpc_scan_clear.expect('Scan "{}" was removed'.format(scan_name)) == 0
 
-    qpc_source_clear = pexpect.spawn("{} -v source clear --name={}".format(client_cmd, name))
+    command = "{} -v source clear --name={}".format(client_cmd, name)
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_clear = pexpect.spawn(command)
 
     assert qpc_source_clear.expect('Source "{}" was removed'.format(name)) == 0
     assert qpc_source_clear.expect(pexpect.EOF) == 0
     qpc_source_clear.close()
     assert qpc_source_clear.exitstatus == 0
 
-    qpc_source_clear = pexpect.spawn("{} -v source clear --name={}".format(client_cmd, name))
+    command = "{} -v source clear --name={}".format(client_cmd, name)
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_clear = pexpect.spawn(command)
     assert qpc_source_clear.expect('Source "{}" was not found.'.format(name)) == 0
     assert qpc_source_clear.expect(pexpect.EOF) == 0
     qpc_source_clear.close()
     assert qpc_source_clear.exitstatus == 1
 
-    qpc_source_show = pexpect.spawn("{} -v source show --name={}".format(client_cmd, name))
+    command = "{} -v source show --name={}".format(client_cmd, name)
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_show = pexpect.spawn(command)
     assert qpc_source_show.expect('Source "{}" does not exist.'.format(name)) == 0
     assert qpc_source_show.expect(pexpect.EOF) == 0
     qpc_source_show.close()
@@ -1615,7 +1667,9 @@ def test_clear_negative(isolated_filesystem, qpc_server_config):
         can't be removed.
     """
     name = utils.uuid4()
-    qpc_source_clear = pexpect.spawn("{} -v source clear --name={}".format(client_cmd, name))
+    command = "{} -v source clear --name={}".format(client_cmd, name)
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_clear = pexpect.spawn(command)
     qpc_source_clear.logfile = BytesIO()
     assert qpc_source_clear.expect(pexpect.EOF) == 0
     assert qpc_source_clear.logfile.getvalue().strip() == 'Source "{}" was not found.'.format(
@@ -1646,8 +1700,10 @@ def test_clear_all(cleaning_data_provider, isolated_filesystem, qpc_server_confi
         [(CONNECTION_PASSWORD_INPUT, utils.uuid4())],
     )
 
+    command = "{} source clear --all".format(client_cmd)
+    logger.debug(CLI_DEBUG_MSG, command)
     qpc_source_clear = pexpect.spawn(
-        "{} source clear --all".format(client_cmd),
+        command,
         timeout=120,
     )
     assert qpc_source_clear.expect(pexpect.EOF) == 0
@@ -1668,17 +1724,19 @@ def test_clear_all(cleaning_data_provider, isolated_filesystem, qpc_server_confi
         if source_type != "network":
             source["options"] = {"ssl_cert_verify": True}
         sources.append(source)
-        qpc_source_add = pexpect.spawn(
-            "{} -v source add --name {} --cred {} --hosts {} --type {}".format(
-                client_cmd, name, cred_name, hosts, source_type
-            )
+        command = "{} -v source add --name {} --cred {} --hosts {} --type {}".format(
+            client_cmd, name, cred_name, hosts, source_type
         )
+        logger.debug(CLI_DEBUG_MSG, command)
+        qpc_source_add = pexpect.spawn(command)
         assert qpc_source_add.expect('Source "{}" was added'.format(name)) == 0
         assert qpc_source_add.expect(pexpect.EOF) == 0
         qpc_source_add.close()
         assert qpc_source_add.exitstatus == 0
 
-    qpc_source_list = pexpect.spawn("{} source list".format(client_cmd))
+    command = "{} source list".format(client_cmd)
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_list = pexpect.spawn(command)
     logfile = BytesIO()
     qpc_source_list.logfile = logfile
     assert qpc_source_list.expect(pexpect.EOF) == 0
@@ -1694,7 +1752,9 @@ def test_clear_all(cleaning_data_provider, isolated_filesystem, qpc_server_confi
     name = operator.itemgetter("name")
     assert sorted(sources, key=name) == sorted(output, key=name)
 
-    qpc_source_clear = pexpect.spawn("{} -v source clear --all".format(client_cmd))
+    command = "{} -v source clear --all".format(client_cmd)
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_clear = pexpect.spawn(command)
     assert (
         qpc_source_clear.expect(
             f"Successfully deleted {len(sources)} sources. 0 sources could not be deleted."
@@ -1705,7 +1765,9 @@ def test_clear_all(cleaning_data_provider, isolated_filesystem, qpc_server_confi
     qpc_source_clear.close()
     assert qpc_source_clear.exitstatus == 0
 
-    qpc_source_list = pexpect.spawn("{} -v source list".format(client_cmd))
+    command = "{} -v source list".format(client_cmd)
+    logger.debug(CLI_DEBUG_MSG, command)
+    qpc_source_list = pexpect.spawn(command)
     assert qpc_source_list.expect("No sources exist yet.") == 0
     assert qpc_source_list.expect(pexpect.EOF) == 0
     qpc_source_list.close()
@@ -1727,8 +1789,10 @@ def test_edit_existing_source_hosts(qpc_server_config, source_type):
     """
     new_hosts = "127.0.0.{}".format(random.randint(1, 254))
 
+    command = "{} -v source list --type {}".format(client_cmd, source_type)
+    logger.debug(CLI_DEBUG_MSG, command)
     output, _ = pexpect.run(
-        "{} -v source list --type {}".format(client_cmd, source_type),
+        command,
         encoding="utf8",
         withexitstatus=True,
     )
@@ -1741,8 +1805,10 @@ def test_edit_existing_source_hosts(qpc_server_config, source_type):
     source_name = source.get("name")
 
     # Edit source
+    command = "{} -v source edit --name='{}' --hosts={}".format(client_cmd, source_name, new_hosts)
+    logger.debug(CLI_DEBUG_MSG, command)
     output, exitstatus = pexpect.run(
-        "{} -v source edit --name='{}' --hosts={}".format(client_cmd, source_name, new_hosts),
+        command,
         encoding="utf-8",
         withexitstatus=True,
     )
@@ -1750,8 +1816,10 @@ def test_edit_existing_source_hosts(qpc_server_config, source_type):
     assert exitstatus == 0
 
     # Grab the new data, prepare both for comparison, compare
+    command = "{} -v source show --name='{}'".format(client_cmd, source_name)
+    logger.debug(CLI_DEBUG_MSG, command)
     output, exitstatus = pexpect.run(
-        "{} -v source show --name='{}'".format(client_cmd, source_name),
+        command,
         encoding="utf-8",
         withexitstatus=True,
     )
@@ -1763,8 +1831,8 @@ def test_edit_existing_source_hosts(qpc_server_config, source_type):
 
     # Restore old hosts value
     old_hosts = source.get("hosts")
-    pexpect.run(
-        "{} -v source edit --name='{}' --hosts {}".format(
-            client_cmd, source_name, " ".join(old_hosts)
-        )
+    command = "{} -v source edit --name='{}' --hosts {}".format(
+        client_cmd, source_name, " ".join(old_hosts)
     )
+    logger.debug(CLI_DEBUG_MSG, command)
+    pexpect.run(command)

--- a/camayoc/ui/decorators.py
+++ b/camayoc/ui/decorators.py
@@ -1,9 +1,12 @@
+import logging
 import warnings
 from functools import wraps
 
 from camayoc.exceptions import IncorrectDecoratorUsageWarning
 from camayoc.types.ui import HistoryRecord
 from camayoc.types.ui import Session
+
+logger = logging.getLogger(__name__)
 
 
 def service(func):
@@ -44,6 +47,13 @@ def record_action(func):
 
     @wraps(func)
     def inner(*args, **kwargs):
+        logger.debug(
+            "Executing page action [class='%s' action_name='%s' args=%s kwargs=%s]",
+            type(args[0]).__name__,
+            func.__name__,
+            args[1:],
+            kwargs,
+        )
         page = func(*args, **kwargs)
 
         try:

--- a/camayoc/ui/models/components/logged_in.py
+++ b/camayoc/ui/models/components/logged_in.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from camayoc.types.ui import UIPage
@@ -9,8 +10,12 @@ if TYPE_CHECKING:
     from .login import Login
 
 
+logger = logging.getLogger(__name__)
+
+
 class LoggedIn(UIPage):
     def logout(self) -> Login:
+        logger.debug("Executing page action [action='logout']")
         app_user_dropdown_button = "button[data-ouia-component-id=user_dropdown_button]:visible"
         logout_link = f"{app_user_dropdown_button} ~ div li[data-ouia-component-id=logout]"
 

--- a/camayoc/ui/models/pages/abstract_page.py
+++ b/camayoc/ui/models/pages/abstract_page.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from importlib import import_module
 from typing import TYPE_CHECKING
 from typing import Union
@@ -14,10 +15,14 @@ if TYPE_CHECKING:
     ClassOrPage = Union[Pages, "AbstractPage"]
 
 
+logger = logging.getLogger(__name__)
+
+
 class AbstractPage(UIPage):
     def __init__(self, client: camayoc.ui.client.Client):
         self._client = client
         self._driver = client.driver
+        logger.debug("Opening page: %s", self.__class__.__name__)
 
     def _new_page(self, class_or_page: ClassOrPage) -> UIPage:
         cls = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,14 +66,25 @@ include = ["camayoc*"]
 namespaces = false
 
 [tool.pytest.ini_options]
+addopts = """
+--log-format='[%(levelname)s %(asctime)s [%(name)s] %(filename)s:%(lineno)d] %(message)s' \
+--log-date-format='%Y-%m-%dT%H:%M:%S.%f' \
+--log-file-level=DEBUG"""
 filterwarnings = "ignore::urllib3.exceptions.InsecureRequestWarning"
 markers = [
     "ssh_keyfile_path: mark test with SSH key file path mapped to /sshkeys/ on the server (deselect with '-m \"not ssh_keyfile_path\"')",
     "runs_scan: tests that run scans (might be slow!)",
     "slow: tests that take a long time to run (on average, more than 30 seconds)",
-    "nightly_only: tests to execute only during nightly (or full) run, i.e. not during PR check; note that actual selection is implemented in discovery-ci",
-    "pr_only: tests to execute only during PR check run, i.e. not during nightly run; note that actual selection is implemented in discovery-ci",
-    "upgrade_only: tests to execute only during upgrade testing; note that actual selection is implemented in discovery-ci",
+    "nightly_only: tests to execute only during nightly (or full) run, i.e. not during PR check; note that custom --camayoc-pipeline flag is preferred",
+    "pr_only: tests to execute only during PR check run, i.e. not during nightly run; note that custom --camayoc-pipeline flag is preferred",
+    "upgrade_only: tests to execute only during upgrade testing; note that custom --camayoc-pipeline flag is preferred",
+]
+camayoc_log_config = [
+    "asyncio: ERROR",
+    "factory.generate: ERROR",
+    "faker.factory: ERROR",
+    "urllib3: ERROR",
+    "urllib3.connectionpool: ERROR",
 ]
 
 [tool.ruff]
@@ -119,6 +130,7 @@ ignore = [
 ]
 "camayoc/data_provider.py" = ["PLW2901"]
 "camayoc/qpc_models.py" = ["PL", "C901"]
+"camayoc/tests/qpc/cli/test_sources.py" = ["PLR0915"]
 "camayoc/tests/qpc/ui/conftest.py" = ["BLE001"]
 "camayoc/tests/qpc/utils.py" = ["PLW2901"]
 "tests/test_command.py" = ["F401"]


### PR DESCRIPTION
Introduce proper logging. Trace is emitted on pytest test start and finish, and when entering and leaving fixtures. All API requests (but not responses) are logged. All CLI commands are logged right before execution (but not their output and exit codes). Traces are emitted for each UI page and main method calls. Finally, shared infrastructure like DataProvider and ScanContainer emit traces for most important method calls.

Log line and date formats are added to pytest.ini. New pytest configuration option, `camayoc_log_config`, allows to silence selected third party library loggers. Value introduced by this commit silences loggers that would emit things during normal pipeline run, not all loggers that are created.

Note that by default this commit will **NOT** create new log files or print additional log entries to terminal. That part is managed by discovery-ci. To see extra logging locally, run either one:

```
pytest --log-file=camayoc.log ...
```
```
pytest --log-cli-level=DEBUG ...
```

Finally, log line format contains name of logger that emits a line, which should make it easier to identify new loggers as they are introduced by our dependencies. To get a list of all loggers created during pipeline run, add following snippet to `camayoc/pytest_plugin.py`:

```
def pytest_unconfigure():
    print(logging.root.manager.loggerDict.keys())
```

Now run all Camayoc tests as usual. List of loggers created during a session will be displayed at the end.

## Summary by Sourcery

Enable comprehensive debug logging across pytest execution, API requests, CLI commands, UI interactions, and shared data provider infrastructure, with configurable log formatting and filtering.

New Features:
- Instrument logging in pytest for test lifecycle events and fixtures with a new `camayoc_log_config` ini option

Enhancements:
- Log all outgoing API requests and CLI command executions at debug level
- Trace UI page navigations and actions via decorators
- Emit debug logs for key method calls in DataProvider and ScanContainer
- Configure default log and date formats in pytest.ini and pyproject.toml and silence noisy third-party loggers

Tests:
- Add debug logging calls before spawning commands in CLI tests and utilities