### PR TITLE
Add a check for Lightspeed report inside report tarball

### DIFF
--- a/camayoc/constants.py
+++ b/camayoc/constants.py
@@ -121,3 +121,10 @@ QPC_BECOME_METHODS = ("doas", "dzdo", "ksu", "pbrun", "pfexec", "runas", "su", "
 
 QPC_OPTIONAL_PRODUCTS = ("jboss_eap", "jboss_fuse", "jboss_ws")
 """Optional products that can be enabled or disabled for a scan."""
+
+SOURCE_TYPES_WITH_LIGHTSPEED_SUPPORT = (
+    "vcenter",
+    "network",
+    "satellite",
+)
+"""Types of sources that can generate lightspeed reports."""

--- a/camayoc/tests/qpc/cli/test_endtoend.py
+++ b/camayoc/tests/qpc/cli/test_endtoend.py
@@ -6,8 +6,10 @@ import pytest
 
 from camayoc.config import settings
 from camayoc.constants import CONNECTION_PASSWORD_INPUT
+from camayoc.constants import SOURCE_TYPES_WITH_LIGHTSPEED_SUPPORT
 from camayoc.qpc_models import Scan
 from camayoc.tests.qpc.utils import assert_ansible_logs
+from camayoc.tests.qpc.utils import assert_lightspeed_report
 from camayoc.tests.qpc.utils import assert_sha256sums
 from camayoc.tests.qpc.utils import end_to_end_sources_names
 from camayoc.utils import uuid4
@@ -102,6 +104,7 @@ def test_end_to_end(tmp_path, qpc_server_config, data_provider, source_name):
 
     # Download and verify a report
     is_network_scan = source_definition.type == "network"
+    expect_lightspeed_report = source_definition.type in SOURCE_TYPES_WITH_LIGHTSPEED_SUPPORT
     downloaded_report = tmp_path / "report.tar.gz"
 
     report_download({"scan-job": scan_job_id, "output-file": downloaded_report.as_posix()})
@@ -109,3 +112,4 @@ def test_end_to_end(tmp_path, qpc_server_config, data_provider, source_name):
     tarfile.open(downloaded_report).extractall(tmp_path, filter="tar")
     assert_sha256sums(tmp_path)
     assert_ansible_logs(tmp_path, is_network_scan)
+    assert_lightspeed_report(tmp_path, expect_lightspeed_report)

--- a/camayoc/tests/qpc/ui/test_endtoend.py
+++ b/camayoc/tests/qpc/ui/test_endtoend.py
@@ -13,8 +13,10 @@ import tarfile
 import pytest
 
 from camayoc.config import settings
+from camayoc.constants import SOURCE_TYPES_WITH_LIGHTSPEED_SUPPORT
 from camayoc.qpc_models import Scan
 from camayoc.tests.qpc.utils import assert_ansible_logs
+from camayoc.tests.qpc.utils import assert_lightspeed_report
 from camayoc.tests.qpc.utils import assert_sha256sums
 from camayoc.tests.qpc.utils import end_to_end_sources_names
 from camayoc.types.ui import AddCredentialDTO
@@ -89,11 +91,13 @@ def test_end_to_end(tmp_path, cleaning_data_provider, ui_client: Client, source_
     )
 
     is_network_scan = source_dto.source_type == SourceTypes.NETWORK_RANGE
+    expect_lightspeed_report = source_dto.source_type.value in SOURCE_TYPES_WITH_LIGHTSPEED_SUPPORT
     downloaded_report = ui_client.downloaded_files[-1]
 
     tarfile.open(downloaded_report.path()).extractall(tmp_path)
     assert_sha256sums(tmp_path)
     assert_ansible_logs(tmp_path, is_network_scan)
+    assert_lightspeed_report(tmp_path, expect_lightspeed_report)
 
 
 def test_translations(ui_client: Client):

--- a/camayoc/tests/qpc/ui/test_scans.py
+++ b/camayoc/tests/qpc/ui/test_scans.py
@@ -13,7 +13,9 @@ import pytest
 
 from camayoc.config import settings
 from camayoc.tests.qpc.utils import assert_ansible_logs
+from camayoc.tests.qpc.utils import assert_lightspeed_report
 from camayoc.tests.qpc.utils import assert_sha256sums
+from camayoc.tests.qpc.utils import scan_should_have_lightspeed_report
 from camayoc.types.ui import SummaryReportData
 from camayoc.ui import Client
 from camayoc.ui import data_factories
@@ -83,11 +85,13 @@ def test_download_scan(tmp_path, scans, ui_client: Client, scan_name):
     )
 
     is_network_scan = has_network_source(scan_name)
+    expect_lightspeed_report = scan_should_have_lightspeed_report(finished_scan)
     downloaded_report = ui_client.downloaded_files[-1]
 
     tarfile.open(downloaded_report.path()).extractall(tmp_path)
     assert_sha256sums(tmp_path)
     assert_ansible_logs(tmp_path, is_network_scan)
+    assert_lightspeed_report(tmp_path, expect_lightspeed_report)
 
 
 @pytest.mark.nightly_only
@@ -121,11 +125,13 @@ def test_download_scan_modal(tmp_path, scans, ui_client: Client, scan_name):
     )
 
     is_network_scan = has_network_source(scan_name)
+    expect_lightspeed_report = scan_should_have_lightspeed_report(finished_scan)
     downloaded_report = ui_client.downloaded_files[-1]
 
     tarfile.open(downloaded_report.path()).extractall(tmp_path)
     assert_sha256sums(tmp_path)
     assert_ansible_logs(tmp_path, is_network_scan)
+    assert_lightspeed_report(tmp_path, expect_lightspeed_report)
 
 
 @pytest.mark.parametrize("scan_name", scan_names())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,7 @@ ignore = [
 "camayoc/qpc_models.py" = ["PL", "C901"]
 "camayoc/tests/qpc/cli/test_sources.py" = ["PLR0915"]
 "camayoc/tests/qpc/ui/conftest.py" = ["BLE001"]
-"camayoc/tests/qpc/utils.py" = ["PLW2901"]
+"camayoc/tests/qpc/utils.py" = ["PLW2901", "E712"]
 "tests/test_command.py" = ["F401"]
 
 [tool.ruff.lint.isort]


### PR DESCRIPTION
In tests that download a report, also check if Lightspeed report is inside (or isn't inside when it shouldn't be). If report is inside, additionally run basic content assertions.

The key is really `camayoc/tests/qpc/cli/test_reports.py::test_lightspeed_report_presence`. But since I already needed to extract Lightspeed tarball content assertions into a separate function, it became cheap to add the call in bunch of other tests that already download reports.

Relates to JIRA: DISCOVERY-1085

## Summary by Sourcery

Add support for verifying Lightspeed reports in scan result tarballs, including a new helper, constant, and tests to assert their presence or absence based on scan source types

New Features:
- Introduce assert_lightspeed_report helper to validate Lightspeed report presence and content
- Add scan_should_have_lightspeed_report utility to determine if a scan should include a Lightspeed report
- Define SOURCE_TYPES_WITH_LIGHTSPEED_SUPPORT constant for source types supporting Lightspeed reports

Build:
- Update ruff lint configuration to ignore E712 in utils

Tests:
- Add parametrized test_lightspeed_report_presence to check Lightspeed report inclusion across scan types
- Update existing CLI, UI, and end-to-end tests to assert Lightspeed report presence or absence accordingly