### PR TITLE
test: Run Jenkins CI against RHEL10

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 def agents = [:]
 agents["failFast"] = false
 
-["fedora", "rhel8", "rhel9"].each { distro_label ->
+["fedora", "rhel8", "rhel9", "rhel10"].each { distro_label ->
     agents[distro_label] = {
         node("discovery_ci && ${distro_label}") {
             timestamps {


### PR DESCRIPTION
Kind of embarrassing I forgot about Camayoc back in November.

Relates to JIRA: DISCOVERY-971

## Summary by Sourcery

CI:
- Add RHEL10 to the Jenkins CI distro matrix so tests also run on RHEL10 nodes.