### PR TITLE
Use Sources API v2

### DIFF
--- a/camayoc/constants.py
+++ b/camayoc/constants.py
@@ -62,7 +62,7 @@ QPC_API_ROOT = "api/"
 QPC_CREDENTIALS_PATH = "v2/credentials/"
 """The path to the credentials endpoint for CRUD tasks."""
 
-QPC_SOURCE_PATH = "v1/sources/"
+QPC_SOURCE_PATH = "v2/sources/"
 """The path to the profiles endpoint for CRUD tasks."""
 
 QPC_SCAN_PATH = "v1/scans/"

--- a/camayoc/tests/qpc/cli/test_endtoend.py
+++ b/camayoc/tests/qpc/cli/test_endtoend.py
@@ -76,8 +76,14 @@ def test_end_to_end(tmp_path, qpc_server_config, data_provider, source_name):
     }
     if source_port := getattr(source_model, "port", None):
         source_add_args["port"] = source_port
-    if source_options := getattr(source_model, "options", {}):
-        source_add_args.update({key.replace("_", "-"): val for key, val in source_options.items()})
+
+    for opt in ("ssl_protocol", "ssl_cert_verify", "disable_ssl", "use_paramiko"):
+        value = getattr(source_model, opt, None)
+        if value is None:
+            continue
+        key = opt.replace("_", "-")
+        source_add_args[key] = value
+
     data_provider.mark_for_cleanup(source_model)
     source_add_and_check(source_add_args)
 

--- a/camayoc/types/settings.py
+++ b/camayoc/types/settings.py
@@ -128,6 +128,10 @@ class SourceOptions(BaseModel):
     port: Optional[int] = None
     credentials: list[str]
     options: Optional[SourceOptionsOptions] = None
+    ssl_protocol: Optional[str] = None  # FIXME: should be enum
+    ssl_cert_verify: Optional[bool] = None
+    disable_ssl: Optional[bool] = None
+    use_paramiko: Optional[bool] = None
 
 
 class ExpectedDistributionData(BaseModel):

--- a/camayoc/types/ui.py
+++ b/camayoc/types/ui.py
@@ -365,7 +365,7 @@ class SatelliteSourceFormDTO:
             source_name=model.name,
             address=model.hosts[0],
             credentials=model.credentials,
-            verify_ssl=model.options.get("ssl_cert_verify"),
+            verify_ssl=model.ssl_cert_verify,
             **port_args,
         )
 
@@ -388,7 +388,7 @@ class VCenterSourceFormDTO:
             source_name=model.name,
             address=model.hosts[0],
             credentials=model.credentials,
-            verify_ssl=model.options.get("ssl_cert_verify"),
+            verify_ssl=model.ssl_cert_verify,
             **port_args,
         )
 
@@ -411,7 +411,7 @@ class OpenShiftSourceFormDTO:
             source_name=model.name,
             address=model.hosts[0],
             credentials=model.credentials,
-            verify_ssl=model.options.get("ssl_cert_verify"),
+            verify_ssl=model.ssl_cert_verify,
             **port_args,
         )
 
@@ -434,7 +434,7 @@ class AnsibleSourceFormDTO:
             source_name=model.name,
             address=model.hosts[0],
             credentials=model.credentials,
-            verify_ssl=model.options.get("ssl_cert_verify"),
+            verify_ssl=model.ssl_cert_verify,
             **port_args,
         )
 
@@ -457,7 +457,7 @@ class RHACSSourceFormDTO:
             source_name=model.name,
             address=model.hosts[0],
             credentials=model.credentials,
-            verify_ssl=model.options.get("ssl_cert_verify"),
+            verify_ssl=model.ssl_cert_verify,
             **port_args,
         )
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -47,7 +47,7 @@ MOCK_SAT6_SOURCE = {
     "source_type": "satellite",
     "name": "e193081c-2423-4407-b9e2-05d20b6443dc",
     "port": 443,
-    "options": {"satellite_version": "6.2", "ssl_cert_verify": False},
+    "ssl_cert_verify": False,
 }
 
 MOCK_SCAN = {
@@ -203,7 +203,7 @@ class SourceTestCase(unittest.TestCase):
             name=MOCK_SAT6_SOURCE["name"],
             hosts=MOCK_SAT6_SOURCE["hosts"],
             credential_ids=[MOCK_SAT6_SOURCE["credentials"][0]["id"]],
-            options=MOCK_SAT6_SOURCE["options"],
+            options={"ssl_cert_verify": MOCK_SAT6_SOURCE["ssl_cert_verify"]},
             port=443,
             client=client,
         )


### PR DESCRIPTION
Switch Camayoc Sources URL to v2.

Until DISCOVERY-1006 is resolved, use v1 for bulk_delete.

Additionally, prepare settings to consume new Source definition schema, where keys from Options are promoted to top-level keys. This is backwards-compatible, allowing us to move configuration at later date.

This requires new dataset for upgrade tests. I have it locally. Will update it on remote server after this PR is merged.

## Summary by Sourcery

Switch Sources API to v2 with backward-compatible top-level SSL schema and introduce v1 fallback for bulk_delete, updating settings, models, UI types, and tests.

New Features:
- Switch default Sources endpoint to API v2.
- Add bulk_delete method fallback to v1 endpoint until DISCOVERY-1006 is resolved.

Enhancements:
- Promote SSL-related settings (ssl_protocol, ssl_cert_verify, disable_ssl, use_paramiko) from nested options to top-level properties in models and settings schema.
- Refactor UI and API types to use top-level SSL attributes instead of nested options.

Tests:
- Update end-to-end and unit tests to use top-level SSL fields instead of options dict.

Chores:
- Update QPC_SOURCE_PATH constant to point at v2/sources.