### PR TITLE
test: add minimal ansible/AAP scan report coverage

### DIFF
--- a/camayoc/tests/qpc/cli/test_ansible.py
+++ b/camayoc/tests/qpc/cli/test_ansible.py
@@ -1,0 +1,183 @@
+"""Tests for Ansible Automation Platform (ansible) sources.
+
+:caseautomation: automated
+:casecomponent: cli
+:caseimportance: high
+:caselevel: integration
+:testtype: functional
+"""
+
+import re
+from uuid import uuid4
+
+import pytest
+
+from camayoc.config import settings
+from camayoc.qpc_models import Scan
+from camayoc.tests.qpc.cli.utils import scan_job
+from camayoc.tests.qpc.cli.utils import scan_start
+from camayoc.tests.qpc.cli.utils import wait_for_scan
+from camayoc.types.settings import SourceOptions
+
+from .utils import retrieve_report
+from .utils import scan_add_and_check
+
+
+def ansible_sources():
+    for source_definition in settings.sources:
+        if source_definition.type != "ansible":
+            continue
+        yield pytest.param(source_definition, id=source_definition.name)
+
+
+def _merged_facts(facts):
+    """Merge per-system fact dicts from the details report into one mapping."""
+    merged = {}
+    for fact in facts or []:
+        merged.update(fact)
+    return merged
+
+
+def _run_ansible_scan(data_provider, source_definition: SourceOptions):
+    source = data_provider.sources.new_one({"name": source_definition.name}, data_only=False)
+    scan_name = uuid4()
+    scan_add_and_check({"name": scan_name, "sources": source.name})
+    data_provider.mark_for_cleanup(Scan(name=scan_name))
+    output = scan_start({"name": scan_name})
+    match_scan_id = re.match(r'Scan "(\d+)" started.', output)
+    assert match_scan_id is not None
+    scan_job_id = match_scan_id.group(1)
+    wait_for_scan(scan_job_id)
+    result = scan_job({"id": scan_job_id})
+    assert result["status"] == "completed"
+    details, deployments, aggregate = retrieve_report(scan_job_id)
+    return source, details, deployments, aggregate
+
+
+def validate_ansible_report_minimum(source_name, details, deployments, aggregate):
+    """Validate minimal ansible report attributes (empty inventory is OK)."""
+    assert details is not None, "details report missing from download"
+    assert deployments is not None, "deployments report missing from download"
+    assert aggregate is not None, "aggregate report missing from download"
+
+    ansible_sources_in_report = [
+        report_source
+        for report_source in details.get("sources", [])
+        if report_source.get("source_type") == "ansible"
+    ]
+    assert len(ansible_sources_in_report) == 1
+    report_source = ansible_sources_in_report[0]
+    assert report_source.get("source_name") == source_name
+
+    fact = _merged_facts(report_source.get("facts"))
+    assert "instance_details" in fact
+    assert "hosts" in fact
+
+    instance_details = fact["instance_details"]
+    system_name = instance_details.get("system_name")
+    version = instance_details.get("version")
+    assert isinstance(system_name, str) and system_name
+    assert isinstance(version, str) and version
+
+    hosts = fact["hosts"]
+    assert isinstance(hosts, list)
+    host_count = len(hosts)
+
+    ansible_fingerprints = [
+        fingerprint
+        for fingerprint in deployments.get("system_fingerprints", [])
+        if fingerprint.get("name") == system_name
+        and any(source.get("source_type") == "ansible" for source in fingerprint.get("sources", []))
+    ]
+    assert len(ansible_fingerprints) >= 1
+    assert ansible_fingerprints[0].get("os_version") == version
+
+    results = aggregate.get("results") or {}
+    assert results.get("ansible_hosts_in_database") == host_count
+
+
+def validate_ansible_unique_hosts_collected(source_name, details, deployments, aggregate):
+    """Validate unique-hosts collection succeeded (host_metrics or /jobs/ fallback)."""
+    validate_ansible_report_minimum(source_name, details, deployments, aggregate)
+
+    report_source = next(
+        report_source
+        for report_source in details.get("sources", [])
+        if report_source.get("source_type") == "ansible"
+    )
+    fact = _merged_facts(report_source.get("facts"))
+    missing = [key for key in ("jobs", "comparison") if key not in fact]
+    assert not missing, (
+        f"Details facts missing required keys: {missing}. "
+        "Missing jobs/comparison usually means unique-hosts collection failed "
+        "(for example host_metrics 40x without /jobs/ fallback)."
+    )
+
+    hosts = fact["hosts"]
+    host_count = len(hosts)
+    jobs = fact["jobs"]
+    assert isinstance(jobs.get("unique_hosts"), list)
+    assert isinstance(jobs.get("job_ids"), list)
+
+    comparison = fact["comparison"]
+    assert comparison.get("number_of_hosts_in_inventory") == host_count
+    assert comparison.get("number_of_hosts_only_in_jobs") == len(
+        comparison.get("hosts_only_in_jobs") or []
+    )
+    assert set(comparison.get("hosts_in_inventory") or []) == {host.get("name") for host in hosts}
+
+    results = aggregate.get("results") or {}
+    diagnostics = aggregate.get("diagnostics") or {}
+    assert results.get("ansible_hosts_in_jobs") == len(set(jobs["unique_hosts"]))
+    assert results.get("ansible_hosts_all") == len(
+        set(comparison.get("hosts_in_inventory") or [])
+        | set(comparison.get("hosts_only_in_jobs") or [])
+    )
+    assert diagnostics.get("inspect_result_status_success") == 1
+    assert diagnostics.get("inspect_result_status_failed") == 0
+
+
+@pytest.mark.runs_scan
+@pytest.mark.parametrize("source_definition", ansible_sources())
+def test_ansible_report_minimum(qpc_server_config, data_provider, source_definition: SourceOptions):
+    """Scan an ansible source and validate minimal report attributes.
+
+    :id: 3f8c2a71-6d4e-4b9a-9e2f-1a7c5d8b0e44
+    :description: Perform an ansible / AAP scan and check details, deployments,
+        and aggregate for attributes that are always expected when connect and
+        basic inspect succeed. Inventory may be empty.
+    :steps:
+        1. Add source with credential for an AAP / Ansible Controller
+        2. Perform a scan
+        3. Collect the report
+    :expectedresults: Scan finishes, report can be downloaded, controller
+        fingerprint matches instance_details, and aggregate inventory count
+        matches ``len(hosts)`` (including zero).
+    """
+    source, details, deployments, aggregate = _run_ansible_scan(data_provider, source_definition)
+    validate_ansible_report_minimum(source.name, details, deployments, aggregate)
+
+
+@pytest.mark.runs_scan
+@pytest.mark.parametrize("source_definition", ansible_sources())
+def test_ansible_unique_hosts_collected(
+    qpc_server_config, data_provider, source_definition: SourceOptions
+):
+    """Scan an ansible source and validate unique-hosts collection end-to-end.
+
+    :id: 9b1e4d52-8c70-4f1a-a3d6-5e2f7c8a9012
+    :description: Perform an ansible / AAP scan and ensure unique-hosts facts
+        (``jobs`` and ``comparison``) are present with a successful inspect
+        status. This covers the host_metrics 40x fallback to ``/jobs/``: when
+        host_metrics is advertised but returns 401/403/404, Discovery should
+        still collect unique hosts via jobs instead of failing inspect.
+    :steps:
+        1. Add source with credential for an AAP / Ansible Controller
+        2. Perform a scan
+        3. Collect the report
+    :expectedresults: Scan finishes with successful inspect diagnostics;
+        details include jobs and comparison; aggregate host metrics are
+        internally consistent. Empty unique_hosts / job_ids are allowed.
+    """
+    source, details, deployments, aggregate = _run_ansible_scan(data_provider, source_definition)
+    validate_ansible_unique_hosts_collected(source.name, details, deployments, aggregate)

--- a/camayoc/tests/qpc/cli/test_ansible.py
+++ b/camayoc/tests/qpc/cli/test_ansible.py
@@ -30,14 +30,6 @@ def ansible_sources():
         yield pytest.param(source_definition, id=source_definition.name)
 
 
-def _merged_facts(facts):
-    """Merge per-system fact dicts from the details report into one mapping."""
-    merged = {}
-    for fact in facts or []:
-        merged.update(fact)
-    return merged
-
-
 def _run_ansible_scan(data_provider, source_definition: SourceOptions):
     source = data_provider.sources.new_one({"name": source_definition.name}, data_only=False)
     scan_name = uuid4()
@@ -55,7 +47,10 @@ def _run_ansible_scan(data_provider, source_definition: SourceOptions):
 
 
 def validate_ansible_report_minimum(source_name, details, deployments, aggregate):
-    """Validate minimal ansible report attributes (empty inventory is OK)."""
+    """Validate minimal ansible report attributes (empty inventory is OK).
+
+    :id: 3f8c2a71-6d4e-4b9a-9e2f-1a7c5d8b0e44
+    """
     assert details is not None, "details report missing from download"
     assert deployments is not None, "deployments report missing from download"
     assert aggregate is not None, "aggregate report missing from download"
@@ -69,7 +64,9 @@ def validate_ansible_report_minimum(source_name, details, deployments, aggregate
     report_source = ansible_sources_in_report[0]
     assert report_source.get("source_name") == source_name
 
-    fact = _merged_facts(report_source.get("facts"))
+    facts = report_source.get("facts", [])
+    assert len(facts) == 1
+    fact = facts[0]
     assert "instance_details" in fact
     assert "hosts" in fact
 
@@ -92,7 +89,7 @@ def validate_ansible_report_minimum(source_name, details, deployments, aggregate
     assert len(ansible_fingerprints) >= 1
     assert ansible_fingerprints[0].get("os_version") == version
 
-    results = aggregate.get("results") or {}
+    results = aggregate.get("results", {})
     assert results.get("ansible_hosts_in_database") == host_count
 
 
@@ -105,13 +102,11 @@ def validate_ansible_unique_hosts_collected(source_name, details, deployments, a
         for report_source in details.get("sources", [])
         if report_source.get("source_type") == "ansible"
     )
-    fact = _merged_facts(report_source.get("facts"))
+    facts = report_source.get("facts", [])
+    assert len(facts) == 1
+    fact = facts[0]
     missing = [key for key in ("jobs", "comparison") if key not in fact]
-    assert not missing, (
-        f"Details facts missing required keys: {missing}. "
-        "Missing jobs/comparison usually means unique-hosts collection failed "
-        "(for example host_metrics 40x without /jobs/ fallback)."
-    )
+    assert not missing, f"Details facts missing required keys: {missing}"
 
     hosts = fact["hosts"]
     host_count = len(hosts)
@@ -122,40 +117,19 @@ def validate_ansible_unique_hosts_collected(source_name, details, deployments, a
     comparison = fact["comparison"]
     assert comparison.get("number_of_hosts_in_inventory") == host_count
     assert comparison.get("number_of_hosts_only_in_jobs") == len(
-        comparison.get("hosts_only_in_jobs") or []
+        comparison.get("hosts_only_in_jobs", [])
     )
-    assert set(comparison.get("hosts_in_inventory") or []) == {host.get("name") for host in hosts}
+    assert set(comparison.get("hosts_in_inventory", [])) == {host.get("name") for host in hosts}
 
-    results = aggregate.get("results") or {}
-    diagnostics = aggregate.get("diagnostics") or {}
+    results = aggregate.get("results", {})
+    diagnostics = aggregate.get("diagnostics", {})
     assert results.get("ansible_hosts_in_jobs") == len(set(jobs["unique_hosts"]))
     assert results.get("ansible_hosts_all") == len(
-        set(comparison.get("hosts_in_inventory") or [])
-        | set(comparison.get("hosts_only_in_jobs") or [])
+        set(comparison.get("hosts_in_inventory", []))
+        | set(comparison.get("hosts_only_in_jobs", []))
     )
     assert diagnostics.get("inspect_result_status_success") == 1
     assert diagnostics.get("inspect_result_status_failed") == 0
-
-
-@pytest.mark.runs_scan
-@pytest.mark.parametrize("source_definition", ansible_sources())
-def test_ansible_report_minimum(qpc_server_config, data_provider, source_definition: SourceOptions):
-    """Scan an ansible source and validate minimal report attributes.
-
-    :id: 3f8c2a71-6d4e-4b9a-9e2f-1a7c5d8b0e44
-    :description: Perform an ansible / AAP scan and check details, deployments,
-        and aggregate for attributes that are always expected when connect and
-        basic inspect succeed. Inventory may be empty.
-    :steps:
-        1. Add source with credential for an AAP / Ansible Controller
-        2. Perform a scan
-        3. Collect the report
-    :expectedresults: Scan finishes, report can be downloaded, controller
-        fingerprint matches instance_details, and aggregate inventory count
-        matches ``len(hosts)`` (including zero).
-    """
-    source, details, deployments, aggregate = _run_ansible_scan(data_provider, source_definition)
-    validate_ansible_report_minimum(source.name, details, deployments, aggregate)
 
 
 @pytest.mark.runs_scan
@@ -170,7 +144,8 @@ def test_ansible_unique_hosts_collected(
         (``jobs`` and ``comparison``) are present with a successful inspect
         status. This covers the host_metrics 40x fallback to ``/jobs/``: when
         host_metrics is advertised but returns 401/403/404, Discovery should
-        still collect unique hosts via jobs instead of failing inspect.
+        still collect unique hosts via jobs instead of failing inspect. Also
+        validates minimal report attributes (details, deployments, aggregate).
     :steps:
         1. Add source with credential for an AAP / Ansible Controller
         2. Perform a scan
@@ -178,6 +153,8 @@ def test_ansible_unique_hosts_collected(
     :expectedresults: Scan finishes with successful inspect diagnostics;
         details include jobs and comparison; aggregate host metrics are
         internally consistent. Empty unique_hosts / job_ids are allowed.
+        Controller fingerprint matches instance_details, and aggregate
+        inventory count matches ``len(hosts)`` (including zero).
     """
     source, details, deployments, aggregate = _run_ansible_scan(data_provider, source_definition)
     validate_ansible_unique_hosts_collected(source.name, details, deployments, aggregate)

--- a/camayoc/tests/qpc/cli/test_openshift.py
+++ b/camayoc/tests/qpc/cli/test_openshift.py
@@ -153,7 +153,7 @@ def test_openshift_clusters(qpc_server_config, data_provider, source_definition:
     wait_for_scan(scan_job_id)
     result = scan_job({"id": scan_job_id})
     assert result["status"] == "completed"
-    details, deployments = retrieve_report(scan_job_id)
+    details, deployments, _aggregate = retrieve_report(scan_job_id)
     cluster_info = openshift_cluster_info(source_definition.name)
     validate_openshift_report(cluster_info, details, deployments)
     validate_operators(cluster_info, details)

--- a/camayoc/tests/qpc/cli/test_rhacs.py
+++ b/camayoc/tests/qpc/cli/test_rhacs.py
@@ -67,7 +67,7 @@ def test_rhacs_data(qpc_server_config, data_provider, source_definition: SourceO
     result = scan_job({"id": scan_job_id})
     assert result["status"] == "completed"
     # to here
-    details, deployments = retrieve_report(scan_job_id)
+    details, deployments, _aggregate = retrieve_report(scan_job_id)
     for report_source in details.get("sources"):
         assert report_source.get("source_name") == source.name
         for fact in report_source.get("facts"):

--- a/camayoc/tests/qpc/cli/test_rhacs.py
+++ b/camayoc/tests/qpc/cli/test_rhacs.py
@@ -67,7 +67,7 @@ def test_rhacs_data(qpc_server_config, data_provider, source_definition: SourceO
     result = scan_job({"id": scan_job_id})
     assert result["status"] == "completed"
     # to here
-    details, deployments, _aggregate = retrieve_report(scan_job_id)
+    details, _deployments, _aggregate = retrieve_report(scan_job_id)
     for report_source in details.get("sources"):
         assert report_source.get("source_name") == source.name
         for fact in report_source.get("facts"):

--- a/camayoc/tests/qpc/cli/utils.py
+++ b/camayoc/tests/qpc/cli/utils.py
@@ -366,20 +366,42 @@ def scan_job(options=None, exitstatus=0):
     return json.loads(cli_command("{} -v scan job".format(client_cmd), options, exitstatus))
 
 
+def _report_json_member(member_name: str, report_type: str) -> bool:
+    """Return True if tar member is a JSON report of the given type.
+
+    Quipucords download compatibility: report tarballs from Quipucords use
+    report-id suffixed names such as ``details-1.json`` (see Quipucords
+    ``create_filename(..., detailed_filename=True)``). Older Camayoc matching
+    only accepted unsuffixed names like ``details.json``; both forms are
+    accepted here.
+    """
+    basename = member_name.rsplit("/", 1)[-1]
+    return bool(re.fullmatch(rf"{report_type}(-\d+)?\.json", basename))
+
+
 def retrieve_report(scan_job_id):
+    """Download a scan-job report tarball and return parsed JSON reports.
+
+    Returns ``(details, deployments, aggregate)``. Filename matching includes a
+    Quipucords download compatibility fix for report-id suffixed members
+    (for example ``details-1.json``).
+    """
     with tempfile.TemporaryDirectory() as tmpdirname:
         output_file = f"{tmpdirname}/report.tar.gz"
         report_download({"scan-job": scan_job_id, "output-file": output_file})
-        details = deployments = None
+        details = deployments = aggregate = None
         with tarfile.open(output_file) as pkg:
             for member in pkg.getmembers():
-                if member.name.endswith("details.json"):
+                if _report_json_member(member.name, "details"):
                     data = pkg.extractfile(member).read()
                     details = json.loads(data)
-                if member.name.endswith("deployments.json"):
+                if _report_json_member(member.name, "deployments"):
                     data = pkg.extractfile(member).read()
                     deployments = json.loads(data)
-    return details, deployments
+                if _report_json_member(member.name, "aggregate"):
+                    data = pkg.extractfile(member).read()
+                    aggregate = json.loads(data)
+    return details, deployments, aggregate
 
 
 def scans_with_source_type(source_type):

--- a/camayoc/tests/qpc/cli/utils.py
+++ b/camayoc/tests/qpc/cli/utils.py
@@ -366,17 +366,7 @@ def scan_job(options=None, exitstatus=0):
     return json.loads(cli_command("{} -v scan job".format(client_cmd), options, exitstatus))
 
 
-def _report_json_member(member_name: str, report_type: str) -> bool:
-    """Return True if tar member is a JSON report of the given type.
-
-    Quipucords download compatibility: report tarballs from Quipucords use
-    report-id suffixed names such as ``details-1.json`` (see Quipucords
-    ``create_filename(..., detailed_filename=True)``). Older Camayoc matching
-    only accepted unsuffixed names like ``details.json``; both forms are
-    accepted here.
-    """
-    basename = member_name.rsplit("/", 1)[-1]
-    return bool(re.fullmatch(rf"{report_type}(-\d+)?\.json", basename))
+_REPORT_MEMBER_RE = re.compile(r"(?P<report_type>details|deployments|aggregate)(-\d+)?\.json")
 
 
 def retrieve_report(scan_job_id):
@@ -389,19 +379,15 @@ def retrieve_report(scan_job_id):
     with tempfile.TemporaryDirectory() as tmpdirname:
         output_file = f"{tmpdirname}/report.tar.gz"
         report_download({"scan-job": scan_job_id, "output-file": output_file})
-        details = deployments = aggregate = None
+        reports = {"details": None, "deployments": None, "aggregate": None}
         with tarfile.open(output_file) as pkg:
             for member in pkg.getmembers():
-                if _report_json_member(member.name, "details"):
-                    data = pkg.extractfile(member).read()
-                    details = json.loads(data)
-                if _report_json_member(member.name, "deployments"):
-                    data = pkg.extractfile(member).read()
-                    deployments = json.loads(data)
-                if _report_json_member(member.name, "aggregate"):
-                    data = pkg.extractfile(member).read()
-                    aggregate = json.loads(data)
-    return details, deployments, aggregate
+                basename = member.name.rsplit("/", 1)[-1]
+                match = _REPORT_MEMBER_RE.fullmatch(basename)
+                if not match:
+                    continue
+                reports[match.group("report_type")] = json.loads(pkg.extractfile(member).read())
+    return reports["details"], reports["deployments"], reports["aggregate"]
 
 
 def scans_with_source_type(source_type):

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -64,6 +64,10 @@ credentials:
     - name: 'rhacs'
       type: 'rhacs'
       auth_token: 'these_tend_to_be_very_long'
+    - name: 'ansible'
+      type: 'ansible'
+      username: 'admin'
+      password: 'CHANGEME'
 
 # Values in "credentials" field can use names present in "credentials" section
 # above
@@ -101,6 +105,13 @@ sources:
           - 'rhacs'
       name: 'RHACS'
       type: 'rhacs'
+      ssl_cert_verify: false
+    - hosts:
+          - 'aap.example.com'
+      credentials:
+          - 'ansible'
+      name: 'ansible'
+      type: 'ansible'
       ssl_cert_verify: false
 
 # Values in "sources" field can use names present in "sources" section above

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -72,6 +72,11 @@ def test_read_example_config():
     assert settings.hashicorp_vault is None
     vault_creds = [c for c in settings.credentials if hasattr(c, "vault_secret_path")]
     assert vault_creds == []
+    ansible_cred = next(c for c in settings.credentials if c.name == "ansible")
+    assert ansible_cred.type == "ansible"
+    ansible_source = next(s for s in settings.sources if s.name == "ansible")
+    assert ansible_source.type == "ansible"
+    assert ansible_source.credentials == ["ansible"]
 
 
 def test_valid_hashicorp_vault_config(tmp_path, example_config):


### PR DESCRIPTION
## Summary
- Add CLI ansible/AAP scan tests for minimal report attributes (empty inventory allowed) and unique-hosts collection (`jobs`/`comparison`, successful inspect), covering host_metrics 40x fallback expectations.
- Fix `retrieve_report` for Quipucords download filenames (`details-1.json`, etc.) and return aggregate JSON.
- Extend example config and settings coverage for ansible credential/source.

Relates to JIRA: [DISCOVERY-1403](https://redhat.atlassian.net/browse/DISCOVERY-1403), [DISCOVERY-1453](https://redhat.atlassian.net/browse/DISCOVERY-1453)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ansible source scanning with report validation and unique-host collection checks.
  * Added Ansible credentials and source settings to the example configuration.
  * Enhanced report retrieval to support aggregate reports and numeric filename suffixes.

* **Tests**
  * Expanded configuration validation for Ansible entries.
  * Updated OpenShift and RHACS report checks to support aggregate reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->