### PR TITLE
fix(tests): add support for vault_secret_key

### DIFF
--- a/camayoc/tests/qpc/cli/test_credentials.py
+++ b/camayoc/tests/qpc/cli/test_credentials.py
@@ -54,6 +54,7 @@ def generate_show_output(data):
     output += '    "username": "{}",\r\n'.format(data["username"])
     output += '    "vault_mount_point": {},\r\n'.format(data.get("vault_mount_point", "null"))
     output += '    "vault_secret_path": {}\r\n'.format(data.get("vault_secret_path", "null"))
+    output += '    "vault_key": {},\r\n'.format(data.get("vault_key", "null"))
     output += "}\r\n"
     return output
 

--- a/camayoc/tests/qpc/cli/test_credentials.py
+++ b/camayoc/tests/qpc/cli/test_credentials.py
@@ -53,8 +53,8 @@ def generate_show_output(data):
     output += '    "updated_at": {},\r\n'.format(data.get("updated_at", ".*"))
     output += '    "username": "{}",\r\n'.format(data["username"])
     output += '    "vault_mount_point": {},\r\n'.format(data.get("vault_mount_point", "null"))
+    output += '    "vault_secret_key": {},\r\n'.format(data.get("vault_secret_key", "null"))
     output += '    "vault_secret_path": {}\r\n'.format(data.get("vault_secret_path", "null"))
-    output += '    "vault_key": {},\r\n'.format(data.get("vault_key", "null"))
     output += "}\r\n"
     return output
 


### PR DESCRIPTION
- Updated the cli tests to know about the vault_secret_key in addition to the vault_secret_path and vault_mount_point.

## Summary by Sourcery

Tests:
- Extend credential CLI show-output test helper to include the vault_key field.

## Summary by Sourcery

Tests:
- Extend credential CLI show-output test helper to render the vault_secret_key field in expected output.