### PR TITLE
Switch Jenkins runners to AWS instances

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ agents["failFast"] = false
 
 ["fedora", "rhel8", "rhel9", "rhel10"].each { distro_label ->
     agents[distro_label] = {
-        node("openstack && discovery_ci && ${distro_label}") {
+        node("aws && x86_64 && discovery_ci && ${distro_label}") {
             timestamps {
                 stage("[${distro_label}] Setup test environment") {
                     echo "Setting up Quipucords PR tests"


### PR DESCRIPTION
SSIA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Jenkins pipeline to run distribution jobs on AWS x86_64 discovery CI nodes instead of OpenStack nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->