### PR TITLE
Remove support for sources v1 API

### DIFF
--- a/example_config.yaml
+++ b/example_config.yaml
@@ -80,32 +80,28 @@ sources:
           - 'vcenter'
       name: 'vcenter'
       type: 'vcenter'
-      options:
-          ssl_cert_verify: false
+      ssl_cert_verify: false
     - hosts:
           - 'sat6.com'
       credentials:
           - 'sat6'
       name: 'sat6'
       type: 'satellite'
-      options:
-          ssl_cert_verify: false
+      ssl_cert_verify: false
     - hosts:
           - 'api.example.com'
       credentials:
           - 'OpenShift'
       name: 'OpenShift'
       type: 'openshift'
-      options:
-          ssl_cert_verify: false
+      ssl_cert_verify: false
     - hosts:
           - 'acs-endpoint.acs.mycluster.com'
       credentials:
           - 'rhacs'
       name: 'RHACS'
       type: 'rhacs'
-      options:
-          ssl_cert_verify: false
+      ssl_cert_verify: false
 
 # Values in "sources" field can use names present in "sources" section above
 scans:

--- a/scripts/create-camayoc-ocp-config.py
+++ b/scripts/create-camayoc-ocp-config.py
@@ -96,7 +96,7 @@ def create_ocp_configuration(args, cluster):
     source = name_and_type | {
         "hosts": [args.api_url],
         "credentials": [args.name],
-        "options": {"ssl_cert_verify": not args.insecure},
+        "ssl_cert_verify": not args.insecure,
     }
     scan = {
         "name": args.name,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -203,7 +203,7 @@ class SourceTestCase(unittest.TestCase):
             name=MOCK_SAT6_SOURCE["name"],
             hosts=MOCK_SAT6_SOURCE["hosts"],
             credential_ids=[MOCK_SAT6_SOURCE["credentials"][0]["id"]],
-            options={"ssl_cert_verify": MOCK_SAT6_SOURCE["ssl_cert_verify"]},
+            ssl_cert_verify=MOCK_SAT6_SOURCE["ssl_cert_verify"],
             port=443,
             client=client,
         )

--- a/tests/test_data_provider.py
+++ b/tests/test_data_provider.py
@@ -44,7 +44,7 @@ SOURCES = [
             "hosts": ["my_vcenter.com"],
             "credentials": ["vcenter"],
             "type": "vcenter",
-            "options": {"ssl_cert_verify": False},
+            "ssl_cert_verify": False,
         }
     ),
 ]


### PR DESCRIPTION
This is a follow up to eb4b80ccff :

- remove backwards compatibility layer in Source model. Pipeline config has been updated over a month ago (discovery-ci PR #179), everyone had about two months to update their local configs (if they have them).
- Use API v2 for bulk_delete, as it is now available in backend.

## Summary by Sourcery

Remove support for sources v1 API by stripping legacy compatibility layers and migrating operations to API v2.

Enhancements:
- Remove backward compatibility code in QPC models (SENTINEL, options parameter, bulk_delete override) to enforce v2-only API
- Flatten ssl_cert_verify into a top-level field in example configurations and related scripts

Tests:
- Update tests to reference ssl_cert_verify directly instead of nested options