### PR TITLE
Improve robustness of test_translations

### DIFF
--- a/camayoc/tests/qpc/ui/test_endtoend.py
+++ b/camayoc/tests/qpc/ui/test_endtoend.py
@@ -125,6 +125,7 @@ def test_translations(ui_client: Client):
         "No, {product} does not automatically send any data to Red Hat."
         " All data is stored locally and creates reports on the local file system."
     )
+    refresh_labels = ("Refreshed just now", "Refreshed a few seconds ago")
 
     page = (
         ui_client.begin()
@@ -150,6 +151,6 @@ def test_translations(ui_client: Client):
     refresh_button = page._driver.locator(
         "button[data-ouia-component-id=refresh] span[class$=button__text]"
     )
-    assert refresh_button.inner_text() == "Refreshed just now"
+    assert refresh_button.inner_text() in refresh_labels
 
     page.logout()


### PR DESCRIPTION
`test_translations` recently started to intermittently fail because UI sometimes show "Refreshed a few seconds ago" instead of "Refreshed just now". While this might be a bug in UI (`refreshTimeButton.tsx` should keep "just now" for about 3 seconds) or Playwright forcing some action to be executed too soon, this doesn't really matter for the intent of the test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end validation for the Sources page Refresh button to accept both immediate and shortly delayed refresh status messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->