### PR TITLE
fix(ui): ignore expected 404 on Vault config probe

### DIFF
--- a/camayoc/ui/client.py
+++ b/camayoc/ui/client.py
@@ -47,6 +47,14 @@ def requestfinished_handler_factory(ui_client):
         if "/reports/" in request.url and response_status == 424:
             return
 
+        # UI probes Vault availability; GET 404 means no global Vault config (Vault auth disabled).
+        if (
+            request.method == "GET"
+            and "/api/v2/auth/hashicorp-vault/" in request.url
+            and response_status == 404
+        ):
+            return
+
         error_msg = f"{request.method} {request.url} returned {response_status}"
         ui_client._log_page_error(error_msg)
 


### PR DESCRIPTION
The credentials UI calls GET /api/v2/auth/hashicorp-vault/ to decide whether Vault auth is available. A 404 means no Vault integration is configured, not a broken page. Stop recording that response in page_errors so ui_client teardown does not fail on DISCOVERY vault credential flows.

## Summary by Sourcery

Bug Fixes:
- Prevent teardown failures in Vault discovery credential flows by ignoring expected 404 responses from the Vault availability check.