### PR TITLE
Make UI compatible with PatternFly 6-based UI

### DIFF
--- a/camayoc/ui/models/components/add_new_dropdown.py
+++ b/camayoc/ui/models/components/add_new_dropdown.py
@@ -14,9 +14,7 @@ class AddNewDropdown(UIPage):
             msg = "{} requires class property 'ADD_BUTTON_LOCATOR' to be set [object={}]"
             raise MisconfiguredWidgetException(msg.format(type(self).__name__, self))
 
-        dropdown_item_locator = (
-            f"{add_button_locator} ~ div ul li[data-ouia-component-id={type_ouiaid}]"
-        )
+        dropdown_item_locator = f"div ul li[data-ouia-component-id={type_ouiaid}]"
 
         exp_msg = (
             "Could not open modal using dropdown menu [button locator={} ; "

--- a/camayoc/ui/models/components/items_list.py
+++ b/camayoc/ui/models/components/items_list.py
@@ -13,7 +13,7 @@ from camayoc.types.ui import UIPage
 class AbstractListItem(UIListItem):
     ACTION_MENU_TOGGLE_LOCATOR = "button[data-ouia-component-id=action_menu_toggle]"
     ACTION_MENU_ITEM_LOCATOR_TEMPLATE = (
-        ACTION_MENU_TOGGLE_LOCATOR + "~ div *[data-ouia-component-id={ouiaid}] button"
+        "body > div[class$=-c-menu] *[data-ouia-component-id={ouiaid}] button"
     )
 
     def __init__(self, locator: Locator, client):
@@ -23,7 +23,7 @@ class AbstractListItem(UIListItem):
     def select_action(self, ouiaid: str, timeout: int = 30_000) -> None:
         self._open_kebab()
         item_locator = self.ACTION_MENU_ITEM_LOCATOR_TEMPLATE.format(ouiaid=ouiaid)
-        self.locator.locator(item_locator).click(timeout=timeout)
+        self._client.driver.locator(item_locator).click(timeout=timeout)
 
     def _open_kebab(self) -> None:
         toggle_elem = self.locator.locator(self.ACTION_MENU_TOGGLE_LOCATOR)
@@ -55,12 +55,12 @@ class ItemsList(UIPage):
         filter_field_button_locator = (
             "div[class*=-c-toolbar__item] button[id]:has(span[class*=-c-menu-toggle])"
         )
-        filter_field_values_locator = "xpath=following-sibling::div[contains(@class, '-c-menu')]"
+        filter_field_values_locator = "body > div[class$=-c-menu]"
 
         filter_field_button = self._driver.locator(filter_field_button_locator).locator("nth=0")
         if filter_field_button.text_content() != "Name":
             filter_field_button.click()
-            values_list = filter_field_button.locator(filter_field_values_locator)
+            values_list = self._driver.locator(filter_field_values_locator)
             values_list.locator("text='Name'").click()
         self._driver.fill("input[placeholder$=name]", name)
         self._driver.keyboard.press("Enter")

--- a/camayoc/ui/models/components/logged_in.py
+++ b/camayoc/ui/models/components/logged_in.py
@@ -17,7 +17,7 @@ class LoggedIn(UIPage):
     def logout(self) -> Login:
         logger.debug("Executing page action [action='logout']")
         app_user_dropdown_button = "button[data-ouia-component-id=user_dropdown_button]:visible"
-        logout_link = f"{app_user_dropdown_button} ~ div li[data-ouia-component-id=logout]"
+        logout_link = "body > div li[data-ouia-component-id=logout]"
 
         self._driver.click(app_user_dropdown_button)
         self._driver.click(logout_link)

--- a/camayoc/ui/models/fields.py
+++ b/camayoc/ui/models/fields.py
@@ -60,9 +60,7 @@ class FilteredMultipleSelectField(Field):
 
         for actual_value in value:
             self.driver.locator(self.locator).locator(filter_input).fill(actual_value)
-            values_list = self.driver.locator(self.locator).locator(
-                "xpath=following-sibling::div//ul[contains(@id, 'select')]"
-            )
+            values_list = self.driver.locator("body > div[class$=-c-menu] ul[id*=select]")
             label_elem = values_list.locator(f"text='{actual_value}'")
             checkbox_elem = label_elem.locator("xpath=parent::span//input[@type='checkbox']")
             if not checkbox_elem.is_checked():
@@ -84,7 +82,7 @@ class InputField(Field):
 class MultipleSelectField(Field):
     def do_fill(self, value: list[str]):
         self.driver.click(self.locator)
-        values_list = self.driver.locator(self.locator).locator("xpath=following-sibling::ul")
+        values_list = self.driver.locator("body > div[class$=-c-menu] ul")
         for actual_value in value:
             values_list.locator(f"text='{actual_value}'").click()
 
@@ -94,11 +92,11 @@ class MultipleSelectField(Field):
 
 class SelectField(Field):
     def do_fill(self, value):
-        values_list_locator = "xpath=following-sibling::div//ul"
+        values_list_locator = "body > div[class$=-c-menu] ul"
 
         if isinstance(value, Enum) and (enum_value := getattr(value, "value")):
             value = enum_value
 
         self.driver.click(self.locator)
-        values_list = self.driver.locator(self.locator).locator(values_list_locator)
+        values_list = self.driver.locator(values_list_locator)
         values_list.locator(f"text='{value}'").click()

--- a/camayoc/ui/models/pages/scans.py
+++ b/camayoc/ui/models/pages/scans.py
@@ -41,7 +41,7 @@ class ScanHistoryModal(Modal, AbstractPage):
             header = self._driver.locator(table_header_locator)
             if header.get_attribute("aria-sort") == ordering.value:
                 return
-            header.click()
+            header.locator("button").click()
             tries += 1
         raise RuntimeError("Failed to sort table")
 

--- a/camayoc/ui/models/pages/sources.py
+++ b/camayoc/ui/models/pages/sources.py
@@ -52,7 +52,7 @@ class NetworkRangeSourceCredentialsForm(SourceForm):
         )
         port = InputField("input[data-ouia-component-id=port]", transform_input=lambda i: str(i))
         credentials = FilteredMultipleSelectField(
-            "div[data-ouia-component-id=add_credentials_select]"
+            "div[class*=typeahead]:has(button[data-ouia-component-id=add_credentials_select])"
         )
         use_paramiko = CheckboxField("input[data-ouia-component-id=options_paramiko]")
 
@@ -71,7 +71,7 @@ class SatelliteSourceCredentialsForm(SourceForm):
         address = InputField("input[data-ouia-component-id=hosts_single]")
         port = InputField("input[data-ouia-component-id=port]")
         credentials = FilteredMultipleSelectField(
-            "div[data-ouia-component-id=add_credentials_select]"
+            "div[class*=typeahead]:has(button[data-ouia-component-id=add_credentials_select])"
         )
         connection = SelectField("button[data-ouia-component-id=options_ssl_protocol]")
         verify_ssl = CheckboxField("input[data-ouia-component-id=options_ssl_cert]")
@@ -91,7 +91,7 @@ class VCenterSourceCredentialsForm(SourceForm):
         address = InputField("input[data-ouia-component-id=hosts_single]")
         port = InputField("input[data-ouia-component-id=port]")
         credentials = FilteredMultipleSelectField(
-            "div[data-ouia-component-id=add_credentials_select]"
+            "div[class*=typeahead]:has(button[data-ouia-component-id=add_credentials_select])"
         )
         connection = SelectField("button[data-ouia-component-id=options_ssl_protocol]")
         verify_ssl = CheckboxField("input[data-ouia-component-id=options_ssl_cert]")
@@ -111,7 +111,7 @@ class OpenShiftSourceCredentialsForm(SourceForm):
         address = InputField("input[data-ouia-component-id=hosts_single]")
         port = InputField("input[data-ouia-component-id=port]")
         credentials = FilteredMultipleSelectField(
-            "div[data-ouia-component-id=add_credentials_select]"
+            "div[class*=typeahead]:has(button[data-ouia-component-id=add_credentials_select])"
         )
         connection = SelectField("button[data-ouia-component-id=options_ssl_protocol]")
         verify_ssl = CheckboxField("input[data-ouia-component-id=options_ssl_cert]")
@@ -131,7 +131,7 @@ class AnsibleSourceCredentialsForm(SourceForm):
         address = InputField("input[data-ouia-component-id=hosts_single]")
         port = InputField("input[data-ouia-component-id=port]")
         credentials = FilteredMultipleSelectField(
-            "div[data-ouia-component-id=add_credentials_select]"
+            "div[class*=typeahead]:has(button[data-ouia-component-id=add_credentials_select])"
         )
         connection = SelectField("button[data-ouia-component-id=options_ssl_protocol]")
         verify_ssl = CheckboxField("input[data-ouia-component-id=options_ssl_cert]")
@@ -151,7 +151,7 @@ class RHACSSourceCredentialsForm(SourceForm):
         address = InputField("input[data-ouia-component-id=hosts_single]")
         port = InputField("input[data-ouia-component-id=port]")
         credentials = FilteredMultipleSelectField(
-            "div[data-ouia-component-id=add_credentials_select]"
+            "div[class*=typeahead]:has(button[data-ouia-component-id=add_credentials_select])"
         )
         connection = SelectField("button[data-ouia-component-id=options_ssl_protocol]")
         verify_ssl = CheckboxField("input[data-ouia-component-id=options_ssl_cert]")


### PR DESCRIPTION
Due to backwards incompatible changes in PatternFly 6, this commit no longer works with PatternFly 5.

This changes are interdependent on commit [783225cb](https://github.com/quipucords/quipucords-ui/pull/664/commits/783225cb5026115391ebad65dcf42fcd54a83498), which is part of https://github.com/quipucords/quipucords-ui/pull/664

Relates to JIRA: DISCOVERY-936

## Summary by Sourcery

Adapt UI model locators across forms, fields, and components to accommodate PatternFly 6 markup changes

Enhancements:
- Replace OUIA-based selectors in form definitions with PF6-compatible typeahead and button-aware locators for credential fields
- Update select and multi-select field implementations to target PF6 popover menus appended to the body via CSS selectors
- Revise action menu, add-new dropdown, logout menu, and table sort locators to align with PF6 structure and nested button clicks