### PR TITLE
chore: Remove upper Python version limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Topic :: Software Development :: Testing",
     "Topic :: Software Development :: Quality Assurance",
 ]
-requires-python = ">= 3.12, < 3.14"
+requires-python = ">= 3.12"
 dependencies = [
     "attrs (>= 24.2.0, < 25.0.0)",
     "dynaconf (>= 3.2.4, < 4.0.0)",

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 2
-requires-python = ">=3.12, <3.14"
+requires-python = ">=3.12"
 resolution-markers = [
     "(implementation_name == 'cpython' and sys_platform == 'darwin') or (implementation_name == 'cpython' and sys_platform == 'linux')",
 ]


### PR DESCRIPTION
Fedora now defaults to Python 3.14, which makes installing camayoc through pipx unnecessarily difficult.

Removal of upper version cap does not mean recommendation, endorsement, or official support.