### PR TITLE
Fix try_reauthenticate wrapper

### DIFF
--- a/camayoc/api.py
+++ b/camayoc/api.py
@@ -112,8 +112,12 @@ def try_reauthenticate(func):
                     func.__name__,
                     i,
                 )
-                self.token = None
-                self.login()
+                try:
+                    client = self.client
+                except AttributeError:
+                    client = self
+                client.token = None
+                client.login()
 
     return wrapper
 


### PR DESCRIPTION
try_reauthenticate was introduced in 4ee2364df. It was supposed to wrap methods of both Client and QPCObject instances, and somehow it escaped me that QPCObject does not inherit from Client - it uses composition instead. So QPCObject methods can't call `self.login()`, they need to call `self.client.login()`.

Tested locally against both Client and QPCObject instances.

## Summary by Sourcery

Fix the try_reauthenticate decorator to support QPCObject instances by routing login calls to the composed client when present

Enhancements:
- Detect presence of a client attribute in the decorator and use it to reset token and invoke login
- Fallback to self for token reset and login when no client attribute exists