### PR TITLE
Introduce a test that checks if translations are correctly loaded

### DIFF
--- a/camayoc/ui/models/pages/login.py
+++ b/camayoc/ui/models/pages/login.py
@@ -10,12 +10,12 @@ from camayoc.ui.enums import Pages
 from .abstract_page import AbstractPage
 
 if TYPE_CHECKING:
-    from .credentials import CredentialsMainPage
+    from .overview import OverviewMainPage
 
 
 class Login(AbstractPage):
     @record_action
-    def login(self, data: LoginFormDTO) -> CredentialsMainPage:
+    def login(self, data: LoginFormDTO) -> OverviewMainPage:
         login_page_indicator = "main[class$=login__main]"
         username_input = "input[name=pf-login-username-id]"
         password_input = "input[name=pf-login-password-id]"


### PR DESCRIPTION
UI unit tests mock translations and never load them. Camayoc tests are designed to work with page structure and elements with stable identifiers. We end up in situation where no automation is checking if translation file is valid and was correctly loaded.

Introduce a Camayoc test that does exactly that. The goal is not to check if all the strings are correctly translated, but if any strings are translated. This should catch low-probability high-impact event where translations are not loaded at all.

Relates to JIRA: DISCOVERY-1140

## Summary by Sourcery

Add an end-to-end Camayoc UI test to verify that translation files are correctly loaded and update the login page model to return the correct overview page type.

New Features:
- Introduce a test_translations function that logs in, navigates through overview and sources pages, and asserts that key UI text elements are displayed in one of the supported language variants.

Enhancements:
- Update the Login model’s return type and TYPE_CHECKING import to reference OverviewMainPage instead of CredentialsMainPage.