### PR TITLE
Use "one" instead of "1"

### DIFF
--- a/camayoc/tests/qpc/cli/test_credentials.py
+++ b/camayoc/tests/qpc/cli/test_credentials.py
@@ -678,7 +678,7 @@ def test_clear_with_source(isolated_filesystem, qpc_server_config):
     assert qpc_cred_clear.expect(pexpect.EOF) == 0
     assert (
         qpc_cred_clear.logfile.getvalue().strip().decode("utf-8")
-        == "Error: Credential cannot be deleted because it is used by 1"
+        == "Error: Credential cannot be deleted because it is used by one"
         " or more sources.\r\n"
         "sources: {'id': '%s', 'name': '%s'}\r\n"
         'Failed to remove credential "%s". '

--- a/camayoc/tests/qpc/cli/test_sources.py
+++ b/camayoc/tests/qpc/cli/test_sources.py
@@ -1645,7 +1645,7 @@ def test_clear_with_scans(isolated_filesystem, qpc_server_config, source_type):
     assert qpc_source_clear.expect(pexpect.EOF) == 0
     assert qpc_source_clear.logfile.getvalue().strip() == (
         "Error: Source cannot be deleted because "
-        "it is used by 1 or more scans.\r\n"
+        "it is used by one or more scans.\r\n"
         "scans: {'id': '%s', 'name': '%s'}\r\n"
         'Failed to remove source "%s".' % (scan_show_result["id"], scan_name, name)
     ).encode("utf-8")


### PR DESCRIPTION
This is required by https://github.com/quipucords/quipucords/pull/3008

Overall it makes message consistent with message displayed in UI: https://github.com/quipucords/quipucords-ui/pull/651

Jenkins is going to fail here. I've ran standalone job with that branch and server-side change: `342`

## Summary by Sourcery

Update CLI tests to expect 'one' instead of '1' in error messages for deleting credentials and sources

Tests:
- Change credential deletion error test to expect "one" instead of "1"
- Change source deletion error test to expect "one" instead of "1"