### PR TITLE
build: add GitHub PR check to forbid "fixup!" commits

### DIFF
--- a/.github/workflows/forbid-fixup-commits.yaml
+++ b/.github/workflows/forbid-fixup-commits.yaml
@@ -1,0 +1,38 @@
+---
+name: Forbid 'fixup!' commits
+
+on:
+  pull_request:
+
+jobs:
+  forbid-fixup-commits:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # Required for git history
+          fetch-depth: 0
+
+      - name: Get base and head commits
+        run: |
+          echo "BASE_REF=${{ github.base_ref }}" >> "$GITHUB_ENV"
+          echo "BASE_SHA=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_ENV"
+          echo "HEAD_SHA=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_ENV"
+
+      - name: Check for fixup commits
+        run: |
+          echo "Checking for 'fixup!' commits between $BASE_SHA and $HEAD_SHA..."
+          FIXUP_COMMITS=$(git log --format="%H %s" $BASE_SHA..$HEAD_SHA | grep "^[^ ]*[ ]*fixup!" || true)
+          if [ -n "$FIXUP_COMMITS" ]; then
+            echo "Error: Found 'fixup!' commits:"
+            echo
+            echo "$FIXUP_COMMITS"
+            echo
+            echo "Please rebase your branch and squash 'fixup!' commits before merging."
+            echo "Consider using: git rebase -i $BASE_REF --autosquash"
+            exit 1
+          else
+            echo "No 'fixup!' commit messages found."
+          fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,4 @@ repos:
       rev: v1.35.1
       hooks:
           - id: yamllint
+            exclude: .github/workflows/forbid-fixup-commits.yaml


### PR DESCRIPTION
Copy-paste of https://github.com/quipucords/quipucords/pull/2981

I needed to add it to pre-commit yamllint exclude, as it complained about lines being over 80 characters.

## Summary by Sourcery

Add GitHub Actions workflow to block "fixup!" commits on pull requests and update pre-commit yamllint settings to exclude the new workflow file

Build:
- Exclude the new GitHub workflow YAML from yamllint in .pre-commit-config.yaml

CI:
- Introduce forbid-fixup-commits workflow that scans PR commits and fails if any "fixup!" messages are found