### PR TITLE
feat(config): add Vault server and credential config support

### DIFF
--- a/camayoc/config.py
+++ b/camayoc/config.py
@@ -32,6 +32,7 @@ default_dynaconf_validators = [
     Validator("quipucords_server.ssh_keyfile_path", default=""),
     Validator("quipucords_cli.executable", default="qpc"),
     Validator("quipucords_cli.display_name", default="qpc"),
+    Validator("hashicorp_vault", default=None),
     Validator("credentials", default=[]),
     Validator("sources", default=[]),
     Validator("scans", default=[]),

--- a/camayoc/types/settings.py
+++ b/camayoc/types/settings.py
@@ -1,13 +1,14 @@
 from pathlib import Path
+from typing import Annotated
 from typing import Any
 from typing import Literal
 from typing import Optional
+from typing import Self
 from typing import Union
 
 from pydantic import BaseModel
 from pydantic import Field
 from pydantic import model_validator
-from typing_extensions import Annotated
 
 
 class CamayocOptions(BaseModel):
@@ -34,6 +35,21 @@ class QuipucordsServerOptions(BaseModel):
 class QuipucordsCLIOptions(BaseModel):
     executable: Optional[str] = "qpc"
     display_name: Optional[str] = "qpc"
+
+
+class HashicorpVaultOptions(BaseModel):
+    address: str
+    port: Optional[int] = 8200
+    ssl_verify: Optional[bool] = True
+    client_cert: Path
+    client_key: Path
+    ca_cert: Optional[Path] = None
+
+    @model_validator(mode="after")
+    def check_ca_cert_when_ssl_verify(self) -> Self:
+        if self.ssl_verify and self.ca_cert is None:
+            raise ValueError("ca_cert is required when ssl_verify is True")
+        return self
 
 
 class PlainNetworkCredentialOptions(BaseModel):
@@ -97,6 +113,23 @@ class AnsibleCredentialOptions(BaseModel):
     password: str
 
 
+# TODO: these models allow config parsing but are not consumed at runtime yet
+class VaultOpenShiftCredentialOptions(BaseModel):
+    name: str
+    type: Literal["openshift"]
+    vault_secret_path: str
+    vault_secret_key: str
+    vault_mount_point: Optional[str] = None
+
+
+class VaultAnsibleCredentialOptions(BaseModel):
+    name: str
+    type: Literal["ansible"]
+    vault_secret_path: str
+    vault_secret_key: str
+    vault_mount_point: Optional[str] = None
+
+
 ServicesCredentialOptions = Annotated[
     Union[
         VCenterCredentialOptions,
@@ -113,6 +146,8 @@ CredentialOptions = Union[
     PlainNetworkCredentialOptions,
     SSHNetworkCredentialOptions,
     PlainOpenShiftCredentialOptions,
+    VaultOpenShiftCredentialOptions,
+    VaultAnsibleCredentialOptions,
     ServicesCredentialOptions,
 ]
 
@@ -181,9 +216,22 @@ class Configuration(BaseModel):
     camayoc: CamayocOptions
     quipucords_server: QuipucordsServerOptions
     quipucords_cli: QuipucordsCLIOptions
+    hashicorp_vault: Optional[HashicorpVaultOptions] = None
     credentials: list[CredentialOptions]
     sources: list[SourceOptions]
     scans: list[ScanOptions]
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_vault_config(cls, values: Any) -> Any:
+        if isinstance(values, dict):
+            has_vault_cred = any(
+                cred.get("vault_secret_path") for cred in values.get("credentials", [])
+            )
+            if has_vault_cred and not values.get("hashicorp_vault"):
+                msg = "hashicorp_vault configuration is required when vault credentials are defined"
+                raise ValueError(msg)
+        return values
 
     @model_validator(mode="before")
     @classmethod

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -14,22 +14,188 @@ with open(EXAMPLE_CONFIG_PATH) as fh:
 # FIXME: this should be an enum
 SOURCE_TYPES = ("network", "satellite", "vcenter")
 
+VAULT_SERVER_CONFIG = {
+    "address": "vault.example.com",
+    "port": 8200,
+    "ssl_verify": True,
+    "client_cert": "/path/to/client.crt",
+    "client_key": "/path/to/client.key",
+    "ca_cert": "/path/to/ca.crt",
+}
+
+VAULT_OPENSHIFT_CRED = {
+    "name": "OpenShiftVault",
+    "type": "openshift",
+    "vault_secret_path": "vault/dev/ocp-token",
+    "vault_secret_key": "auth_token",
+    "vault_mount_point": "discovery",
+}
+
+VAULT_OPENSHIFT_SOURCE = {
+    "hosts": ["api.vault-ocp.example.com"],
+    "credentials": ["OpenShiftVault"],
+    "name": "OpenShiftVault",
+    "type": "openshift",
+    "ssl_cert_verify": False,
+}
+
+VAULT_ANSIBLE_CRED = {
+    "name": "AnsibleVault",
+    "type": "ansible",
+    "vault_secret_path": "vault/dev/aap-token",
+    "vault_secret_key": "password",
+}
+
+VAULT_ANSIBLE_SOURCE = {
+    "hosts": ["aap.example.com"],
+    "credentials": ["AnsibleVault"],
+    "name": "AnsibleVault",
+    "type": "ansible",
+    "ssl_cert_verify": False,
+}
+
 
 @pytest.fixture
 def example_config():
     return deepcopy(EXAMPLE_CONFIG)
 
 
+def write_config(tmp_path, config):
+    config_file = tmp_path / "config.yaml"
+    with open(config_file, "w") as fh:
+        yaml.dump(data=config, stream=fh)
+    return config_file
+
+
 def test_read_example_config():
     settings = get_settings(path=EXAMPLE_CONFIG_PATH)
     assert settings.quipucords_server
+    assert settings.hashicorp_vault is None
+    vault_creds = [c for c in settings.credentials if hasattr(c, "vault_secret_path")]
+    assert vault_creds == []
+
+
+def test_valid_hashicorp_vault_config(tmp_path, example_config):
+    example_config["hashicorp_vault"] = VAULT_SERVER_CONFIG
+    config_file = write_config(tmp_path, example_config)
+
+    settings = get_settings(config_file)
+
+    assert settings.hashicorp_vault is not None
+    assert settings.hashicorp_vault.address == "vault.example.com"
+    assert settings.hashicorp_vault.port == 8200
+    assert settings.hashicorp_vault.ssl_verify is True
+    assert settings.hashicorp_vault.client_cert == Path("/path/to/client.crt")
+    assert settings.hashicorp_vault.client_key == Path("/path/to/client.key")
+    assert settings.hashicorp_vault.ca_cert == Path("/path/to/ca.crt")
+
+
+def test_hashicorp_vault_ssl_verify_requires_ca_cert(tmp_path, example_config):
+    example_config["hashicorp_vault"] = {
+        **VAULT_SERVER_CONFIG,
+        "ca_cert": None,
+    }
+    config_file = write_config(tmp_path, example_config)
+
+    with pytest.raises(ValidationError):
+        get_settings(config_file)
+
+
+def test_hashicorp_vault_ssl_verify_false_without_ca_cert(tmp_path, example_config):
+    vault_config = {**VAULT_SERVER_CONFIG, "ssl_verify": False}
+    vault_config.pop("ca_cert")
+    example_config["hashicorp_vault"] = vault_config
+    config_file = write_config(tmp_path, example_config)
+
+    settings = get_settings(config_file)
+
+    assert settings.hashicorp_vault is not None
+    assert settings.hashicorp_vault.ssl_verify is False
+    assert settings.hashicorp_vault.ca_cert is None
+
+
+def test_valid_vault_openshift_credential(tmp_path, example_config):
+    example_config["hashicorp_vault"] = VAULT_SERVER_CONFIG
+    example_config["credentials"].append(VAULT_OPENSHIFT_CRED)
+    example_config["sources"].append(VAULT_OPENSHIFT_SOURCE)
+    config_file = write_config(tmp_path, example_config)
+
+    settings = get_settings(config_file)
+
+    credential = next(c for c in settings.credentials if c.name == "OpenShiftVault")
+    assert credential.vault_secret_path == "vault/dev/ocp-token"
+    assert credential.vault_secret_key == "auth_token"
+    assert credential.vault_mount_point == "discovery"
+
+
+def test_valid_vault_ansible_credential(tmp_path, example_config):
+    example_config["hashicorp_vault"] = VAULT_SERVER_CONFIG
+    example_config["credentials"].append(VAULT_ANSIBLE_CRED)
+    example_config["sources"].append(VAULT_ANSIBLE_SOURCE)
+    config_file = write_config(tmp_path, example_config)
+
+    settings = get_settings(config_file)
+
+    credential = next(c for c in settings.credentials if c.name == "AnsibleVault")
+    assert credential.vault_secret_path == "vault/dev/aap-token"
+    assert credential.vault_secret_key == "password"
+    assert credential.vault_mount_point is None
+
+
+def test_invalid_vault_credential_without_vault_config(tmp_path, example_config):
+    example_config["credentials"].append(VAULT_OPENSHIFT_CRED)
+    example_config["sources"].append(VAULT_OPENSHIFT_SOURCE)
+    config_file = write_config(tmp_path, example_config)
+
+    with pytest.raises(ValidationError):
+        get_settings(config_file)
+
+
+@pytest.mark.parametrize("missing_field", ("vault_secret_path", "vault_secret_key"))
+def test_invalid_vault_credential_missing_required_field(tmp_path, example_config, missing_field):
+    example_config["hashicorp_vault"] = VAULT_SERVER_CONFIG
+    credential = {
+        "name": "OpenShiftVaultMissing",
+        "type": "openshift",
+        "vault_secret_path": "vault/dev/ocp-token",
+        "vault_secret_key": "auth_token",
+    }
+    credential.pop(missing_field)
+    example_config["credentials"].append(credential)
+    config_file = write_config(tmp_path, example_config)
+
+    with pytest.raises(ValidationError):
+        get_settings(config_file)
+
+
+def test_invalid_vault_credential_source_type_mismatch(tmp_path, example_config):
+    example_config["hashicorp_vault"] = VAULT_SERVER_CONFIG
+    example_config["credentials"].append(
+        {
+            "name": "OpenShiftVaultMismatch",
+            "type": "openshift",
+            "vault_secret_path": "vault/dev/ocp-token",
+            "vault_secret_key": "auth_token",
+        }
+    )
+    example_config["sources"].append(
+        {
+            "hosts": ["api.vault-ocp.example.com"],
+            "credentials": ["OpenShiftVaultMismatch"],
+            "name": "OpenShiftVaultMismatch",
+            "type": "network",
+            "ssl_cert_verify": False,
+        }
+    )
+    config_file = write_config(tmp_path, example_config)
+
+    with pytest.raises(ValidationError):
+        get_settings(config_file)
 
 
 def test_invalid_missing_section(tmp_path, example_config):
-    config_file = tmp_path / "config.yaml"
     example_config.pop("quipucords_server")
-    with open(config_file, "w") as fh:
-        yaml.dump(data=example_config, stream=fh)
+    config_file = write_config(tmp_path, example_config)
 
     with pytest.raises(ValidationError):
         get_settings(config_file)
@@ -37,17 +203,14 @@ def test_invalid_missing_section(tmp_path, example_config):
 
 @pytest.mark.parametrize("option", ("credentials", "sources", "scans"))
 def test_invalid_not_unique_names(tmp_path, example_config, option):
-    config_file = tmp_path / "config.yaml"
     example_config[option].append(example_config[option][0])
-    with open(config_file, "w") as fh:
-        yaml.dump(data=example_config, stream=fh)
+    config_file = write_config(tmp_path, example_config)
 
     with pytest.raises(ValidationError):
         get_settings(config_file)
 
 
 def test_invalid_non_existing_credential(tmp_path, faker, example_config):
-    config_file = tmp_path / "config.yaml"
     new_source = {
         "hosts": [faker.ipv4()],
         "name": faker.name(),
@@ -55,19 +218,16 @@ def test_invalid_non_existing_credential(tmp_path, faker, example_config):
         "credentials": [faker.name()],
     }
     example_config["sources"].append(new_source)
-    with open(config_file, "w") as fh:
-        yaml.dump(data=example_config, stream=fh)
+    config_file = write_config(tmp_path, example_config)
 
     with pytest.raises(ValidationError):
         get_settings(config_file)
 
 
 def test_invalid_non_existing_source(tmp_path, faker, example_config):
-    config_file = tmp_path / "config.yaml"
     new_scan = {"name": faker.name(), "sources": [faker.name()]}
     example_config["scans"].append(new_scan)
-    with open(config_file, "w") as fh:
-        yaml.dump(data=example_config, stream=fh)
+    config_file = write_config(tmp_path, example_config)
 
     with pytest.raises(ValidationError):
         get_settings(config_file)
@@ -75,7 +235,6 @@ def test_invalid_non_existing_source(tmp_path, faker, example_config):
 
 @pytest.mark.parametrize("stype", SOURCE_TYPES)
 def test_invalid_source_credential_type_mismatch(tmp_path, faker, example_config, stype):
-    config_file = tmp_path / "config.yaml"
     new_type = faker.random_element([_ for _ in SOURCE_TYPES if _ != stype])
     source = faker.random_element(
         [source for source in example_config.get("sources") if source.get("type") == stype]
@@ -91,8 +250,7 @@ def test_invalid_source_credential_type_mismatch(tmp_path, faker, example_config
     credential["type"] = new_type
     if new_type in ("satellite", "vcenter", "openshift") and not credential.get("password"):
         credential["password"] = faker.password()
-    with open(config_file, "w") as fh:
-        yaml.dump(data=example_config, stream=fh)
+    config_file = write_config(tmp_path, example_config)
 
     with pytest.raises(ValidationError):
         get_settings(config_file)


### PR DESCRIPTION
Extend Camayoc's config schema so config.yaml can define HashiCorp Vault server settings and Vault-backed OpenShift/Ansible credentials, enabling future Vault auth flow testing.

Generated-by: Cursor Auto
Relates to JIRA: DISCOVERY-1382

## Summary by Sourcery

Add configuration schema support for HashiCorp Vault server settings and Vault-backed OpenShift/Ansible credentials in config.yaml.

New Features:
- Allow configuring a HashiCorp Vault server in the main configuration, including TLS options.
- Support Vault-backed OpenShift and Ansible credentials that reference secrets stored in Vault.

Enhancements:
- Extend example_config.yaml with commented examples for Vault server and Vault-backed credentials and sources.
- Ensure settings defaults and validation cover the optional Vault configuration and its required fields.

Tests:
- Add tests covering HashiCorp Vault server config parsing and validation rules.
- Add tests for Vault-backed OpenShift and Ansible credential parsing, including validation of required fields and source type matching.