### PR TITLE
test: CLI e2e for vault-backed Ansible/AAP scans

### DIFF
--- a/camayoc/tests/qpc/cli/test_ansible_vault.py
+++ b/camayoc/tests/qpc/cli/test_ansible_vault.py
@@ -1,0 +1,187 @@
+"""End-to-end CLI tests for Ansible/AAP scans with Vault-backed credentials.
+
+:caseautomation: automated
+:casecomponent: cli
+:caseimportance: high
+:caselevel: integration
+:testtype: functional
+"""
+
+import re
+from uuid import uuid4
+
+import pytest
+
+from camayoc.config import settings
+from camayoc.qpc_models import Credential
+from camayoc.qpc_models import Scan
+from camayoc.qpc_models import Source
+from camayoc.tests.qpc.cli.utils import configure_server_vault
+from camayoc.tests.qpc.cli.utils import cred_add_and_check
+from camayoc.tests.qpc.cli.utils import retrieve_report
+from camayoc.tests.qpc.cli.utils import scan_add_and_check
+from camayoc.tests.qpc.cli.utils import scan_job
+from camayoc.tests.qpc.cli.utils import scan_start
+from camayoc.tests.qpc.cli.utils import source_add_and_check
+from camayoc.tests.qpc.cli.utils import wait_for_scan
+from camayoc.types.settings import SourceOptions
+from camayoc.types.settings import VaultAnsibleCredentialOptions
+
+
+def _vault_ansible_credentials_for_source(source_definition: SourceOptions):
+    credentials_by_name = {credential.name: credential for credential in settings.credentials}
+    for credential_name in source_definition.credentials:
+        credential = credentials_by_name.get(credential_name)
+        if isinstance(credential, VaultAnsibleCredentialOptions):
+            yield credential
+
+
+def vault_ansible_sources():
+    """Yield ansible sources that use vault-backed credentials.
+
+    Skips collection when ``hashicorp_vault`` or matching sources are missing.
+    """
+    if settings.hashicorp_vault is None:
+        return
+
+    for source_definition in settings.sources:
+        if source_definition.type != "ansible":
+            continue
+        if not any(_vault_ansible_credentials_for_source(source_definition)):
+            continue
+        yield pytest.param(source_definition, id=source_definition.name)
+
+
+_VAULT_ANSIBLE_SOURCES = list(vault_ansible_sources())
+_SKIP_NO_VAULT_ANSIBLE = pytest.mark.skip(
+    reason="No hashicorp_vault config or vault-backed ansible sources configured"
+)
+
+
+def _merged_facts(facts):
+    """Merge per-system fact dicts from the details report into one mapping."""
+    merged = {}
+    for fact in facts or []:
+        merged.update(fact)
+    return merged
+
+
+def validate_ansible_vault_report(source_name, details, deployments):
+    """Validate report attributes expected from a successful vault-backed AAP scan."""
+    assert details is not None, "details report missing from download"
+    assert deployments is not None, "deployments report missing from download"
+
+    ansible_sources_in_report = [
+        report_source
+        for report_source in details.get("sources", [])
+        if report_source.get("source_type") == "ansible"
+    ]
+    assert len(ansible_sources_in_report) == 1
+    report_source = ansible_sources_in_report[0]
+    assert report_source.get("source_name") == source_name
+
+    fact = _merged_facts(report_source.get("facts"))
+    assert "instance_details" in fact
+    assert "hosts" in fact
+
+    instance_details = fact["instance_details"]
+    system_name = instance_details.get("system_name")
+    version = instance_details.get("version")
+    assert isinstance(system_name, str) and system_name
+    assert isinstance(version, str) and version
+    assert isinstance(fact["hosts"], list)
+
+    ansible_fingerprints = [
+        fingerprint
+        for fingerprint in deployments.get("system_fingerprints", [])
+        if fingerprint.get("name") == system_name
+        and any(source.get("source_type") == "ansible" for source in fingerprint.get("sources", []))
+    ]
+    assert len(ansible_fingerprints) >= 1
+    assert ansible_fingerprints[0].get("os_version") == version
+
+
+@pytest.fixture
+def configured_vault_server(qpc_server_config):
+    """Configure Discovery server vault settings from Camayoc config, or skip."""
+    if settings.hashicorp_vault is None:
+        pytest.skip("hashicorp_vault is not configured in camayoc config")
+    configure_server_vault()
+
+
+@pytest.mark.runs_scan
+@pytest.mark.parametrize(
+    "source_definition",
+    _VAULT_ANSIBLE_SOURCES
+    or [pytest.param(None, id="no-vault-ansible-config", marks=_SKIP_NO_VAULT_ANSIBLE)],
+)
+def test_ansible_scan_with_vault_credential(
+    configured_vault_server, data_provider, source_definition: SourceOptions
+):
+    """Scan an AAP source using a vault-backed Ansible credential via CLI.
+
+    :id: 7c2e9a14-5b8d-4f31-9c6a-2e4d8f0b1a55
+    :description: Create a vault-backed Ansible credential and ansible source
+        through the CLI, run a scan, and validate the downloaded report. This
+        covers the HashiCorp Vault credential flow from server vault
+        configuration through scan execution and report generation.
+    :steps:
+        1. Configure global HashiCorp Vault settings on the server via CLI
+        2. Create an Ansible credential that references a Vault secret
+        3. Create an ansible source that uses that credential
+        4. Perform a scan and wait for completion
+        5. Download and validate the report
+    :expectedresults: Vault configuration succeeds, credential and source are
+        created, the scan completes, and the report contains ansible
+        instance_details and hosts facts with a matching fingerprint.
+    """
+    vault_credential = next(_vault_ansible_credentials_for_source(source_definition))
+
+    cred_name = str(uuid4())
+    source_name = str(uuid4())
+    scan_name = str(uuid4())
+
+    cred_options = {
+        "name": cred_name,
+        "type": "ansible",
+        "vault-secret-path": vault_credential.vault_secret_path,
+        "vault-secret-key": vault_credential.vault_secret_key,
+    }
+    if vault_credential.vault_mount_point is not None:
+        cred_options["vault-mount-point"] = vault_credential.vault_mount_point
+
+    cred_add_and_check(cred_options)
+    data_provider.mark_for_cleanup(Credential(name=cred_name, cred_type="ansible"))
+
+    source_options = {
+        "name": source_name,
+        "type": "ansible",
+        "hosts": source_definition.hosts,
+        "cred": [cred_name],
+    }
+    if source_definition.port is not None:
+        source_options["port"] = source_definition.port
+    if source_definition.ssl_cert_verify is not None:
+        source_options["ssl-cert-verify"] = str(source_definition.ssl_cert_verify).lower()
+    if source_definition.disable_ssl is not None:
+        source_options["disable-ssl"] = str(source_definition.disable_ssl).lower()
+    if source_definition.ssl_protocol is not None:
+        source_options["ssl-protocol"] = source_definition.ssl_protocol
+
+    source_add_and_check(source_options)
+    data_provider.mark_for_cleanup(Source(name=source_name, source_type="ansible"))
+
+    scan_add_and_check({"name": scan_name, "sources": source_name})
+    data_provider.mark_for_cleanup(Scan(name=scan_name))
+
+    output = scan_start({"name": scan_name})
+    match_scan_id = re.match(r'Scan "(\d+)" started.', output)
+    assert match_scan_id is not None
+    scan_job_id = match_scan_id.group(1)
+
+    wait_for_scan(scan_job_id)
+    result = scan_job({"id": scan_job_id})
+    assert result["status"] == "completed"
+
+    details, deployments = retrieve_report(scan_job_id)
+    validate_ansible_vault_report(source_name, details, deployments)

--- a/camayoc/tests/qpc/cli/test_ansible_vault.py
+++ b/camayoc/tests/qpc/cli/test_ansible_vault.py
@@ -58,14 +58,6 @@ _SKIP_NO_VAULT_ANSIBLE = pytest.mark.skip(
 )
 
 
-def _merged_facts(facts):
-    """Merge per-system fact dicts from the details report into one mapping."""
-    merged = {}
-    for fact in facts or []:
-        merged.update(fact)
-    return merged
-
-
 def validate_ansible_vault_report(source_name, details, deployments):
     """Validate report attributes expected from a successful vault-backed AAP scan."""
     assert details is not None, "details report missing from download"
@@ -80,7 +72,9 @@ def validate_ansible_vault_report(source_name, details, deployments):
     report_source = ansible_sources_in_report[0]
     assert report_source.get("source_name") == source_name
 
-    fact = _merged_facts(report_source.get("facts"))
+    facts = report_source.get("facts", [])
+    assert len(facts) == 1
+    fact = facts[0]
     assert "instance_details" in fact
     assert "hosts" in fact
 
@@ -183,5 +177,5 @@ def test_ansible_scan_with_vault_credential(
     result = scan_job({"id": scan_job_id})
     assert result["status"] == "completed"
 
-    details, deployments = retrieve_report(scan_job_id)
+    details, deployments, _aggregate = retrieve_report(scan_job_id)
     validate_ansible_vault_report(source_name, details, deployments)

--- a/camayoc/tests/qpc/cli/test_ansible_vault.py
+++ b/camayoc/tests/qpc/cli/test_ansible_vault.py
@@ -16,6 +16,8 @@ from camayoc.config import settings
 from camayoc.qpc_models import Credential
 from camayoc.qpc_models import Scan
 from camayoc.qpc_models import Source
+from camayoc.tests.qpc.cli.test_ansible import validate_ansible_report_minimum
+from camayoc.tests.qpc.cli.utils import clear_server_vault
 from camayoc.tests.qpc.cli.utils import configure_server_vault
 from camayoc.tests.qpc.cli.utils import cred_add_and_check
 from camayoc.tests.qpc.cli.utils import retrieve_report
@@ -23,92 +25,42 @@ from camayoc.tests.qpc.cli.utils import scan_add_and_check
 from camayoc.tests.qpc.cli.utils import scan_job
 from camayoc.tests.qpc.cli.utils import scan_start
 from camayoc.tests.qpc.cli.utils import source_add_and_check
+from camayoc.tests.qpc.cli.utils import source_to_cli_options
 from camayoc.tests.qpc.cli.utils import wait_for_scan
 from camayoc.types.settings import SourceOptions
 from camayoc.types.settings import VaultAnsibleCredentialOptions
 
 
-def _vault_ansible_credentials_for_source(source_definition: SourceOptions):
-    credentials_by_name = {credential.name: credential for credential in settings.credentials}
-    for credential_name in source_definition.credentials:
-        credential = credentials_by_name.get(credential_name)
-        if isinstance(credential, VaultAnsibleCredentialOptions):
-            yield credential
-
-
 def vault_ansible_sources():
-    """Yield ansible sources that use vault-backed credentials.
-
-    Skips collection when ``hashicorp_vault`` or matching sources are missing.
-    """
-    if settings.hashicorp_vault is None:
-        return
-
+    """Yield ansible sources that use a vault-backed credential."""
+    credentials_by_name = {credential.name: credential for credential in settings.credentials}
     for source_definition in settings.sources:
         if source_definition.type != "ansible":
             continue
-        if not any(_vault_ansible_credentials_for_source(source_definition)):
+        credential = credentials_by_name.get(source_definition.credentials[0])
+        if not isinstance(credential, VaultAnsibleCredentialOptions):
             continue
         yield pytest.param(source_definition, id=source_definition.name)
 
 
 _VAULT_ANSIBLE_SOURCES = list(vault_ansible_sources())
-_SKIP_NO_VAULT_ANSIBLE = pytest.mark.skip(
-    reason="No hashicorp_vault config or vault-backed ansible sources configured"
-)
-
-
-def validate_ansible_vault_report(source_name, details, deployments):
-    """Validate report attributes expected from a successful vault-backed AAP scan."""
-    assert details is not None, "details report missing from download"
-    assert deployments is not None, "deployments report missing from download"
-
-    ansible_sources_in_report = [
-        report_source
-        for report_source in details.get("sources", [])
-        if report_source.get("source_type") == "ansible"
-    ]
-    assert len(ansible_sources_in_report) == 1
-    report_source = ansible_sources_in_report[0]
-    assert report_source.get("source_name") == source_name
-
-    facts = report_source.get("facts", [])
-    assert len(facts) == 1
-    fact = facts[0]
-    assert "instance_details" in fact
-    assert "hosts" in fact
-
-    instance_details = fact["instance_details"]
-    system_name = instance_details.get("system_name")
-    version = instance_details.get("version")
-    assert isinstance(system_name, str) and system_name
-    assert isinstance(version, str) and version
-    assert isinstance(fact["hosts"], list)
-
-    ansible_fingerprints = [
-        fingerprint
-        for fingerprint in deployments.get("system_fingerprints", [])
-        if fingerprint.get("name") == system_name
-        and any(source.get("source_type") == "ansible" for source in fingerprint.get("sources", []))
-    ]
-    assert len(ansible_fingerprints) >= 1
-    assert ansible_fingerprints[0].get("os_version") == version
 
 
 @pytest.fixture
 def configured_vault_server(qpc_server_config):
-    """Configure Discovery server vault settings from Camayoc config, or skip."""
-    if settings.hashicorp_vault is None:
-        pytest.skip("hashicorp_vault is not configured in camayoc config")
+    """Configure Discovery server vault settings for the test, then clear them."""
+    clear_server_vault()
     configure_server_vault()
+    yield
+    clear_server_vault()
 
 
 @pytest.mark.runs_scan
-@pytest.mark.parametrize(
-    "source_definition",
-    _VAULT_ANSIBLE_SOURCES
-    or [pytest.param(None, id="no-vault-ansible-config", marks=_SKIP_NO_VAULT_ANSIBLE)],
+@pytest.mark.skipif(
+    not _VAULT_ANSIBLE_SOURCES,
+    reason="No vault-backed ansible sources configured",
 )
+@pytest.mark.parametrize("source_definition", _VAULT_ANSIBLE_SOURCES)
 def test_ansible_scan_with_vault_credential(
     configured_vault_server, data_provider, source_definition: SourceOptions
 ):
@@ -129,7 +81,8 @@ def test_ansible_scan_with_vault_credential(
         created, the scan completes, and the report contains ansible
         instance_details and hosts facts with a matching fingerprint.
     """
-    vault_credential = next(_vault_ansible_credentials_for_source(source_definition))
+    credentials_by_name = {credential.name: credential for credential in settings.credentials}
+    vault_credential = credentials_by_name[source_definition.credentials[0]]
 
     cred_name = str(uuid4())
     source_name = str(uuid4())
@@ -147,22 +100,14 @@ def test_ansible_scan_with_vault_credential(
     cred_add_and_check(cred_options)
     data_provider.mark_for_cleanup(Credential(name=cred_name, cred_type="ansible"))
 
-    source_options = {
-        "name": source_name,
-        "type": "ansible",
-        "hosts": source_definition.hosts,
-        "cred": [cred_name],
-    }
-    if source_definition.port is not None:
-        source_options["port"] = source_definition.port
-    if source_definition.ssl_cert_verify is not None:
-        source_options["ssl-cert-verify"] = str(source_definition.ssl_cert_verify).lower()
-    if source_definition.disable_ssl is not None:
-        source_options["disable-ssl"] = str(source_definition.disable_ssl).lower()
-    if source_definition.ssl_protocol is not None:
-        source_options["ssl-protocol"] = source_definition.ssl_protocol
-
-    source_add_and_check(source_options)
+    source_add_and_check(
+        source_to_cli_options(
+            source_definition,
+            name=source_name,
+            credentials=[cred_name],
+            source_type="ansible",
+        )
+    )
     data_provider.mark_for_cleanup(Source(name=source_name, source_type="ansible"))
 
     scan_add_and_check({"name": scan_name, "sources": source_name})
@@ -177,5 +122,5 @@ def test_ansible_scan_with_vault_credential(
     result = scan_job({"id": scan_job_id})
     assert result["status"] == "completed"
 
-    details, deployments, _aggregate = retrieve_report(scan_job_id)
-    validate_ansible_vault_report(source_name, details, deployments)
+    details, deployments, aggregate = retrieve_report(scan_job_id)
+    validate_ansible_report_minimum(source_name, details, deployments, aggregate)

--- a/camayoc/tests/qpc/cli/test_endtoend.py
+++ b/camayoc/tests/qpc/cli/test_endtoend.py
@@ -20,6 +20,7 @@ from .utils import scan_add_and_check
 from .utils import scan_job
 from .utils import scan_start
 from .utils import source_add_and_check
+from .utils import source_to_cli_options
 from .utils import wait_for_scan
 
 
@@ -70,24 +71,14 @@ def test_end_to_end(tmp_path, qpc_server_config, data_provider, source_name):
     source_model = data_provider.sources.new_one(
         {"name": source_definition.name}, new_dependencies=True, data_only=True
     )
-    source_add_args = {
-        "name": source_model.name,
-        "cred": [credential_model.name],
-        "hosts": source_model.hosts,
-        "type": source_model.source_type,
-    }
-    if source_port := getattr(source_model, "port", None):
-        source_add_args["port"] = source_port
-
-    for opt in ("ssl_protocol", "ssl_cert_verify", "disable_ssl", "use_paramiko"):
-        value = getattr(source_model, opt, None)
-        if value is None:
-            continue
-        key = opt.replace("_", "-")
-        source_add_args[key] = value
-
     data_provider.mark_for_cleanup(source_model)
-    source_add_and_check(source_add_args)
+    source_add_and_check(
+        source_to_cli_options(
+            source_model,
+            name=source_model.name,
+            credentials=[credential_model.name],
+        )
+    )
 
     # Create and run a scan
     data_provider.mark_for_cleanup(Scan(name=scan_name))

--- a/camayoc/tests/qpc/cli/utils.py
+++ b/camayoc/tests/qpc/cli/utils.py
@@ -9,7 +9,6 @@ import tarfile
 import tempfile
 import time
 from pprint import pformat
-from typing import Optional
 
 import pexpect
 
@@ -95,13 +94,15 @@ def cli_command(command, options=None, exitstatus=0):
 
 def hashicorp_vault_cli_options(vault: HashicorpVaultOptions) -> dict:
     """Map Camayoc ``hashicorp_vault`` settings to ``qpc vault add`` options."""
-    return {
+    options = {
         "address": vault.address,
-        "port": vault.port,
         "client-cert": str(vault.client_cert),
         "client-key": str(vault.client_key),
         "ca-cert": str(vault.ca_cert),
     }
+    if vault.port is not None:
+        options["port"] = vault.port
+    return options
 
 
 def vault_add_and_check(options=None, exitstatus=0):
@@ -110,20 +111,17 @@ def vault_add_and_check(options=None, exitstatus=0):
     :param options: A dictionary mapping ``qpc vault add`` option names and
         their values. Pass ``None`` for flag options.
     :param exitstatus: Expected exit status code.
-    :returns: Command output.
     """
     output = cli_command("{} -v vault add".format(client_cmd), options, exitstatus)
     if exitstatus == 0:
         assert VAULT_CONFIG_SUCCESS in output, output
-    return output
 
 
-def vault_clear(exitstatus=None):
+def clear_server_vault(exitstatus=None):
     """Clear the server HashiCorp Vault configuration via CLI.
 
     :param exitstatus: Expected exit status. ``None`` accepts any status
         (useful when no vault config exists yet).
-    :returns: Command output.
     """
     command = "{} -v vault clear".format(client_cmd)
     logger.debug(CLI_DEBUG_MSG, command)
@@ -132,21 +130,46 @@ def vault_clear(exitstatus=None):
     )
     if exitstatus is not None:
         assert command_exitstatus == exitstatus, output
-    return output
 
 
-def configure_server_vault(vault_settings: Optional[HashicorpVaultOptions] = None):
+def configure_server_vault():
     """Configure Discovery server vault settings from Camayoc config.
 
-    Clears any existing vault configuration first so re-runs are idempotent.
-    Uses ``settings.hashicorp_vault`` when ``vault_settings`` is omitted.
-    Raises ``ValueError`` when no vault configuration is available.
+    Uses ``settings.hashicorp_vault``. Raises ``ValueError`` when vault is not
+    configured. Does not clear existing server vault settings; callers (usually
+    fixtures) own that lifecycle.
     """
-    vault = settings.hashicorp_vault if vault_settings is None else vault_settings
+    vault = settings.hashicorp_vault
     if vault is None:
         raise ValueError("hashicorp_vault is not configured")
-    vault_clear()
-    return vault_add_and_check(hashicorp_vault_cli_options(vault))
+    vault_add_and_check(hashicorp_vault_cli_options(vault))
+
+
+def source_to_cli_options(source, *, name, credentials, source_type=None):
+    """Build ``qpc source add`` options from a source definition or model.
+
+    ``source`` may be a settings ``SourceOptions`` or a ``Source`` model. Boolean
+    SSL flags are lowercased for the CLI. ``port`` is included only when set.
+    """
+    resolved_type = source_type
+    if resolved_type is None:
+        resolved_type = getattr(source, "type", None) or getattr(source, "source_type", None)
+    options = {
+        "name": name,
+        "type": resolved_type,
+        "hosts": list(source.hosts),
+        "cred": list(credentials),
+    }
+    port = getattr(source, "port", None)
+    if port is not None:
+        options["port"] = port
+    for opt in ("ssl_protocol", "ssl_cert_verify", "disable_ssl", "use_paramiko"):
+        value = getattr(source, opt, None)
+        if value is None:
+            continue
+        key = opt.replace("_", "-")
+        options[key] = str(value).lower() if isinstance(value, bool) else value
+    return options
 
 
 def cred_add_and_check(options, inputs=None, exitstatus=0):

--- a/camayoc/tests/qpc/cli/utils.py
+++ b/camayoc/tests/qpc/cli/utils.py
@@ -95,16 +95,13 @@ def cli_command(command, options=None, exitstatus=0):
 
 def hashicorp_vault_cli_options(vault: HashicorpVaultOptions) -> dict:
     """Map Camayoc ``hashicorp_vault`` settings to ``qpc vault add`` options."""
-    options = {
+    return {
         "address": vault.address,
         "port": vault.port,
-        "ssl-verify": "true" if vault.ssl_verify else "false",
         "client-cert": str(vault.client_cert),
         "client-key": str(vault.client_key),
+        "ca-cert": str(vault.ca_cert),
     }
-    if vault.ca_cert is not None:
-        options["ca-cert"] = str(vault.ca_cert)
-    return options
 
 
 def vault_add_and_check(options=None, exitstatus=0):

--- a/camayoc/tests/qpc/cli/utils.py
+++ b/camayoc/tests/qpc/cli/utils.py
@@ -121,15 +121,34 @@ def vault_add_and_check(options=None, exitstatus=0):
     return output
 
 
+def vault_clear(exitstatus=None):
+    """Clear the server HashiCorp Vault configuration via CLI.
+
+    :param exitstatus: Expected exit status. ``None`` accepts any status
+        (useful when no vault config exists yet).
+    :returns: Command output.
+    """
+    command = "{} -v vault clear".format(client_cmd)
+    logger.debug(CLI_DEBUG_MSG, command)
+    output, command_exitstatus = pexpect.run(
+        command, encoding="utf-8", timeout=60, withexitstatus=True
+    )
+    if exitstatus is not None:
+        assert command_exitstatus == exitstatus, output
+    return output
+
+
 def configure_server_vault(vault_settings: Optional[HashicorpVaultOptions] = None):
     """Configure Discovery server vault settings from Camayoc config.
 
+    Clears any existing vault configuration first so re-runs are idempotent.
     Uses ``settings.hashicorp_vault`` when ``vault_settings`` is omitted.
     Raises ``ValueError`` when no vault configuration is available.
     """
     vault = settings.hashicorp_vault if vault_settings is None else vault_settings
     if vault is None:
         raise ValueError("hashicorp_vault is not configured")
+    vault_clear()
     return vault_add_and_check(hashicorp_vault_cli_options(vault))
 
 

--- a/camayoc/tests/qpc/cli/utils.py
+++ b/camayoc/tests/qpc/cli/utils.py
@@ -117,19 +117,16 @@ def vault_add_and_check(options=None, exitstatus=0):
         assert VAULT_CONFIG_SUCCESS in output, output
 
 
-def clear_server_vault(exitstatus=None):
+def clear_server_vault():
     """Clear the server HashiCorp Vault configuration via CLI.
 
-    :param exitstatus: Expected exit status. ``None`` accepts any status
-        (useful when no vault config exists yet).
+    Best-effort: ignores CLI exit status so setup/teardown stays resilient on a
+    shared server when clear fails unexpectedly. Callers never need a specific
+    exit code (for example when nothing is configured yet).
     """
     command = "{} -v vault clear".format(client_cmd)
     logger.debug(CLI_DEBUG_MSG, command)
-    output, command_exitstatus = pexpect.run(
-        command, encoding="utf-8", timeout=60, withexitstatus=True
-    )
-    if exitstatus is not None:
-        assert command_exitstatus == exitstatus, output
+    pexpect.run(command, encoding="utf-8", timeout=60, withexitstatus=True)
 
 
 def configure_server_vault():

--- a/camayoc/tests/qpc/cli/utils.py
+++ b/camayoc/tests/qpc/cli/utils.py
@@ -9,6 +9,7 @@ import tarfile
 import tempfile
 import time
 from pprint import pformat
+from typing import Optional
 
 import pexpect
 
@@ -16,9 +17,12 @@ from camayoc.config import settings
 from camayoc.constants import CLI_DEBUG_MSG
 from camayoc.exceptions import FailedScanException
 from camayoc.exceptions import WaitTimeError
+from camayoc.types.settings import HashicorpVaultOptions
 from camayoc.utils import client_cmd
 
 logger = logging.getLogger(__name__)
+
+VAULT_CONFIG_SUCCESS = "HashiCorp Vault configuration was successfully configured."
 
 
 def clear_all_entities():
@@ -87,6 +91,46 @@ def cli_command(command, options=None, exitstatus=0):
     )
     assert command_exitstatus == exitstatus, output
     return output
+
+
+def hashicorp_vault_cli_options(vault: HashicorpVaultOptions) -> dict:
+    """Map Camayoc ``hashicorp_vault`` settings to ``qpc vault add`` options."""
+    options = {
+        "address": vault.address,
+        "port": vault.port,
+        "ssl-verify": "true" if vault.ssl_verify else "false",
+        "client-cert": str(vault.client_cert),
+        "client-key": str(vault.client_key),
+    }
+    if vault.ca_cert is not None:
+        options["ca-cert"] = str(vault.ca_cert)
+    return options
+
+
+def vault_add_and_check(options=None, exitstatus=0):
+    """Configure the server HashiCorp Vault integration via CLI.
+
+    :param options: A dictionary mapping ``qpc vault add`` option names and
+        their values. Pass ``None`` for flag options.
+    :param exitstatus: Expected exit status code.
+    :returns: Command output.
+    """
+    output = cli_command("{} -v vault add".format(client_cmd), options, exitstatus)
+    if exitstatus == 0:
+        assert VAULT_CONFIG_SUCCESS in output, output
+    return output
+
+
+def configure_server_vault(vault_settings: Optional[HashicorpVaultOptions] = None):
+    """Configure Discovery server vault settings from Camayoc config.
+
+    Uses ``settings.hashicorp_vault`` when ``vault_settings`` is omitted.
+    Raises ``ValueError`` when no vault configuration is available.
+    """
+    vault = settings.hashicorp_vault if vault_settings is None else vault_settings
+    if vault is None:
+        raise ValueError("hashicorp_vault is not configured")
+    return vault_add_and_check(hashicorp_vault_cli_options(vault))
 
 
 def cred_add_and_check(options, inputs=None, exitstatus=0):

--- a/camayoc/types/settings.py
+++ b/camayoc/types/settings.py
@@ -105,7 +105,8 @@ class AnsibleCredentialOptions(BaseModel):
     password: str
 
 
-# TODO: these models allow config parsing but are not consumed at runtime yet
+# VaultOpenShiftCredentialOptions is parsed from config but not yet consumed
+# by runtime helpers (OpenShift vault e2e is out of scope for DISCOVERY-1367).
 class VaultOpenShiftCredentialOptions(BaseModel):
     name: str
     type: Literal["openshift"]
@@ -114,6 +115,7 @@ class VaultOpenShiftCredentialOptions(BaseModel):
     vault_mount_point: Optional[str] = None
 
 
+# Consumed by CLI vault Ansible e2e tests (DISCOVERY-1367).
 class VaultAnsibleCredentialOptions(BaseModel):
     name: str
     type: Literal["ansible"]

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -25,6 +25,18 @@ quipucords_server:
 quipucords_cli:
     executable: qpc
 
+# HashiCorp Vault server configuration for Discovery Vault integration.
+# Cert paths are local file paths. Camayoc configures the server via
+# ``qpc vault add`` / ``dsc vault add``, which base64-encodes the certs.
+# Required when any credential below uses vault_secret_path.
+# hashicorp_vault:
+#     address: vault.example.com
+#     port: 8200
+#     ssl_verify: true
+#     client_cert: /path/to/client.crt
+#     client_key: /path/to/client.key
+#     ca_cert: /path/to/ca.crt
+
 # We host most of our test machines on a VCenter instance
 # and this section contains its URL and the credentials
 # needed to log in to it

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -32,7 +32,6 @@ quipucords_cli:
 # hashicorp_vault:
 #     address: vault.example.com
 #     port: 8200
-#     ssl_verify: true
 #     client_cert: /path/to/client.crt
 #     client_key: /path/to/client.key
 #     ca_cert: /path/to/ca.crt

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -80,6 +80,17 @@ credentials:
       type: 'ansible'
       username: 'admin'
       password: 'CHANGEME'
+    # Vault-backed credentials (require hashicorp_vault server config above):
+    # - name: 'OpenShiftVault'
+    #   type: 'openshift'
+    #   vault_secret_path: vault/dev/ocp-token
+    #   vault_secret_key: auth_token
+    #   vault_mount_point: discovery
+    # - name: 'AnsibleVault'
+    #   type: 'ansible'
+    #   vault_secret_path: vault/dev/aap-token
+    #   vault_secret_key: password
+    #   vault_mount_point: discovery
 
 # Values in "credentials" field can use names present in "credentials" section
 # above
@@ -125,6 +136,21 @@ sources:
       name: 'ansible'
       type: 'ansible'
       ssl_cert_verify: false
+    # Vault-backed source examples (uncomment with Vault credentials above):
+    # - hosts:
+    #       - 'api.vault-ocp.example.com'
+    #   credentials:
+    #       - 'OpenShiftVault'
+    #   name: 'OpenShiftVault'
+    #   type: 'openshift'
+    #   ssl_cert_verify: false
+    # - hosts:
+    #       - 'aap.example.com'
+    #   credentials:
+    #       - 'AnsibleVault'
+    #   name: 'AnsibleVault'
+    #   type: 'ansible'
+    #   ssl_cert_verify: false
 
 # Values in "sources" field can use names present in "sources" section above
 scans:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -6,6 +6,8 @@ import yaml
 from pydantic import ValidationError
 
 from camayoc.config import get_settings
+from camayoc.tests.qpc.cli.utils import hashicorp_vault_cli_options
+from camayoc.types.settings import HashicorpVaultOptions
 
 EXAMPLE_CONFIG_PATH = Path(__file__).parent / "../example_config.yaml"
 with open(EXAMPLE_CONFIG_PATH) as fh:
@@ -220,6 +222,35 @@ def test_invalid_non_existing_source(tmp_path, faker, example_config):
 
     with pytest.raises(ValidationError):
         get_settings(config_file)
+
+
+def test_hashicorp_vault_cli_options_with_ca_cert():
+    vault = HashicorpVaultOptions(**VAULT_SERVER_CONFIG)
+    assert hashicorp_vault_cli_options(vault) == {
+        "address": "vault.example.com",
+        "port": 8200,
+        "ssl-verify": "true",
+        "client-cert": "/path/to/client.crt",
+        "client-key": "/path/to/client.key",
+        "ca-cert": "/path/to/ca.crt",
+    }
+
+
+def test_hashicorp_vault_cli_options_without_ca_cert():
+    vault = HashicorpVaultOptions(
+        address="vault.example.com",
+        port=8200,
+        ssl_verify=False,
+        client_cert="/path/to/client.crt",
+        client_key="/path/to/client.key",
+    )
+    assert hashicorp_vault_cli_options(vault) == {
+        "address": "vault.example.com",
+        "port": 8200,
+        "ssl-verify": "false",
+        "client-cert": "/path/to/client.crt",
+        "client-key": "/path/to/client.key",
+    }
 
 
 @pytest.mark.parametrize("stype", SOURCE_TYPES)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -224,32 +224,14 @@ def test_invalid_non_existing_source(tmp_path, faker, example_config):
         get_settings(config_file)
 
 
-def test_hashicorp_vault_cli_options_with_ca_cert():
+def test_hashicorp_vault_cli_options():
     vault = HashicorpVaultOptions(**VAULT_SERVER_CONFIG)
     assert hashicorp_vault_cli_options(vault) == {
         "address": "vault.example.com",
         "port": 8200,
-        "ssl-verify": "true",
         "client-cert": "/path/to/client.crt",
         "client-key": "/path/to/client.key",
         "ca-cert": "/path/to/ca.crt",
-    }
-
-
-def test_hashicorp_vault_cli_options_without_ca_cert():
-    vault = HashicorpVaultOptions(
-        address="vault.example.com",
-        port=8200,
-        ssl_verify=False,
-        client_cert="/path/to/client.crt",
-        client_key="/path/to/client.key",
-    )
-    assert hashicorp_vault_cli_options(vault) == {
-        "address": "vault.example.com",
-        "port": 8200,
-        "ssl-verify": "false",
-        "client-cert": "/path/to/client.crt",
-        "client-key": "/path/to/client.key",
     }
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -6,8 +6,6 @@ import yaml
 from pydantic import ValidationError
 
 from camayoc.config import get_settings
-from camayoc.tests.qpc.cli.utils import hashicorp_vault_cli_options
-from camayoc.types.settings import HashicorpVaultOptions
 
 EXAMPLE_CONFIG_PATH = Path(__file__).parent / "../example_config.yaml"
 with open(EXAMPLE_CONFIG_PATH) as fh:
@@ -222,17 +220,6 @@ def test_invalid_non_existing_source(tmp_path, faker, example_config):
 
     with pytest.raises(ValidationError):
         get_settings(config_file)
-
-
-def test_hashicorp_vault_cli_options():
-    vault = HashicorpVaultOptions(**VAULT_SERVER_CONFIG)
-    assert hashicorp_vault_cli_options(vault) == {
-        "address": "vault.example.com",
-        "port": 8200,
-        "client-cert": "/path/to/client.crt",
-        "client-key": "/path/to/client.key",
-        "ca-cert": "/path/to/ca.crt",
-    }
 
 
 @pytest.mark.parametrize("stype", SOURCE_TYPES)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,13 @@
 # coding=utf-8
 """Unit tests for :mod:`camayoc.utils`."""
 
+from pathlib import Path
 from tempfile import mkdtemp
 from unittest import mock
 
 from camayoc import utils
+from camayoc.tests.qpc.cli.utils import hashicorp_vault_cli_options
+from camayoc.types.settings import HashicorpVaultOptions
 from camayoc.types.settings import QuipucordsServerOptions
 from camayoc.types.settings import ScanOptions
 
@@ -90,3 +93,38 @@ def test_expected_data_has_attribute_no_expected_data():
         }
     )
     assert not utils.expected_data_has_attribute(scan, "distribution")
+
+
+def test_hashicorp_vault_cli_options():
+    vault = HashicorpVaultOptions(
+        address="vault.example.com",
+        port=8200,
+        client_cert=Path("/path/to/client.crt"),
+        client_key=Path("/path/to/client.key"),
+        ca_cert=Path("/path/to/ca.crt"),
+    )
+    assert hashicorp_vault_cli_options(vault) == {
+        "address": "vault.example.com",
+        "port": 8200,
+        "client-cert": "/path/to/client.crt",
+        "client-key": "/path/to/client.key",
+        "ca-cert": "/path/to/ca.crt",
+    }
+
+
+def test_hashicorp_vault_cli_options_omits_null_port():
+    vault = HashicorpVaultOptions(
+        address="vault.example.com",
+        port=None,
+        client_cert=Path("/path/to/client.crt"),
+        client_key=Path("/path/to/client.key"),
+        ca_cert=Path("/path/to/ca.crt"),
+    )
+    options = hashicorp_vault_cli_options(vault)
+    assert "port" not in options
+    assert options == {
+        "address": "vault.example.com",
+        "client-cert": "/path/to/client.crt",
+        "client-key": "/path/to/client.key",
+        "ca-cert": "/path/to/ca.crt",
+    }


### PR DESCRIPTION
## Summary
- Add Camayoc CLI helpers to configure Discovery's HashiCorp Vault settings from `hashicorp_vault` config (`vault clear` + `vault add`), covering [DISCOVERY-1384](https://redhat.atlassian.net/browse/DISCOVERY-1384).
- Add CLI e2e coverage that creates a vault-backed Ansible credential, scans AAP, and validates the report, with skip logic when Vault/AAP config is missing ([DISCOVERY-1367](https://redhat.atlassian.net/browse/DISCOVERY-1367)).
- Document vault examples in `example_config.yaml`, and align with main's `retrieve_report` 3-tuple / report-id suffix parsing from #636.

## Test plan
- [x] `pytest tests/test_settings.py -k 'vault or hashicorp'`
- [x] `pytest camayoc/tests/qpc/cli/test_ansible_vault.py` skips without vault/ansible vault config
- [x] Full e2e against TestLab Vault + AAP with Camayoc config (`-m runs_scan`) passed
- [x] CI green on this PR

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added example configuration for HashiCorp Vault integration, including server settings, certificates, credentials, and sources.
  * Added end-to-end support coverage for Ansible scans using Vault-backed credentials.

* **Bug Fixes**
  * Improved CLI source configuration handling for optional ports and SSL settings.

* **Tests**
  * Added validation for Vault CLI option conversion and Ansible scan reports.
  * Improved source setup and cleanup coverage for end-to-end CLI scans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->