### PR TITLE
Add overview page

### DIFF
--- a/camayoc/ui/enums.py
+++ b/camayoc/ui/enums.py
@@ -17,6 +17,7 @@ class LowercasedStrEnum(Enum):
 class Pages(StrEnum):
     CREDENTIALS = "credentials.CredentialsMainPage"
     LOGIN = "login.Login"
+    OVERVIEW = "overview.OverviewMainPage"
     SCANS = "scans.ScansMainPage"
     SOURCES = "sources.SourcesMainPage"
 
@@ -25,6 +26,7 @@ class MainMenuPages(StrEnum):
     SOURCES = auto()
     SCANS = auto()
     CREDENTIALS = auto()
+    OVERVIEW = auto()
 
 
 class CredentialTypes(StrEnum):

--- a/camayoc/ui/models/pages/login.py
+++ b/camayoc/ui/models/pages/login.py
@@ -35,4 +35,4 @@ class Login(AbstractPage):
             self._driver.fill(password_input, data.password)
             self._driver.click(submit_button)
 
-        return self._new_page(Pages.CREDENTIALS)
+        return self._new_page(Pages.OVERVIEW)

--- a/camayoc/ui/models/pages/overview.py
+++ b/camayoc/ui/models/pages/overview.py
@@ -1,0 +1,5 @@
+from ..mixins import MainPageMixin
+
+
+class OverviewMainPage(MainPageMixin):
+    pass


### PR DESCRIPTION
This should be merged **after** https://github.com/quipucords/quipucords-ui/pull/705 is merged **and** a feature flag is flipped.

As far as I can tell, all the tests explicitly navigate to page they care about, so default page after login is not really depended on by anything. So strictly speaking, this is not _required_ - if we merge above PR and flip a feature flag, Camayoc will still work flawlessly. But let's keep it in sync with actual implementation.

Relates to JIRA: DISCOVERY-1098

## Summary by Sourcery

Introduce an overview page and update the login process to land users on it by default

New Features:
- Add a new OverviewMainPage class for the overview page in the UI
- Register the overview page in the Pages and MainMenuPages enums
- Redirect the login flow to navigate to the overview page after successful authentication