### PR TITLE
fix(tests): adapt to preserved CIDR/range notation

### DIFF
--- a/camayoc/tests/qpc/cli/test_sources.py
+++ b/camayoc/tests/qpc/cli/test_sources.py
@@ -74,6 +74,10 @@ INVALID_SOURCE_TYPE_HOSTS_WITH_EXCLUDE = (
 def generate_show_output(data):
     """Generate a regex pattern that matches `qpc source show` output (API v2)."""
 
+    def _escape_regex(value):
+        """Escape regex special characters in host patterns (e.g., Ansible ranges)."""
+        return value.replace("[", r"\[").replace("]", r"\]")
+
     def _nullable_field(data, key, is_string=False, trailing_comma=True):
         if key in data:
             val = '"{}"'.format(data[key]) if is_string else str(data[key]).lower()
@@ -97,7 +101,7 @@ def generate_show_output(data):
         output += (
             r'    "exclude_hosts": \[\r\n'
             r'        "{}"\r\n'
-            r"    \],\r\n".format(data["exclude_hosts"])
+            r"    \],\r\n".format(_escape_regex(data["exclude_hosts"]))
         )
     else:
         output += r'    "exclude_hosts": null,\r\n'
@@ -105,7 +109,7 @@ def generate_show_output(data):
     output += (
         r'    "hosts": \[\r\n'
         r'        "{}"\r\n'
-        r"    \],\r\n".format(data["hosts"])
+        r"    \],\r\n".format(_escape_regex(data["hosts"]))
     )
     output += (
         r'    "id": \d+,\r\n'

--- a/camayoc/tests/qpc/cli/utils.py
+++ b/camayoc/tests/qpc/cli/utils.py
@@ -2,7 +2,6 @@
 """Utility functions for Quipucords cli tests."""
 
 import functools
-import ipaddress
 import json
 import logging
 import re
@@ -179,21 +178,8 @@ report_aggregate = functools.partial(cli_command, "{} -v report aggregate".forma
 
 
 def convert_ip_format(ipaddr):
-    """Convert IP strings (for generating expected test results)."""
-    # Expand CIDR to a formatted list of IPs
-    if "/" in ipaddr:
-        network = ipaddress.ip_network(ipaddr, strict=False)
-        ipaddr = '",\r\n        "'.join(str(ip) for ip in network.hosts())
-    # Expand Ansible-style range
-    elif re.search(r"\[\d+:\d+\]", ipaddr):
-        match = re.match(r"(.*)\[(\d+):(\d+)\]", ipaddr)
-        if match:
-            base_ip, start, end = match.groups()
-            start, end = int(start), int(end)
-            expanded_ips = [f"{base_ip}{i}" for i in range(start, end + 1)]
-            ipaddr = '",\r\n        "'.join(expanded_ips)
-    # Convert space-separated IPs into formatted multi-line string
-    elif " " in ipaddr:
+    """Format space-separated IPs for multi-line JSON display."""
+    if " " in ipaddr:
         ipaddr = '",\r\n        "'.join(ipaddr.split(" "))
     return ipaddr
 


### PR DESCRIPTION
Update test expectations after Quipucords PR-3073: hosts like 192.168.0.0/24 and 192.168.0.[1:100] are no longer expanded.

Related to JIRA: DISCOVERY-1110

## Summary by Sourcery

Update test utilities and expectations to handle preserved CIDR and range host notation without expanding them into individual IPs.

Bug Fixes:
- Adjust source show output tests to escape regex special characters in host patterns so Ansible-style ranges and CIDR-like strings are matched literally.

Enhancements:
- Simplify IP formatting helper in test utilities to only reformat space-separated IP lists for multi-line JSON output.