### PR TITLE
chore: add CODEOWNERS file to satisfy IBM/Red Hat security requirements

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @quipucords/maintainers


### PR DESCRIPTION
Relates to JIRA: DISCOVERY-1285

## Summary by Sourcery

Chores:
- Introduce a CODEOWNERS file to satisfy organizational security and ownership policy requirements.