### PR TITLE
Bump playwright to 1.59

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     # playwright needs to download browsers. We do that during Jenkins agent image
     # generation to save time during execution, but that means we need to keep
     # version here in sync with version used when generating images
-    "playwright==1.52.0",
+    "playwright==1.59.0",
     "pydantic (>= 2.6.3, < 3.0.0)",
     "pytest (>= 8.3.4, < 9.0.0)",
     "pytest-ibutsu (>= 2.2.4, < 3.0.0)",


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Bump playwright dependency from 1.52.0 to 1.59.0 in project configuration.