### PR TITLE
build: drop uv version restrictions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,6 @@ convention = "pep257"
 # here should be matched by version available in image.
 [tool.uv]
 package = true
-required-version = ">=0.6.11,<0.7"
 environments = [
     "implementation_name == 'cpython' and (sys_platform == 'linux' or sys_platform == 'darwin')",
 ]


### PR DESCRIPTION
Corresponds with https://github.com/quipucords/quipucords/pull/2977 and https://github.com/quipucords/qpc/pull/376 updates to allow uv 0.7+.