### PR TITLE
refactor: Removing ssl_verify option from HashiCorp Vault configuration

### DIFF
--- a/camayoc/types/settings.py
+++ b/camayoc/types/settings.py
@@ -3,7 +3,6 @@ from typing import Annotated
 from typing import Any
 from typing import Literal
 from typing import Optional
-from typing import Self
 from typing import Union
 
 from pydantic import BaseModel
@@ -40,16 +39,9 @@ class QuipucordsCLIOptions(BaseModel):
 class HashicorpVaultOptions(BaseModel):
     address: str
     port: Optional[int] = 8200
-    ssl_verify: Optional[bool] = True
     client_cert: Path
     client_key: Path
-    ca_cert: Optional[Path] = None
-
-    @model_validator(mode="after")
-    def check_ca_cert_when_ssl_verify(self) -> Self:
-        if self.ssl_verify and self.ca_cert is None:
-            raise ValueError("ca_cert is required when ssl_verify is True")
-        return self
+    ca_cert: Path
 
 
 class PlainNetworkCredentialOptions(BaseModel):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -17,7 +17,6 @@ SOURCE_TYPES = ("network", "satellite", "vcenter")
 VAULT_SERVER_CONFIG = {
     "address": "vault.example.com",
     "port": 8200,
-    "ssl_verify": True,
     "client_cert": "/path/to/client.crt",
     "client_key": "/path/to/client.key",
     "ca_cert": "/path/to/ca.crt",
@@ -84,34 +83,19 @@ def test_valid_hashicorp_vault_config(tmp_path, example_config):
     assert settings.hashicorp_vault is not None
     assert settings.hashicorp_vault.address == "vault.example.com"
     assert settings.hashicorp_vault.port == 8200
-    assert settings.hashicorp_vault.ssl_verify is True
     assert settings.hashicorp_vault.client_cert == Path("/path/to/client.crt")
     assert settings.hashicorp_vault.client_key == Path("/path/to/client.key")
     assert settings.hashicorp_vault.ca_cert == Path("/path/to/ca.crt")
 
 
-def test_hashicorp_vault_ssl_verify_requires_ca_cert(tmp_path, example_config):
-    example_config["hashicorp_vault"] = {
-        **VAULT_SERVER_CONFIG,
-        "ca_cert": None,
-    }
-    config_file = write_config(tmp_path, example_config)
-
-    with pytest.raises(ValidationError):
-        get_settings(config_file)
-
-
-def test_hashicorp_vault_ssl_verify_false_without_ca_cert(tmp_path, example_config):
-    vault_config = {**VAULT_SERVER_CONFIG, "ssl_verify": False}
+def test_hashicorp_vault_requires_ca_cert(tmp_path, example_config):
+    vault_config = {**VAULT_SERVER_CONFIG}
     vault_config.pop("ca_cert")
     example_config["hashicorp_vault"] = vault_config
     config_file = write_config(tmp_path, example_config)
 
-    settings = get_settings(config_file)
-
-    assert settings.hashicorp_vault is not None
-    assert settings.hashicorp_vault.ssl_verify is False
-    assert settings.hashicorp_vault.ca_cert is None
+    with pytest.raises(ValidationError):
+        get_settings(config_file)
 
 
 def test_valid_vault_openshift_credential(tmp_path, example_config):


### PR DESCRIPTION
- The server was updated to no longer support the ssl_verify option in the HashiCorp vault configuration. It always expects all cert, key and ca_cert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Vault configurations now require a CA certificate.
  * Removed the optional SSL verification setting and related conditional validation.
* **Tests**
  * Updated configuration validation coverage to confirm that missing CA certificates are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->