### PR TITLE
Fix test_products_found_deployment_report

### DIFF
--- a/camayoc/tests/qpc/api/v1/reports/test_reports.py
+++ b/camayoc/tests/qpc/api/v1/reports/test_reports.py
@@ -57,36 +57,37 @@ def test_products_found_deployment_report(scans, scan_name):
     for hostname, expected_data in finished_scan.definition.expected_data.items():
         if not (expected_products := expected_data.products):
             continue
-        if not found_hosts.get(hostname):
+        actual_data = found_hosts.get(hostname, {})
+        if not actual_data:
             errors_found.append(
                 f"Host '{hostname}' was expected for scan {scan_name}, but not found"
             )
-        for fingerprint in system_fingerprints:
-            present_product_names = {
-                product["name"]
-                for product in fingerprint.get("products")
-                if product["presence"] == "present"
-            }
-            expected_product_names = {
-                product.name for product in expected_products if product.presence == "present"
-            }
-            unexpected_product_names = {
-                product_name
-                for product_name in present_product_names
-                if product_name not in expected_product_names
-            }
-            if len(unexpected_product_names) > 0:
-                errors_found.append(
-                    "Found {found_products} but only expected to find\n"
-                    "{expected_products} on {host_found_on}.\n"
-                    "All information about the fingerprint was as follows\n"
-                    "{fingerprint_info}".format(
-                        found_products=unexpected_product_names,
-                        expected_products=expected_product_names,
-                        host_found_on=hostname,
-                        fingerprint_info=pformat(fingerprint),
-                    )
+            continue
+        present_product_names = {
+            product["name"]
+            for product in actual_data.get("products", [])
+            if product["presence"] == "present"
+        }
+        expected_product_names = {
+            product.name for product in expected_products if product.presence == "present"
+        }
+        unexpected_product_names = {
+            product_name
+            for product_name in present_product_names
+            if product_name not in expected_product_names
+        }
+        if len(unexpected_product_names) > 0:
+            errors_found.append(
+                "Found {found_products} but only expected to find\n"
+                "{expected_products} on {host_found_on}.\n"
+                "All information about the fingerprint was as follows\n"
+                "{fingerprint_info}".format(
+                    found_products=unexpected_product_names,
+                    expected_products=expected_product_names,
+                    host_found_on=hostname,
+                    fingerprint_info=pformat(actual_data),
                 )
+            )
     assert len(errors_found) == 0, (
         "Found {num} unexpected products!\n"
         "Errors are listed below: \n {errors}.\n"


### PR DESCRIPTION
The main loop iterated through `system_fingerprints`, which is a list of data about all hosts. Then, it wanted to find expected products in each fingerprint. This only ever worked when all scanned hosts had exact same set of products installed - or, more likely, when only one host was scanned.

Curiously enough, that issue was not present in other tests, where `found_hosts.get(hostname)` was used instead of looping through system_fingerprints. It seems that many tests were introduced in f1b417b63a4515eec56dc452da93080cbb6e0ca2 , but that commit did not modify existing tests.

## Summary by Sourcery

Fix product presence validation in deployment report tests to check per-host data instead of iterating over all system fingerprints.

Bug Fixes:
- Correct product comparison in test_products_found_deployment_report to use the specific host's fingerprint data and avoid cross-host mixing of products.

Tests:
- Adjust test_products_found_deployment_report to derive present products from the matched host data and improve error reporting context.