### PR TITLE
fix(tests): update dropdown selectors

### DIFF
--- a/camayoc/ui/models/components/items_list.py
+++ b/camayoc/ui/models/components/items_list.py
@@ -13,7 +13,7 @@ from camayoc.types.ui import UIPage
 class AbstractListItem(UIListItem):
     ACTION_MENU_TOGGLE_LOCATOR = "button[data-ouia-component-id=action_menu_toggle]"
     ACTION_MENU_ITEM_LOCATOR_TEMPLATE = (
-        "body > div[class$=-c-menu] *[data-ouia-component-id={ouiaid}] button"
+        "body > div[class*=-c-menu] *[data-ouia-component-id={ouiaid}] button"
     )
 
     def __init__(self, locator: Locator, client):
@@ -55,7 +55,7 @@ class ItemsList(UIPage):
         filter_field_button_locator = (
             "div[class*=-c-toolbar__item] button[id]:has(span[class*=-c-menu-toggle])"
         )
-        filter_field_values_locator = "body > div[class$=-c-menu]"
+        filter_field_values_locator = "body > div[class*=-c-menu]"
 
         filter_field_button = self._driver.locator(filter_field_button_locator).locator("nth=0")
         if filter_field_button.text_content() != "Name":

--- a/camayoc/ui/models/fields.py
+++ b/camayoc/ui/models/fields.py
@@ -60,7 +60,7 @@ class FilteredMultipleSelectField(Field):
 
         for actual_value in value:
             self.driver.locator(self.locator).locator(filter_input).fill(actual_value)
-            values_list = self.driver.locator("body > div[class$=-c-menu] ul[id*=select]")
+            values_list = self.driver.locator("body > div[class*=-c-menu] ul[id*=select]")
             label_elem = values_list.locator(f"text='{actual_value}'")
             checkbox_elem = label_elem.locator("xpath=parent::span//input[@type='checkbox']")
             if not checkbox_elem.is_checked():
@@ -103,7 +103,7 @@ class MultipleSelectField(Field):
 
 class SelectField(Field):
     def do_fill(self, value):
-        values_list_locator = "body > div[class$=-c-menu] ul"
+        values_list_locator = "body > div[class*=-c-menu] ul"
 
         if isinstance(value, Enum) and (enum_value := getattr(value, "value")):
             value = enum_value


### PR DESCRIPTION
PatternFly 6 dropdowns with scrollable menus (maxMenuHeight/isScrollable) generate different CSS class structures, causing test selectors to fail.

Changed CSS attribute selectors from `$=-c-menu` (ends with) to `*=-c-menu` (contains) to match the new class structure generated by scrollable dropdowns.

Relates to JIRA:DISCOVERY-837

## Summary by Sourcery

Bug Fixes:
- Replace [class$=-c-menu] selectors with [class*=-c-menu] in dropdown menu locators across items_list and fields modules to prevent test failures