### PR TITLE
get-version: improve UI robustness

### DIFF
--- a/scripts/get-version.py
+++ b/scripts/get-version.py
@@ -46,11 +46,13 @@ def get_frontend_version():
     if podman_ps_a_result.returncode != 0:
         return
 
-    app_names = [f"{app_name}-app.cid" for app_name in ("quipucords", "discovery")]
+    app_cids = [f"{app_name}-app.cid" for app_name in ("quipucords", "discovery")]
+    app_names = {f"{app_name}-app" for app_name in ("quipucords", "discovery")}
     containers = json.loads(podman_ps_a_result.stdout)
     for container in containers:
         cid = container.get("CIDFile", "")
-        if not cid.endswith(tuple(app_names)):
+        names = container.get("Names", [])
+        if not cid.endswith(tuple(app_cids)) and set(names).isdisjoint(app_names):
             continue
         image_id = container.get("ImageID")
         versions = [f"image_id={image_id}"]


### PR DESCRIPTION
On my local Fedora 42 "CIDFile" for all containers is empty string, and UI version ends up being None.

On Jenkins Fedora 42 "CIDFile" seems to still be present, for some reason.

This might depend on configuration that I forgot I ever changed, but let's just use another field in case CIDFile is not available.

## Summary by Sourcery

Enhancements:
- Enhance get-version script to check container Names as a fallback for identifying quipucords and discovery apps when CIDFile is empty